### PR TITLE
Support for translog fetch at the leader(remote) cluster

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
@@ -122,7 +122,7 @@ import com.amazon.elasticsearch.replication.action.status.TransportReplicationSt
 import com.amazon.elasticsearch.replication.metadata.ReplicationMetadataManager
 import com.amazon.elasticsearch.replication.metadata.store.ReplicationMetadataStore
 import com.amazon.elasticsearch.replication.rest.*
-
+import com.amazon.elasticsearch.replication.seqno.RemoteClusterTranslogService
 
 internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin, RepositoryPlugin, EnginePlugin {
 
@@ -159,7 +159,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
 
     override fun getGuiceServiceClasses(): Collection<Class<out LifecycleComponent>> {
         return listOf(Injectables::class.java,
-                RemoteClusterRestoreLeaderService::class.java)
+                RemoteClusterRestoreLeaderService::class.java, RemoteClusterTranslogService::class.java)
     }
 
     override fun getActions(): List<ActionHandler<out ActionRequest, out ActionResponse>> {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/repository/RemoteClusterRepository.kt
@@ -53,6 +53,7 @@ import org.elasticsearch.common.UUIDs
 import org.elasticsearch.common.component.AbstractLifecycleComponent
 import org.elasticsearch.common.metrics.CounterMetric
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.index.IndexSettings
 import org.elasticsearch.index.mapper.MapperService
 import org.elasticsearch.index.shard.ShardId
 import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus
@@ -242,6 +243,10 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         val builder = Settings.builder().put(indexMetadata.settings)
         val replicatedIndex = "${repositoryMetadata.remoteClusterName()}:${index.name}"
         builder.put(ReplicationPlugin.REPLICATED_INDEX_SETTING.key, replicatedIndex)
+
+        // Remove translog pruning for the follower index
+        builder.remove(IndexSettings.INDEX_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key)
+
         val indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder)
         indexMetadata.aliases.valuesIt().forEach {
             indexMdBuilder.putAlias(it)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/seqno/RemoteClusterTranslogService.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/seqno/RemoteClusterTranslogService.kt
@@ -1,0 +1,65 @@
+package com.amazon.elasticsearch.replication.seqno
+
+import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ResourceNotFoundException
+import org.elasticsearch.common.component.AbstractLifecycleComponent
+import org.elasticsearch.common.inject.Singleton
+import org.elasticsearch.core.internal.io.IOUtils
+import org.elasticsearch.index.engine.Engine
+import org.elasticsearch.index.shard.IndexShard
+import org.elasticsearch.index.translog.Translog
+import java.io.Closeable
+
+@Singleton
+class RemoteClusterTranslogService : AbstractLifecycleComponent(){
+    companion object {
+        private val log = LogManager.getLogger(RemoteClusterTranslogService::class.java)
+        private const val SOURCE_NAME = "os_plugin_replication"
+    }
+
+    override fun doStart() {
+    }
+
+    override fun doStop() {
+    }
+
+    override fun doClose() {
+    }
+    
+    public fun getHistoryOfOperations(indexShard: IndexShard, startSeqNo: Long, toSeqNo: Long): List<Translog.Operation> {
+        if(!indexShard.hasCompleteHistoryOperations(SOURCE_NAME, Engine.HistorySource.TRANSLOG, startSeqNo)) {
+            log.debug("Doesn't have history of operations starting from $startSeqNo")
+            throw ResourceNotFoundException("$indexShard doesn't contain ops starting from $startSeqNo " +
+                    "with source ${Engine.HistorySource.TRANSLOG.name}")
+        }
+        log.trace("Fetching translog snapshot for $indexShard - from $startSeqNo to $toSeqNo")
+        val snapshot = indexShard.getHistoryOperations(SOURCE_NAME, Engine.HistorySource.TRANSLOG, startSeqNo, toSeqNo)
+
+        // Total ops to be fetched (both toSeqNo and startSeqNo are inclusive)
+        val opsSize = toSeqNo - startSeqNo + 1
+        val ops = ArrayList<Translog.Operation>(opsSize.toInt())
+
+        // Filter and sort specific ops from the obtained history
+        var filteredOpsFromTranslog = 0
+        snapshot.use {
+            var op  = snapshot.next()
+            while(op != null) {
+                if(op.seqNo() in startSeqNo..toSeqNo) {
+                    ops.add(op)
+                    filteredOpsFromTranslog++
+                }
+                op = snapshot.next()
+            }
+        }
+        assert(filteredOpsFromTranslog == opsSize.toInt()) {"Missing operations while fetching from translog"}
+
+        val sortedOps = ArrayList<Translog.Operation>(opsSize.toInt())
+        sortedOps.addAll(ops)
+        for(ele in ops) {
+            sortedOps[(ele.seqNo() - startSeqNo).toInt()] = ele
+        }
+
+        log.debug("Starting seqno after sorting ${sortedOps[0].seqNo()} and ending seqno ${sortedOps[ops.size-1].seqNo()}")
+        return sortedOps.subList(0, ops.size.coerceAtMost((opsSize).toInt()))
+    }
+}


### PR DESCRIPTION
### Description
- Support for Translog fetch at the leader(remote) cluster
- and enable Translog pruning during replication setup
 
### Issues Resolved
N/A
 
### Testing
- Tested locally.
```
curl "{leader}/remote-index/_settings?pretty"
{
  "remote-index" : {
    "settings" : {
      "index" : {
        "number_of_shards" : "1",
        "translog" : {
          "retention_lease" : {
            "pruning" : {
              "enabled" : "true"
            }
          }
        },
        "provided_name" : "remote-index",
        "creation_date" : "1624936380777",
        "number_of_replicas" : "1",
        "uuid" : "UnLK64RiQpW3kAHOxkZNsQ",
        "version" : {
          "created" : "7100299"
        }
      }
    }
  }
}
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
