### PR TITLE
Enforce metadata write block on follower indices

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
@@ -108,6 +108,8 @@ import com.amazon.elasticsearch.replication.rest.ReplicateIndexHandler
 import com.amazon.elasticsearch.replication.rest.ResumeIndexReplicationHandler
 import com.amazon.elasticsearch.replication.rest.StopIndexReplicationHandler
 import com.amazon.elasticsearch.replication.rest.UpdateAutoFollowPatternsHandler
+import com.amazon.elasticsearch.replication.metadata.TransportUpdateMetadataAction
+import com.amazon.elasticsearch.replication.metadata.UpdateMetadataAction
 import org.elasticsearch.common.util.concurrent.EsExecutors
 import org.elasticsearch.threadpool.FixedExecutorBuilder
 
@@ -156,7 +158,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             ActionHandler(PauseIndexReplicationAction.INSTANCE, TransportPauseIndexReplicationAction::class.java),
             ActionHandler(ResumeIndexReplicationAction.INSTANCE, TransportResumeIndexReplicationAction::class.java),
             ActionHandler(UpdateIndexBlockAction.INSTANCE, TransportUpddateIndexBlockAction::class.java),
-            ActionHandler(ReleaseLeaderResourcesAction.INSTANCE, TransportReleaseLeaderResourcesAction::class.java)
+            ActionHandler(ReleaseLeaderResourcesAction.INSTANCE, TransportReleaseLeaderResourcesAction::class.java),
+            ActionHandler(UpdateMetadataAction.INSTANCE, TransportUpdateMetadataAction::class.java)
         )
     }
 

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/replay/TransportReplayChangesAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/replay/TransportReplayChangesAction.kt
@@ -16,9 +16,12 @@
 package com.amazon.elasticsearch.replication.action.replay
 
 import com.amazon.elasticsearch.replication.ReplicationException
+import com.amazon.elasticsearch.replication.metadata.UpdateMetadataAction
+import com.amazon.elasticsearch.replication.metadata.UpdateMetadataRequest
 import com.amazon.elasticsearch.replication.metadata.checkIfIndexBlockedWithLevel
 import com.amazon.elasticsearch.replication.util.completeWith
 import com.amazon.elasticsearch.replication.util.coroutineContext
+import com.amazon.elasticsearch.replication.util.suspendExecute
 import com.amazon.elasticsearch.replication.util.suspending
 import com.amazon.elasticsearch.replication.util.waitForNextChange
 import kotlinx.coroutines.CoroutineScope
@@ -185,12 +188,9 @@ class TransportReplayChangesAction @Inject constructor(settings: Settings, trans
         val putMappingRequest = PutMappingRequest().indices(followerIndex).indicesOptions(options)
             .type(type).source(mappingSource, XContentType.JSON)
             //TODO: call .masterNodeTimeout() with the setting indices.mapping.dynamic_timeout
-        val putMappingResponse = suspending(client.admin().indices()::putMapping)(putMappingRequest)
-        if (!putMappingResponse.isAcknowledged) {
-            throw ReplicationException("failed to update mappings to match mapping in source clusters")
-        } else {
-            log.debug("Mappings synced for $followerIndex")
-        }
+        val updateMappingRequest = UpdateMetadataRequest(followerIndex, UpdateMetadataRequest.Type.MAPPING, putMappingRequest)
+        client.suspendExecute(UpdateMetadataAction.INSTANCE, updateMappingRequest)
+        log.debug("Mappings synced for $followerIndex")
     }
 
     /**

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/TransportUpdateMetadataAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/TransportUpdateMetadataAction.kt
@@ -1,0 +1,229 @@
+package com.amazon.elasticsearch.replication.metadata
+
+import com.amazon.elasticsearch.replication.action.stop.StopIndexReplicationRequest
+import org.apache.logging.log4j.LogManager
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.IndicesRequest
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesClusterStateUpdateRequest
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingClusterStateUpdateRequest
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsClusterStateUpdateRequest
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.elasticsearch.action.support.ActionFilters
+import org.elasticsearch.action.support.IndicesOptions
+import org.elasticsearch.action.support.master.AcknowledgedResponse
+import org.elasticsearch.action.support.master.TransportMasterNodeAction
+import org.elasticsearch.cluster.ClusterState
+import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse
+import org.elasticsearch.cluster.block.ClusterBlockException
+import org.elasticsearch.cluster.block.ClusterBlockLevel
+import org.elasticsearch.cluster.metadata.AliasAction
+import org.elasticsearch.cluster.metadata.AliasAction.RemoveIndex
+import org.elasticsearch.cluster.metadata.IndexAbstraction
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver
+import org.elasticsearch.cluster.metadata.Metadata
+import org.elasticsearch.cluster.metadata.MetadataIndexAliasesService
+import org.elasticsearch.cluster.metadata.MetadataMappingService
+import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.common.inject.Inject
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.index.Index
+import org.elasticsearch.index.IndexNotFoundException
+import org.elasticsearch.rest.action.admin.indices.AliasesNotFoundException
+import org.elasticsearch.threadpool.ThreadPool
+import org.elasticsearch.transport.TransportService
+import java.lang.Exception
+import java.util.*
+
+/*
+ This action allows the replication plugin to update the index metadata(mapping, setting & aliases) on the follower index
+ when there is a metadata write block(added by the plugin).
+ */
+class TransportUpdateMetadataAction @Inject constructor(
+    transportService: TransportService, actionFilters: ActionFilters, threadPool: ThreadPool,
+    clusterService: ClusterService, indexNameExpressionResolver: IndexNameExpressionResolver,
+    val metadataMappingService: MetadataMappingService,
+    val updateSettingsService: MetadataUpdateSettingsService,
+    val indexAliasService: MetadataIndexAliasesService
+) : TransportMasterNodeAction<UpdateMetadataRequest, AcknowledgedResponse>(UpdateMetadataAction.NAME,
+    transportService, clusterService, threadPool, actionFilters, ::UpdateMetadataRequest, indexNameExpressionResolver) {
+
+    companion object {
+        private val log = LogManager.getLogger(TransportUpdateMetadataAction::class.java)
+        private val indicesOptions = IndicesOptions.fromOptions(false, false, true, true)
+    }
+
+    override fun executor(): String = ThreadPool.Names.SAME
+    override fun read(inp: StreamInput?) = AcknowledgedResponse(inp)
+    override fun checkBlock(request: UpdateMetadataRequest, state: ClusterState): ClusterBlockException? {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
+    }
+
+    override fun masterOperation(
+        request: UpdateMetadataRequest,
+        state: ClusterState,
+        listener: ActionListener<AcknowledgedResponse>
+    ) {
+        val concreteIndices = resolveIndices(state, request, indexNameExpressionResolver)
+        when (request.type) {
+            UpdateMetadataRequest.Type.SETTING -> {
+                performSettingUpdate(concreteIndices, request, listener, updateSettingsService)
+            }
+            UpdateMetadataRequest.Type.MAPPING -> {
+                performMappingUpdate(concreteIndices, request, listener, metadataMappingService)
+            }
+            UpdateMetadataRequest.Type.ALIAS -> {
+                performAliasUpdate(concreteIndices, request, listener, indexAliasService, state)
+            }
+        }
+    }
+
+    private fun performAliasUpdate(concreteIndices: Array<Index>, request: UpdateMetadataRequest,
+                                   listener: ActionListener<AcknowledgedResponse>,
+                                   indexAliasService: MetadataIndexAliasesService, clusterState: ClusterState) {
+        val indicesAliasesRequest = request.request as IndicesAliasesRequest
+        val actions: List<AliasActions> = indicesAliasesRequest.aliasActions
+        var finalActions: ArrayList<AliasAction> = ArrayList()
+
+        // Resolve all the AliasActions into AliasAction instances and gather all the aliases
+        val aliases: HashSet<String> = HashSet()
+        for (action in actions) {
+            for (concreteIndex in concreteIndices) {
+                val indexAbstraction: IndexAbstraction =
+                    clusterState.metadata().getIndicesLookup().get(concreteIndex.name)
+                        ?: error("invalid cluster metadata. index [" + concreteIndex.name + "] was not found")
+                require(indexAbstraction.parentDataStream == null) {
+                    ("The provided expressions [" + java.lang.String.join(",", *action.indices())
+                            + "] match a backing index belonging to data stream [" + indexAbstraction.parentDataStream?.getName()
+                            + "]. Data streams and their backing indices don't support aliases.")
+                }
+            }
+
+            Collections.addAll(aliases, *action.originalAliases)
+            for (index in concreteIndices) {
+                when (action.actionType()) {
+                    AliasActions.Type.ADD -> for (alias in concreteAliases(action,clusterState.metadata(), index.name)) {
+                        finalActions.add(AliasAction.Add(index.name, alias, action.filter(), action.indexRouting(),
+                                action.searchRouting(), action.writeIndex(), action.isHidden))
+                    }
+                    AliasActions.Type.REMOVE -> for (alias in concreteAliases(action, clusterState.metadata(), index.name)) {
+                        finalActions.add(AliasAction.Remove(index.name, alias, action.mustExist()))
+                    }
+                    AliasActions.Type.REMOVE_INDEX -> finalActions.add(RemoveIndex(index.name))
+                    else -> throw IllegalArgumentException("Unsupported action [" + action.actionType() + "]")
+                }
+            }
+        }
+
+        if (finalActions.isEmpty() && !actions.isEmpty()) {
+            throw AliasesNotFoundException(*aliases.toTypedArray())
+        }
+
+        val updateRequest =
+            IndicesAliasesClusterStateUpdateRequest(Collections.unmodifiableList(finalActions))
+                .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
+
+        indexAliasService.indicesAliases(
+            updateRequest,
+            object : ActionListener<ClusterStateUpdateResponse> {
+                override fun onResponse(response: ClusterStateUpdateResponse) {
+                    listener.onResponse(AcknowledgedResponse(response.isAcknowledged))
+                }
+
+                override fun onFailure(t: Exception) {
+                    log.error("failed to perform aliases on index ${request.indexName}", t)
+                    listener.onFailure(t)
+                }
+            })
+    }
+
+    private fun performSettingUpdate(concreteIndices: Array<Index>, request: UpdateMetadataRequest,
+                                             listener: ActionListener<AcknowledgedResponse>,
+                                             updateSettingsService: MetadataUpdateSettingsService) {
+        val updateSettingsRequest = request.request as UpdateSettingsRequest
+        val clusterStateUpdateRequest = UpdateSettingsClusterStateUpdateRequest()
+            .indices(concreteIndices)
+            .settings(updateSettingsRequest.settings())
+            .setPreserveExisting(updateSettingsRequest.isPreserveExisting)
+            .ackTimeout(request.timeout())
+            .masterNodeTimeout(request.masterNodeTimeout())
+
+
+        updateSettingsService.updateSettings(clusterStateUpdateRequest,
+            object : ActionListener<ClusterStateUpdateResponse> {
+                override fun onResponse(response: ClusterStateUpdateResponse) {
+                    listener.onResponse(AcknowledgedResponse(response.isAcknowledged))
+                }
+
+                override fun onFailure(t: Exception) {
+                    log.error("failed to update settings on index ${request.indexName}")
+                    listener.onFailure(t)
+                }
+        })
+    }
+
+    private fun resolveIndices(state: ClusterState?, request: UpdateMetadataRequest, iner: IndexNameExpressionResolver
+            ): Array<Index> {
+        try {
+            return iner.concreteIndices(state, object : IndicesRequest {
+                override fun indices(): Array<String> {
+                    return arrayOf(request.indexName)
+                }
+
+                override fun indicesOptions(): IndicesOptions {
+                    return indicesOptions
+                }
+            })
+        } catch (ex: IndexNotFoundException) {
+            log.error("Failed to execute UpdateMetadataRequest. Index ${request.indexName} not found. type: ${request.type}: $ex")
+            throw ex
+        }
+    }
+
+    private fun performMappingUpdate(concreteIndices: Array<Index>, request: UpdateMetadataRequest,
+                                     listener: ActionListener<AcknowledgedResponse>, metadataMappingService: MetadataMappingService
+    ) {
+        val mappingRequest = request.request as PutMappingRequest
+        val updateRequest = PutMappingClusterStateUpdateRequest()
+            .ackTimeout(mappingRequest.timeout()).masterNodeTimeout(mappingRequest.masterNodeTimeout())
+            .indices(concreteIndices).type(mappingRequest.type())
+            .source(mappingRequest.source())
+
+        metadataMappingService.putMapping(updateRequest,
+            object : ActionListener<ClusterStateUpdateResponse> {
+                override fun onResponse(response: ClusterStateUpdateResponse) {
+                    listener.onResponse(AcknowledgedResponse(response.isAcknowledged))
+                }
+                override fun onFailure(ex: Exception) {
+                    log.error("failed to put mappings on indices ${request.indexName} : $ex")
+                    listener.onFailure(ex)
+                }
+            })
+    }
+    private fun concreteAliases(
+        action: AliasActions,
+        metadata: Metadata,
+        concreteIndex: String
+    ): Array<String> {
+        return if (action.expandAliasesWildcards()) {
+            //for DELETE we expand the aliases
+            val indexAsArray = arrayOf(concreteIndex)
+            val aliasMetadata = metadata.findAliases(action, indexAsArray)
+            val finalAliases: MutableList<String> = ArrayList()
+            for (curAliases in aliasMetadata.values()) {
+                for (aliasMeta in curAliases.value) {
+                    finalAliases.add(aliasMeta.alias())
+                }
+            }
+            finalAliases.toTypedArray()
+        } else {
+            //for ADD and REMOVE_INDEX we just return the current aliases
+            action.aliases()
+        }
+    }
+
+
+}

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/UpdateMetadataAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/UpdateMetadataAction.kt
@@ -1,0 +1,13 @@
+package com.amazon.elasticsearch.replication.metadata
+
+import org.elasticsearch.action.ActionType
+import org.elasticsearch.action.support.master.AcknowledgedResponse
+
+
+class UpdateMetadataAction private constructor(): ActionType<AcknowledgedResponse>(
+    NAME, ::AcknowledgedResponse) {
+    companion object {
+            const val NAME = "indices:admin/opendistro/replication/index/update_metadata"
+            val INSTANCE: UpdateMetadataAction = UpdateMetadataAction()
+    }
+}

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/UpdateMetadataRequest.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/UpdateMetadataRequest.kt
@@ -1,0 +1,42 @@
+package com.amazon.elasticsearch.replication.metadata
+
+import org.elasticsearch.action.ActionRequestValidationException
+import org.elasticsearch.action.ValidateActions.addValidationError
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.elasticsearch.action.support.master.AcknowledgedRequest
+import org.elasticsearch.common.io.stream.StreamInput
+
+class UpdateMetadataRequest : AcknowledgedRequest<UpdateMetadataRequest> {
+    var indexName: String
+    var type: Type
+    lateinit var request: AcknowledgedRequest<*>
+
+    constructor(indexName: String, type: Type, request: AcknowledgedRequest<*>) : super() {
+        this.indexName = indexName
+        this.type = type
+        this.request = request
+    }
+
+    enum class Type {
+        MAPPING, SETTING, ALIAS
+    }
+
+    constructor(inp: StreamInput): super(inp) {
+        indexName = inp.readString()
+        type = inp.readEnum(Type::class.java)
+        when (type) {
+            Type.MAPPING -> PutMappingRequest(inp)
+            Type.SETTING -> UpdateSettingsRequest(inp)
+            Type.ALIAS -> IndicesAliasesRequest(inp)
+        }
+    }
+
+    override fun validate(): ActionRequestValidationException? {
+        var validationException: ActionRequestValidationException? = request.validate()
+        if (indexName == null) validationException = addValidationError("index name is missing", validationException)
+        if (type == null) validationException = addValidationError("operation types is missing", validationException)
+        return validationException
+    }
+}

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/BasicReplicationIT.kt
@@ -47,18 +47,21 @@ class BasicReplicationIT : MultiClusterRestTestCase() {
         // Create an empty index on the leader and trigger replication on it
         val createIndexResponse = leader.indices().create(CreateIndexRequest(leaderIndex), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        follower.startReplication(StartReplicationRequest("source", leaderIndex, followerIndex), waitForRestore=true)
+        try {
+            follower.startReplication(StartReplicationRequest("source", leaderIndex, followerIndex), waitForRestore=true)
 
-        val source = mapOf("name" to randomAlphaOfLength(20), "age" to randomInt().toString())
-        val response = leader.index(IndexRequest(leaderIndex).id("1").source(source), RequestOptions.DEFAULT)
-        assertThat(response.result).isEqualTo(Result.CREATED)
+            val source = mapOf("name" to randomAlphaOfLength(20), "age" to randomInt().toString())
+            val response = leader.index(IndexRequest(leaderIndex).id("1").source(source), RequestOptions.DEFAULT)
+            assertThat(response.result).isEqualTo(Result.CREATED)
 
-        assertBusy {
-            val getResponse = follower.get(GetRequest(followerIndex, "1"), RequestOptions.DEFAULT)
-            assertThat(getResponse.isExists).isTrue()
-            assertThat(getResponse.sourceAsMap).isEqualTo(source)
+            assertBusy {
+                val getResponse = follower.get(GetRequest(followerIndex, "1"), RequestOptions.DEFAULT)
+                assertThat(getResponse.isExists).isTrue()
+                assertThat(getResponse.sourceAsMap).isEqualTo(source)
+            }
+        } finally {
+            follower.stopReplication(followerIndex)
         }
-        follower.stopReplication(followerIndex)
     }
 
     fun `test existing index replication`() {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -66,13 +66,13 @@ fun getAckResponse(lowLevelResponse: Response): AcknowledgedResponse {
     return AcknowledgedResponse.fromXContent(xcp)
 }
 
-fun RestHighLevelClient.stopReplication(index: String) {
+fun RestHighLevelClient.stopReplication(index: String, shouldWait: Boolean = true) {
     val lowLevelStopRequest = Request("POST", REST_REPLICATION_STOP.replace("{index}", index,true))
     lowLevelStopRequest.setJsonEntity("{}")
     val lowLevelStopResponse = lowLevelClient.performRequest(lowLevelStopRequest)
     val response = getAckResponse(lowLevelStopResponse)
     assertThat(response.isAcknowledged).withFailMessage("Replication could not be stopped").isTrue()
-    waitForReplicationStop(index)
+    if (shouldWait) waitForReplicationStop(index)
 }
 
 fun RestHighLevelClient.pauseReplication(index: String) {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StopReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StopReplicationIT.kt
@@ -194,38 +194,4 @@ class StopReplicationIT: MultiClusterRestTestCase() {
         }.isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("No replication in progress for index:follower_index")
     }
-
-    fun `test stop with deleted follower index`() {
-        val followerClient = getClientForCluster(FOLLOWER)
-        val leaderClient = getClientForCluster(LEADER)
-        createConnectionBetweenClusters(FOLLOWER, LEADER)
-        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
-        assertThat(createIndexResponse.isAcknowledged).isTrue()
-        val sourceMap = mapOf("name" to randomAlphaOfLength(5))
-        leaderClient.index(IndexRequest(leaderIndexName).id("1").source(sourceMap), RequestOptions.DEFAULT)
-        // Need to set waitForRestore=true as the cluster blocks are added only
-        // after restore is completed.
-        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-        // Need to wait till index blocks appear into state
-        assertBusy ({
-            val clusterBlocksResponse = followerClient.lowLevelClient.performRequest(Request("GET", "/_cluster/state/blocks"))
-            val clusterResponseString = EntityUtils.toString(clusterBlocksResponse.entity)
-            assertThat(clusterResponseString.contains("cross-cluster-replication"))
-                    .withFailMessage("Cant find replication block afer starting replication")
-                    .isTrue()
-        }, 10, TimeUnit.SECONDS)
-        //Now delete the follower index
-        val deleteIndexResponse = followerClient.indices().delete(DeleteIndexRequest(followerIndexName), RequestOptions.DEFAULT)
-        assertThat(deleteIndexResponse.isAcknowledged).isTrue()
-        //Stop the replication
-        followerClient.stopReplication(followerIndexName)
-        //verify that replication metadata state is cleared from cluster state
-        val followerClusterState = followerClient.lowLevelClient.performRequest(Request("GET", "/_cluster/state/metadata"))
-        val followerClusterStateString = EntityUtils.toString(followerClusterState.entity)
-        assertThat(followerClusterStateString.contains("REPLICATION_OVERALL_STATE_KEY"))
-                .isFalse()
-                .withFailMessage("Replication params existing after stop is called")
-
-    }
 }


### PR DESCRIPTION
### Description
This change enforces metadata write block on follower index to prevent any metadata changes by any user/plugin.
Since replication plugin(as an exception) still need to change the metadata, we've implemented our own actions which do not honour the metadata write block.

I've added settings, alias and mapping update as part of a single transport action as there is a lot of logic sharing. But it can easily be split across 3 separate actions.
 
PS: Few integ tests are also failing and I'll address the fix for those in upcoming revisions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
