### PR TITLE
Rename opendistro endpoints

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -136,11 +136,11 @@ indices:admin/close[s]
 indices:admin/create
 indices:admin/mapping/put
 indices:admin/open
-indices:admin/opendistro/replication/index/start
-indices:admin/opendistro/replication/index/stop
-indices:data/read/opendistro/replication/file_metadata
+indices:admin/plugins/replication/index/start
+indices:admin/plugins/replication/index/stop
+indices:data/read/plugins/replication/file_metadata
 indices:data/write/index
-indices:data/write/opendistro/replication/changes
+indices:data/write/plugins/replication/changes
 indices:data/write/replication
 indices:monitor/stats
 
@@ -148,17 +148,17 @@ indices:monitor/stats
 
 cluster:monitor/state
 cluster:admin/snapshot/restore
-cluster:admin/opendistro/replication/autofollow/update
+cluster:admin/plugins/replication/autofollow/update
 ```
 
 ### Required permissions on leader cluster
 
 ```
 # Index Level Permissions
-indices:data/read/opendistro/replication/file_chunk
-indices:data/read/opendistro/replication/file_metadata
-indices:admin/opendistro/replication/resources/release
-indices:data/read/opendistro/replication/changes
+indices:data/read/plugins/replication/file_chunk
+indices:data/read/plugins/replication/file_metadata
+indices:admin/plugins/replication/resources/release
+indices:data/read/plugins/replication/changes
 indices:admin/mappings/get
 indices:monitor/stats
 
@@ -184,7 +184,7 @@ This API is used to initiate replication of an index from the leader cluster ont
 ```bash
 # REQUEST
 
-PUT localhost:{{foll_port}}/_opendistro/_replication/<index>/_start
+PUT localhost:{{foll_port}}/_plugins/_replication/<index>/_start
 Content-Type: application/json
 
 {  "remote_cluster" : "leader-cluster",  "remote_index": "<index>"}
@@ -201,7 +201,7 @@ Content-Type: application/json
 **Example** 
 ```bash
 curl -k -u testuser:testuser -XPUT \
-"https://${FOLLOWER}/_opendistro/_replication/follower-01/_start?pretty" \
+"https://${FOLLOWER}/_plugins/_replication/follower-01/_start?pretty" \
 -H 'Content-type: application/json' \
 -d'{"remote_cluster":"leader-cluster", "remote_index": "leader-01"}'
 
@@ -220,7 +220,7 @@ Note that the follower index is NOT deleted on stopping replication.
 ```bash
 # REQUEST
 
-POST localhost:{{foll_port}}/_opendistro/<index>/replicate/_stop
+POST localhost:{{foll_port}}/_plugins/<index>/replicate/_stop
 Content-Type: application/json
 {}
 
@@ -234,7 +234,7 @@ Content-Type: application/json
 **Example**
 ```bash
 curl -k -u testuser:testuser -XPOST \
-"https://${FOLLOWER}/_opendistro/_replication/follower-01/_stop?pretty" \
+"https://${FOLLOWER}/_plugins/_replication/follower-01/_stop?pretty" \
 -H 'Content-type: application/json' -d'{}'
 
 # You can confirm data isn't replicated any more by making modifications to
@@ -250,7 +250,7 @@ AutoFollow API helps to automatically start replication on indices matching a pa
 ```bash
 # REQUEST
 
-POST localhost:{{foll_port}}/_opendistro/_replication/_autofollow
+POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
 {"connection" : "<remote cluster connection name>",  "pattern": "<index pattern>", "name": "<name to identify autofollow task>"}
@@ -265,7 +265,7 @@ Content-Type: application/json
 **Example**
 ```bash
 curl -k -u testuser:testuser -XPOST \
-"https://${FOLLOWER}/_opendistro/_replication/_autofollow?pretty" \
+"https://${FOLLOWER}/_plugins/_replication/_autofollow?pretty" \
 -H 'Content-type: application/json' \
 -d'{"connection":"leader-cluster","pattern":"leader-*", "name":"my-replication"}'
 ```
@@ -277,7 +277,7 @@ AutoFollow can be removed by invoking API on the follower as follows. Invocation
 **Signature**
 
 ```bash
-DELETE localhost:{{foll_port}}/_opendistro/_replication/_autofollow
+DELETE localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
 {
@@ -290,7 +290,7 @@ Content-Type: application/json
 
 ```bash
 curl -k -u testuser:testuser -XDELETE \
-"https://${FOLLOWER}/_opendistro/_replication/_autofollow?pretty" \
+"https://${FOLLOWER}/_plugins/_replication/_autofollow?pretty" \
 -H 'Content-type: application/json' \
 -d'{"connection":"leader-cluster", "name":"my-replication"}'
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ curl -XPOST "http://${LEADER}/leader-01/_doc/1" -H 'Content-Type: application/js
 ### Step 4: Start replication
 
 ```bash
-curl -XPUT "http://${FOLLOWER}/_opendistro/_replication/follower-01/_start?pretty" \
+curl -XPUT "http://${FOLLOWER}/_plugins/_replication/follower-01/_start?pretty" \
 -H 'Content-type: application/json' \
 -d'{"remote_cluster":"leader-cluster", "remote_index": "leader-01"}'
 ```
@@ -137,7 +137,7 @@ At this point, any changes to leader-01 continues to be replicated to follower-0
 Stopping replication opens up the replicated index on the follower cluster for writes. This can be leveraged to failover to the follower cluster when the need arises.
 
 ```bash
-curl -XPOST "http://${FOLLOWER}/_opendistro/_replication/follower-01/_stop?pretty" \
+curl -XPOST "http://${FOLLOWER}/_plugins/_replication/follower-01/_stop?pretty" \
 -H 'Content-type: application/json' -d'{}'
 
 # You can confirm data isn't replicated any more by making modifications to

--- a/docs/RFC.md
+++ b/docs/RFC.md
@@ -104,7 +104,7 @@ This API is used to initiate replication of an index from the leader cluster ont
 ```bash
 Request
 
-PUT $FOLLOWER/_opendistro/_replication/<index>/_start
+PUT $FOLLOWER/_plugins/_replication/<index>/_start
 Content-Type: application/json
 
 {  "remote_cluster" : "leader-cluster",  "remote_index": "<index>"}
@@ -125,7 +125,7 @@ Note that the follower index is NOT deleted on stopping replication.
 ```bash
 
 Request
-POST $FOLLOWER/_opendistro/<index>/replicate/_stop
+POST $FOLLOWER/_plugins/_replication/<index>/_stop
 Content-Type: application/json
 
 {}
@@ -144,7 +144,7 @@ AutoFollow makes it easy to automatically replicate multiple indices matching a 
 
 ```bash
 Request
-POST $FOLLOWER/_opendistro/_replication/_autofollow
+POST $FOLLOWER/_plugins/_replication/_autofollow
 Content-Type: application/json
 
 {
@@ -159,7 +159,7 @@ Content-Type: application/json
 AutoFollow can be removed by invoking API on the follower as follows. Invocation of the API is only to stop any new auto-follow activity and does NOT stop replication of indices already initiated by the auto-follow.
 
 ```bash
-DELETE $FOLLOWER/_opendistro/_replication/_autofollow
+DELETE $FOLLOWER/_plugins/_replication/_autofollow
 Content-Type: application/json
 
 {

--- a/examples/sample/setup_permissions.sh
+++ b/examples/sample/setup_permissions.sh
@@ -42,11 +42,11 @@ curl -ks -u $admin -XPUT "https://${endpoint}/_opendistro/_security/api/actiongr
     "indices:admin/create",
     "indices:admin/mapping/put",
     "indices:admin/open",
-    "indices:admin/opendistro/replication/index/start",
-    "indices:admin/opendistro/replication/index/stop",
-    "indices:data/read/opendistro/replication/file_metadata",
+    "indices:admin/plugins/replication/index/start",
+    "indices:admin/plugins/replication/index/stop",
+    "indices:data/read/plugins/replication/file_metadata",
     "indices:data/write/index",
-    "indices:data/write/opendistro/replication/changes",
+    "indices:data/write/plugins/replication/changes",
     "indices:data/write/replication",
     "indices:monitor/stats"
   ]
@@ -61,7 +61,7 @@ curl -ks -u $admin -XPUT "https://${endpoint}/_opendistro/_security/api/actiongr
   "allowed_actions": [
     "cluster:monitor/state",
     "cluster:admin/snapshot/restore",
-    "cluster:admin/opendistro/replication/autofollow/update"
+    "cluster:admin/plugins/replication/autofollow/update"
   ]
 }
 '
@@ -73,10 +73,10 @@ echo "Creating actiongroup 'leader-replication-action-group' and associating ind
 curl -ks -u $admin -XPUT "https://${endpoint}/_opendistro/_security/api/actiongroups/leader-replication-action-group" -H 'Content-Type: application/json' -d'
 {
   "allowed_actions": [
-    "indices:data/read/opendistro/replication/file_chunk",
-    "indices:data/read/opendistro/replication/file_metadata",
-    "indices:admin/opendistro/replication/resources/release",
-    "indices:data/read/opendistro/replication/changes",
+    "indices:data/read/plugins/replication/file_chunk",
+    "indices:data/read/plugins/replication/file_metadata",
+    "indices:admin/plugins/replication/resources/release",
+    "indices:data/read/plugins/replication/changes",
     "indices:admin/mappings/get",
     "indices:monitor/stats"
   ]

--- a/replication.http
+++ b/replication.http
@@ -42,7 +42,7 @@ Content-Type: application/json
 }
 
 ### request with security plugin
-PUT https://localhost:{{foll_port}}/_opendistro/_replication/customer/_start?pretty
+PUT https://localhost:{{foll_port}}/_plugins/_replication/customer/_start?pretty
 Authorization: Basic admin admin
 Content-Type: application/json
 
@@ -92,7 +92,7 @@ Content-Type: application/json
 POST localhost:{{leader_port}}/_flush
 
 ### Start replication
-PUT localhost:{{foll_port}}/_opendistro/_replication/customer/_start
+PUT localhost:{{foll_port}}/_plugins/_replication/customer/_start
 Content-Type: application/json
 
 
@@ -147,7 +147,7 @@ GET localhost:{{leader_port}}/_cat/shards?v&h=i,s,pr,node,globalCheckpoint,maxSe
 GET localhost:{{foll_port}}/_cat/shards?v&h=i,s,pr,node,globalCheckpoint,maxSeqNo,segmentsCount,docs
 
 ### Update auto follow actions
-POST localhost:{{foll_port}}/_opendistro/_replication/_autofollow
+POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
 {
@@ -157,7 +157,7 @@ Content-Type: application/json
 }
 
 ### Add auto follow actions with Security plugin
-POST localhost:{{foll_port}}/_opendistro/_replication/_autofollow
+POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
 {
@@ -171,7 +171,7 @@ Content-Type: application/json
 }
 
 ### Delete the auto follow pattern
-DELETE localhost:{{foll_port}}/_opendistro/_replication/_autofollow
+DELETE localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
 {
@@ -180,7 +180,7 @@ Content-Type: application/json
 }
 
 ### Stop replication
-POST localhost:{{foll_port}}/_opendistro/_replication/customer/_stop
+POST localhost:{{foll_port}}/_plugins/_replication/customer/_stop
 Content-Type: application/json
 
 {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
@@ -136,13 +136,13 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
     companion object {
         const val REPLICATION_EXECUTOR_NAME_LEADER = "replication_leader"
         const val REPLICATION_EXECUTOR_NAME_FOLLOWER = "replication_follower"
-        val REPLICATED_INDEX_SETTING: Setting<String> = Setting.simpleString("index.opendistro.replicated",
+        val REPLICATED_INDEX_SETTING: Setting<String> = Setting.simpleString("index.plugins.replication.replicated",
             Setting.Property.InternalIndex, Setting.Property.IndexScope)
-        val REPLICATION_CHANGE_BATCH_SIZE: Setting<Int> = Setting.intSetting("opendistro.replication.ops_batch_size", 512, 16,
+        val REPLICATION_CHANGE_BATCH_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.ops_batch_size", 512, 16,
             Setting.Property.Dynamic, Setting.Property.NodeScope)
-        val REPLICATION_LEADER_THREADPOOL_SIZE: Setting<Int> = Setting.intSetting("opendistro.replication.leader.size", 0, 0,
+        val REPLICATION_LEADER_THREADPOOL_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.leader.size", 0, 0,
             Setting.Property.Dynamic, Setting.Property.NodeScope)
-        val REPLICATION_LEADER_THREADPOOL_QUEUE_SIZE: Setting<Int> = Setting.intSetting("opendistro.replication.leader.queue_size", 1000, 0,
+        val REPLICATION_LEADER_THREADPOOL_QUEUE_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.leader.queue_size", 1000, 0,
             Setting.Property.Dynamic, Setting.Property.NodeScope)
     }
 

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/AutoFollowMasterNodeAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/AutoFollowMasterNodeAction.kt
@@ -5,7 +5,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class AutoFollowMasterNodeAction: ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "internal:cluster:admin/opendistro/replication/autofollow/update"
+        const val NAME = "internal:cluster:admin/plugins/replication/autofollow/update"
         val INSTANCE = AutoFollowMasterNodeAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/UpdateAutoFollowPatternAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/UpdateAutoFollowPatternAction.kt
@@ -21,7 +21,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 class UpdateAutoFollowPatternAction : ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
 
     companion object {
-        const val NAME = "cluster:admin/opendistro/replication/autofollow/update"
+        const val NAME = "cluster:admin/plugins/replication/autofollow/update"
         val INSTANCE = UpdateAutoFollowPatternAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/changes/GetChangesAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/changes/GetChangesAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.ActionType
 class GetChangesAction private constructor() : ActionType<GetChangesResponse>(NAME, ::GetChangesResponse) {
 
     companion object {
-        const val NAME = "indices:data/read/opendistro/replication/changes"
+        const val NAME = "indices:data/read/plugins/replication/changes"
         val INSTANCE = GetChangesAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexAction.kt
@@ -19,7 +19,7 @@ import org.elasticsearch.action.ActionType
 
 class ReplicateIndexAction private constructor(): ActionType<ReplicateIndexResponse>(NAME, ::ReplicateIndexResponse) {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/start"
+        const val NAME = "indices:admin/plugins/replication/index/start"
         val INSTANCE: ReplicateIndexAction = ReplicateIndexAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexMasterNodeAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexMasterNodeAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class ReplicateIndexMasterNodeAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "internal:indices/admin/opendistro/replication/index/start"
+        const val NAME = "internal:indices/admin/plugins/replication/index/start"
         val INSTANCE: ReplicateIndexMasterNodeAction = ReplicateIndexMasterNodeAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/block/UpdateIndexBlockAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/block/UpdateIndexBlockAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class UpdateIndexBlockAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "internal:indices/admin/opendistro/replication/index/add_block"
+        const val NAME = "internal:indices/admin/plugins/replication/index/add_block"
         val INSTANCE: UpdateIndexBlockAction = UpdateIndexBlockAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class PauseIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/pause"
+        const val NAME = "indices:admin/plugins/replication/index/pause"
         val INSTANCE: PauseIndexReplicationAction = PauseIndexReplicationAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/replay/ReplayChangesAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/replay/ReplayChangesAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.ActionType
 class ReplayChangesAction private constructor() : ActionType<ReplayChangesResponse>(NAME, ::ReplayChangesResponse) {
 
     companion object {
-        const val NAME = "indices:data/write/opendistro/replication/changes"
+        const val NAME = "indices:data/write/plugins/replication/changes"
         val INSTANCE = ReplayChangesAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/replicationstatedetails/UpdateReplicationStateAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/replicationstatedetails/UpdateReplicationStateAction.kt
@@ -5,7 +5,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class UpdateReplicationStateAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "internal:cluster:admin/opendistro/replication/index/state"
+        const val NAME = "internal:cluster:admin/plugins/replication/index/state"
         val INSTANCE: UpdateReplicationStateAction = UpdateReplicationStateAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/repository/GetFileChunkAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/repository/GetFileChunkAction.kt
@@ -19,7 +19,7 @@ import org.elasticsearch.action.ActionType
 
 class GetFileChunkAction private constructor() : ActionType<GetFileChunkResponse>(NAME, ::GetFileChunkResponse) {
     companion object {
-        const val NAME = "indices:data/read/opendistro/replication/file_chunk"
+        const val NAME = "indices:data/read/plugins/replication/file_chunk"
         val INSTANCE = GetFileChunkAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/repository/GetStoreMetadataAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/repository/GetStoreMetadataAction.kt
@@ -19,7 +19,7 @@ import org.elasticsearch.action.ActionType
 
 class GetStoreMetadataAction private constructor() : ActionType<GetStoreMetadataResponse>(NAME, ::GetStoreMetadataResponse) {
     companion object {
-        const val NAME = "indices:data/read/opendistro/replication/file_metadata"
+        const val NAME = "indices:data/read/plugins/replication/file_metadata"
         val INSTANCE = GetStoreMetadataAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/repository/ReleaseLeaderResourcesAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/repository/ReleaseLeaderResourcesAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class ReleaseLeaderResourcesAction private constructor() : ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse)  {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/resources/release"
+        const val NAME = "indices:admin/plugins/replication/resources/release"
         val INSTANCE = ReleaseLeaderResourcesAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/resume/ResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/resume/ResumeIndexReplicationAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class ResumeIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/resume"
+        const val NAME = "indices:admin/plugins/replication/index/resume"
         val INSTANCE: ResumeIndexReplicationAction = ResumeIndexReplicationAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/setup/SetupChecksAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/setup/SetupChecksAction.kt
@@ -5,7 +5,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class SetupChecksAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "internal:indices/admin/opendistro/replication/index/setup"
+        const val NAME = "internal:indices/admin/plugins/replication/index/setup"
         val INSTANCE: SetupChecksAction = SetupChecksAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/setup/ValidatePermissionsAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/setup/ValidatePermissionsAction.kt
@@ -5,7 +5,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class ValidatePermissionsAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse){
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/setup/validate"
+        const val NAME = "indices:admin/plugins/replication/index/setup/validate"
         val INSTANCE: ValidatePermissionsAction = ValidatePermissionsAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusAction.kt
@@ -5,7 +5,7 @@ import org.elasticsearch.common.io.stream.Writeable
 
 class ReplicationStatusAction : ActionType<ReplicationStatusResponse>(NAME, reader) {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/status-check"
+        const val NAME = "indices:admin/plugins/replication/index/status-check"
         val INSTANCE = ReplicationStatusAction()
         val reader = Writeable.Reader { inp -> ReplicationStatusResponse(inp) }
     }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardsInfoAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardsInfoAction.kt
@@ -6,7 +6,7 @@ import org.elasticsearch.common.io.stream.Writeable
 
 class ShardsInfoAction : ActionType<ReplicationStatusResponse>(NAME, reader) {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/all-shards"
+        const val NAME = "indices:admin/plugins/replication/index/all-shards"
         val INSTANCE = ShardsInfoAction()
         val reader = Writeable.Reader { inp -> ReplicationStatusResponse(inp) }
     }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/StopIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/StopIndexReplicationAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class StopIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/stop"
+        const val NAME = "indices:admin/plugins/replication/index/stop"
         val INSTANCE: StopIndexReplicationAction = StopIndexReplicationAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/UpdateIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/UpdateIndexReplicationAction.kt
@@ -20,7 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 
 class UpdateIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {
-        const val NAME = "indices:admin/opendistro/replication/index/update"
+        const val NAME = "indices:admin/plugins/replication/index/update"
         val INSTANCE: UpdateIndexReplicationAction = UpdateIndexReplicationAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/UpdateMetadataAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/UpdateMetadataAction.kt
@@ -7,7 +7,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse
 class UpdateMetadataAction private constructor(): ActionType<AcknowledgedResponse>(
     NAME, ::AcknowledgedResponse) {
     companion object {
-            const val NAME = "indices:admin/opendistro/replication/index/update_metadata"
+            const val NAME = "indices:admin/plugins/replication/index/update_metadata"
             val INSTANCE: UpdateMetadataAction = UpdateMetadataAction()
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/repository/RemoteClusterRepository.kt
@@ -76,9 +76,9 @@ import java.util.function.Consumer
 import java.util.function.Function
 import kotlin.collections.ArrayList
 
-const val REMOTE_REPOSITORY_PREFIX = "opendistro-remote-repo-"
-const val REMOTE_REPOSITORY_TYPE = "opendistro-remote-repository"
-const val REMOTE_SNAPSHOT_NAME = "opendistro-remote-snapshot"
+const val REMOTE_REPOSITORY_PREFIX = "replication-remote-repo-"
+const val REMOTE_REPOSITORY_TYPE = "replication-remote-repository"
+const val REMOTE_SNAPSHOT_NAME = "replication-remote-snapshot"
 
 class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata,
                               private val client: Client,

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/rest/PauseIndexReplicationHandler.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/rest/PauseIndexReplicationHandler.kt
@@ -33,11 +33,11 @@ class PauseIndexReplicationHandler : BaseRestHandler() {
     }
 
     override fun routes(): List<RestHandler.Route> {
-        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_opendistro/_replication/{index}/_pause"))
+        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_plugins/_replication/{index}/_pause"))
     }
 
     override fun getName(): String {
-        return "opendistro_index_pause_replicate_action"
+        return "plugins_index_pause_replicate_action"
     }
 
     @Throws(IOException::class)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/rest/ReplicateIndexHandler.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/rest/ReplicateIndexHandler.kt
@@ -29,11 +29,11 @@ import java.io.IOException
 class ReplicateIndexHandler : BaseRestHandler() {
 
     override fun routes(): List<RestHandler.Route> {
-        return listOf(RestHandler.Route(RestRequest.Method.PUT, "/_opendistro/_replication/{index}/_start"))
+        return listOf(RestHandler.Route(RestRequest.Method.PUT, "/_plugins/_replication/{index}/_start"))
     }
 
     override fun getName(): String {
-        return "opendistro_index_start_replicate_action"
+        return "plugins_index_start_replicate_action"
     }
 
     @Throws(IOException::class)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/rest/ReplicationStatusHandler.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/rest/ReplicationStatusHandler.kt
@@ -18,11 +18,11 @@ class ReplicationStatusHandler : BaseRestHandler() {
     }
 
     override fun routes(): List<RestHandler.Route> {
-        return listOf(RestHandler.Route(RestRequest.Method.GET, "/_opendistro/_replication/{index}/_status"))
+        return listOf(RestHandler.Route(RestRequest.Method.GET, "/_plugins/_replication/{index}/_status"))
     }
 
     override fun getName(): String {
-        return "opendistro_replication_status"
+        return "plugins_replication_status"
     }
 
     @Throws(IOException::class)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/rest/ResumeIndexReplicationHandler.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/rest/ResumeIndexReplicationHandler.kt
@@ -33,11 +33,11 @@ class ResumeIndexReplicationHandler : BaseRestHandler() {
     }
 
     override fun routes(): List<RestHandler.Route> {
-        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_opendistro/_replication/{index}/_resume"))
+        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_plugins/_replication/{index}/_resume"))
     }
 
     override fun getName(): String {
-        return "opendistro_index_resume_replicate_action"
+        return "plugins_index_resume_replicate_action"
     }
 
     @Throws(IOException::class)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/rest/StopIndexReplicationHandler.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/rest/StopIndexReplicationHandler.kt
@@ -28,11 +28,11 @@ import java.io.IOException
 class StopIndexReplicationHandler : BaseRestHandler() {
 
     override fun routes(): List<RestHandler.Route> {
-        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_opendistro/_replication/{index}/_stop"))
+        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_plugins/_replication/{index}/_stop"))
     }
 
     override fun getName(): String {
-        return "opendistro_index_stop_replicate_action"
+        return "plugins_index_stop_replicate_action"
     }
 
     @Throws(IOException::class)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/rest/UpdateAutoFollowPatternsHandler.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/rest/UpdateAutoFollowPatternsHandler.kt
@@ -29,7 +29,7 @@ import org.elasticsearch.rest.action.RestToXContentListener
 class UpdateAutoFollowPatternsHandler : BaseRestHandler() {
 
     companion object {
-        const val PATH = "/_opendistro/_replication/_autofollow"
+        const val PATH = "/_plugins/_replication/_autofollow"
     }
 
     override fun routes(): List<RestHandler.Route> {
@@ -37,7 +37,7 @@ class UpdateAutoFollowPatternsHandler : BaseRestHandler() {
             RestHandler.Route(RestRequest.Method.DELETE, PATH))
     }
 
-    override fun getName() = "opendistro_replication_autofollow_update"
+    override fun getName() = "plugins_replication_autofollow_update"
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val action = when {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/rest/UpdateIndexHandler.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/rest/UpdateIndexHandler.kt
@@ -33,11 +33,11 @@ import java.io.IOException
 class UpdateIndexHandler : BaseRestHandler() {
 
     override fun routes(): List<RestHandler.Route> {
-        return listOf(RestHandler.Route(RestRequest.Method.PUT, "/_opendistro/_replication/{index}/_update"))
+        return listOf(RestHandler.Route(RestRequest.Method.PUT, "/_plugins/_replication/{index}/_update"))
     }
 
     override fun getName(): String {
-        return "opendistro_index_update_replicate_action"
+        return "plugins_index_update_replicate_action"
     }
 
     @Throws(IOException::class)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowExecutor.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowExecutor.kt
@@ -31,7 +31,7 @@ class AutoFollowExecutor(executor: String, private val clusterService: ClusterSe
     PersistentTasksExecutor<AutoFollowParams>(TASK_NAME, executor) {
 
     companion object {
-        const val TASK_NAME = "cluster:opendistro/admin/replication/autofollow"
+        const val TASK_NAME = "cluster:admin/plugins/replication/autofollow"
     }
 
     override fun nodeOperation(task: AllocatedPersistentTask, params: AutoFollowParams, state: PersistentTaskState?) {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
@@ -591,7 +591,7 @@ class IndexReplicationTask(id: Long, type: String, action: String, description: 
      * validation for the index before we allow the index replication to move to following state.
      * The validation done are:
      * 1. The index still exists and has been created using replication
-     *    workflow i.e. index settings contains 'index.opendistro.replicated'
+     *    workflow i.e. index settings contains 'index.plugins.replication.replicated'
      * 2. There shouldn't be any primary shard in active recovery.
      */
     private fun doesValidIndexExists(): Boolean {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -35,13 +35,13 @@ import java.util.concurrent.TimeUnit
 
 data class StartReplicationRequest(val remoteClusterAlias: String, val remoteIndex: String, val toIndex: String)
 
-const val REST_REPLICATION_PREFIX = "/_opendistro/_replication/"
+const val REST_REPLICATION_PREFIX = "/_plugins/_replication/"
 const val REST_REPLICATION_START = "$REST_REPLICATION_PREFIX{index}/_start"
 const val REST_REPLICATION_STOP = "$REST_REPLICATION_PREFIX{index}/_stop"
 const val REST_REPLICATION_PAUSE = "$REST_REPLICATION_PREFIX{index}/_pause"
 const val REST_REPLICATION_RESUME = "$REST_REPLICATION_PREFIX{index}/_resume"
 const val REST_REPLICATION_UPDATE = "$REST_REPLICATION_PREFIX{index}/_update"
-const val REST_AUTO_FOLLOW_PATTERN = "_opendistro/_replication/_autofollow"
+const val REST_AUTO_FOLLOW_PATTERN = "${REST_REPLICATION_PREFIX}_autofollow"
 
 fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
                                          waitFor: TimeValue = TimeValue.timeValueSeconds(10),


### PR DESCRIPTION
### Description
This change is required to rename the replication endpoints from _opendistro/_replication
to _plugins/_replication according to the recommendations for OpenSearch plugins:
https://github.com/opensearch-project/opensearch-plugins/blob/main/CONVENTIONS.md

The replication Rest endpoints, actions and snapshot repository have been renamed.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
