### PR TITLE
added few integ tests related to status api.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
@@ -87,4 +87,10 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
         if (::followerIndexName.isInitialized)
             out.writeString(followerIndexName)
     }
+
+    override fun toString(): String {
+        return "ReplicationStatusResponse(shardInfoResponse=$shardInfoResponse, status='$status', connectionAlias='$connectionAlias', leaderIndexName='$leaderIndexName', followerIndexName='$followerIndexName')"
+    }
+
+
 }

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/ResumeReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/ResumeReplicationIT.kt
@@ -37,6 +37,7 @@ import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.index.mapper.MapperService
 import org.elasticsearch.test.ESTestCase.assertBusy
+import org.junit.Assert
 import java.util.concurrent.TimeUnit
 
 
@@ -64,7 +65,11 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
             and verify the same
              */
             followerClient.pauseReplication(followerIndexName)
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
             followerClient.resumeReplication(followerIndexName)
+            statusResp = followerClient.replicationStatus(followerIndexName)
+            Assert.assertNotEquals(statusResp.getValue("status"),"PAUSED")
         } finally {
             followerClient.stopReplication(followerIndexName)
         }
@@ -139,7 +144,11 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
             leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
             leaderClient.indices().open(OpenIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
 
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
             followerClient.resumeReplication(followerIndexName)
+            statusResp = followerClient.replicationStatus(followerIndexName)
+            Assert.assertNotEquals(statusResp.getValue("status"),"PAUSED")
         } finally {
             followerClient.stopReplication(followerIndexName)
         }

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
@@ -64,6 +64,8 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            assertThat(statusResp.getValue("status")).isIn(("SYNCING"),("BOOTSTRAPPING"),("RUNNING"))
             assertBusy {
                 assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
             }


### PR DESCRIPTION
### Description
Added Status api call to existing integ tests, where ever applicable.
 
### Testing
```
./gradlew integTest

=======================================
Elasticsearch Build Hamster says Hello!
 Gradle Version    : 6.6.1
 OS Info        : Mac OS X 10.14.6 (x86_64)
 JDK Version      : 14 (AdoptOpenJDK)
 JAVA_HOME       : /Library/Java/JavaVirtualMachines/adoptopenjdk-14.jdk/Contents/Home
 Random Testing Seed  : A1C77BFFADE9CCF8
 In FIPS 140 mode   : false
=======================================
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6.1/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 7m 20s
7 actionable tasks: 1 executed, 6 up-to-date
```

 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
