### PR TITLE
added connections alias and doc count in status api.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
@@ -14,6 +14,9 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
 
     lateinit var shardInfoResponse: MutableList<ShardInfoResponse>
     lateinit var status: String
+    lateinit var connectionAlias: String
+    lateinit var leaderIndexName: String
+    lateinit var followerIndexName: String
 
     @Throws(IOException::class)
     constructor(inp: StreamInput) : super(inp) {
@@ -58,6 +61,12 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
         builder.startObject()
         if (::status.isInitialized)
             builder.field("status",status)
+        if (::connectionAlias.isInitialized)
+            builder.field("connection_alias",connectionAlias)
+        if (::leaderIndexName.isInitialized)
+            builder.field("leader_index",leaderIndexName)
+        if (::followerIndexName.isInitialized)
+            builder.field("follower_index",followerIndexName)
         if (::shardInfoResponse.isInitialized)
             builder.field("replication_data",shardInfoResponse)
         builder.endObject()
@@ -71,5 +80,11 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
             out.writeList(shardInfoResponse)
         if (::status.isInitialized)
             out.writeString(status)
+        if (::connectionAlias.isInitialized)
+            out.writeString(connectionAlias)
+        if (::leaderIndexName.isInitialized)
+            out.writeString(leaderIndexName)
+        if (::followerIndexName.isInitialized)
+            out.writeString(followerIndexName)
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardInfoResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardInfoResponse.kt
@@ -15,29 +15,34 @@ import java.io.IOException
 class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
 
     val status: String
+    val docCount: Long
     lateinit var replayDetails: ReplayDetails
     lateinit var restoreDetails: RestoreDetails
 
     constructor(si: StreamInput) : super(si) {
         this.status = si.readString()
+        this.docCount = si.readLong()
         if (status.equals("SYNCING"))
             this.replayDetails = ReplayDetails(si)
         if (status.equals("BOOTSTRAPPING"))
             this.restoreDetails = RestoreDetails(si)
     }
 
-    constructor(shardId: ShardId, status :String, restoreDetailsShard : RestoreDetails) : super(shardId) {
+    constructor(shardId: ShardId, docCount: Long, status :String, restoreDetailsShard : RestoreDetails) : super(shardId) {
         this.status = status
+        this.docCount = docCount
         this.restoreDetails = restoreDetailsShard
     }
 
-    constructor(shardId: ShardId, status :String, replayDetailsShard : ReplayDetails) : super(shardId) {
+    constructor(shardId: ShardId, docCount: Long, status :String, replayDetailsShard : ReplayDetails) : super(shardId) {
         this.status = status
+        this.docCount = docCount
         this.replayDetails = replayDetailsShard
     }
 
-    constructor(shardId: ShardId, status :String, replayDetailsShard : ReplayDetails, restoreDetailsShard : RestoreDetails) : super(shardId) {
+    constructor(shardId: ShardId, docCount: Long, status :String, replayDetailsShard : ReplayDetails, restoreDetailsShard : RestoreDetails) : super(shardId) {
         this.status = status
+        this.docCount = docCount
         this.replayDetails = replayDetailsShard
         this.restoreDetails = restoreDetailsShard
     }
@@ -46,6 +51,7 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
         out.writeString(status)
+        out.writeLong(docCount)
         if (::replayDetails.isInitialized)
             replayDetails.writeTo(out)
         if (::restoreDetails.isInitialized)
@@ -53,6 +59,7 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     }
 
     private val SHARDID = ParseField("shard_id")
+    private val DOCCOUNT = ParseField("doc_count")
     private val REPLAYDETAILS = ParseField("syncing_task_details")
     private val RESTOREDETAILS = ParseField("bootstrap_task_details")
 
@@ -61,6 +68,7 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params?): XContentBuilder? {
         builder!!.startObject()
         builder.field(SHARDID.preferredName, shardId)
+        builder.field(DOCCOUNT.preferredName, docCount)
         if (::replayDetails.isInitialized)
             builder.field(REPLAYDETAILS.preferredName, replayDetails)
         if (::restoreDetails.isInitialized)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TranportShardsInfoAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TranportShardsInfoAction.kt
@@ -76,12 +76,12 @@ class TranportShardsInfoAction  @Inject constructor(clusterService: ClusterServi
         var seqNo = indexShard.localCheckpoint + 1
         if (indexShard.recoveryState().recoverySource.type.equals(org.elasticsearch.cluster.routing.RecoverySource.Type.SNAPSHOT) and
                 (indexState.recoveredBytesPercent() <100)) {
-            return ShardInfoResponse(shardRouting.shardId(),"BOOTSTRAPPING",
+            return ShardInfoResponse(shardRouting.shardId(),indexShard.docStats().count,"BOOTSTRAPPING",
                     RestoreDetails(indexState.totalBytes(), indexState.recoveredBytes(),
                             indexState.recoveredBytesPercent(), indexState.totalFileCount(), indexState.recoveredFileCount(),
                             indexState.recoveredFilesPercent(), indexState.startTime(), indexState.time()))
         }
-        return ShardInfoResponse(shardRouting.shardId(),"SYNCING", ReplayDetails(indexShard.lastKnownGlobalCheckpoint,
+        return ShardInfoResponse(shardRouting.shardId(),indexShard.docStats().count,"SYNCING", ReplayDetails(indexShard.lastKnownGlobalCheckpoint,
                 indexShard.lastSyncedGlobalCheckpoint, seqNo))
     }
 

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
@@ -59,6 +59,9 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
                             followerResponse.shardInfoResponse = shardResponses
                         }
                     }
+                    followerResponse.connectionAlias = metadata.connectionName
+                    followerResponse.followerIndexName = metadata.followerContext.resource
+                    followerResponse.leaderIndexName = metadata.leaderContext.resource
                     followerResponse.status = status
                     followerResponse
                 } catch(e : Exception) {


### PR DESCRIPTION
### Description
Added few more fields in status api useful for publishing metrics to cloudwatch.

 
New response :
```
syncing phase:

{
    "status": "SYNCING",
    "connection_alias": "source",
    "leader_index": "check6",
    "follower_index": "folcheck6",
    "replication_data": [
        {
            "shard_id": "[folcheck6][0]",
            "doc_count": 1,
            "syncing_task_details": {
                "remote_checkpoint": 0,
                "local_checkpoint": 0,
                "seq_no": 1
            }
        },
        {
            "shard_id": "[folcheck6][1]",
            "doc_count": 1,
            "syncing_task_details": {
                "remote_checkpoint": 0,
                "local_checkpoint": 0,
                "seq_no": 1
            }
        }
    ]
}

Bootstrap phase :

{
    "status": "BOOTSTRAPPING",
    "connection_alias": "source",
    "leader_index": "check6",
    "follower_index": "folcheck6",
    "replication_data": [
        {
            "shard_id": "[folcheck6][0]",
            "doc_count": 0,
            "bootstrap_task_details": {
                "bytes_total": 208,
                "bytes_recovered": 208,
                "bytes_percent": 100.0,
                "files_total": 1,
                "files_recovered": 1,
                "files_percent": 100.0,
                "start_time": 1625138711361,
                "running_time": 177
            }
        },
        {
            "shard_id": "[folcheck6][1]",
            "doc_count": 0,
            "bootstrap_task_details": {
                "bytes_total": 208,
                "bytes_recovered": 208,
                "bytes_percent": 100.0,
                "files_total": 1,
                "files_recovered": 1,
                "files_percent": 100.0,
                "start_time": 1625138711350,
                "running_time": 203
            }
        }
    ]
}```


 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
