### PR TITLE
bootstrapping bug fix and few integ tests.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
@@ -87,4 +87,11 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
         if (::followerIndexName.isInitialized)
             out.writeString(followerIndexName)
     }
+
+    override fun toString(): String {
+        return "ReplicationStatusResponse(shardInfoResponse=$shardInfoResponse, status='$status'," +
+                " connectionAlias='$connectionAlias', leaderIndexName='$leaderIndexName', followerIndexName='$followerIndexName')"
+    }
+
+
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardInfoResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardInfoResponse.kt
@@ -15,34 +15,29 @@ import java.io.IOException
 class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
 
     val status: String
-    val docCount: Long
     lateinit var replayDetails: ReplayDetails
     lateinit var restoreDetails: RestoreDetails
 
     constructor(si: StreamInput) : super(si) {
         this.status = si.readString()
-        this.docCount = si.readLong()
         if (status.equals("SYNCING"))
             this.replayDetails = ReplayDetails(si)
         if (status.equals("BOOTSTRAPPING"))
             this.restoreDetails = RestoreDetails(si)
     }
 
-    constructor(shardId: ShardId, docCount: Long, status :String, restoreDetailsShard : RestoreDetails) : super(shardId) {
+    constructor(shardId: ShardId, status :String, restoreDetailsShard : RestoreDetails) : super(shardId) {
         this.status = status
-        this.docCount = docCount
         this.restoreDetails = restoreDetailsShard
     }
 
-    constructor(shardId: ShardId, docCount: Long, status :String, replayDetailsShard : ReplayDetails) : super(shardId) {
+    constructor(shardId: ShardId, status :String, replayDetailsShard : ReplayDetails) : super(shardId) {
         this.status = status
-        this.docCount = docCount
         this.replayDetails = replayDetailsShard
     }
 
-    constructor(shardId: ShardId, docCount: Long, status :String, replayDetailsShard : ReplayDetails, restoreDetailsShard : RestoreDetails) : super(shardId) {
+    constructor(shardId: ShardId, status :String, replayDetailsShard : ReplayDetails, restoreDetailsShard : RestoreDetails) : super(shardId) {
         this.status = status
-        this.docCount = docCount
         this.replayDetails = replayDetailsShard
         this.restoreDetails = restoreDetailsShard
     }
@@ -51,7 +46,6 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
         out.writeString(status)
-        out.writeLong(docCount)
         if (::replayDetails.isInitialized)
             replayDetails.writeTo(out)
         if (::restoreDetails.isInitialized)
@@ -68,7 +62,6 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params?): XContentBuilder? {
         builder!!.startObject()
         builder.field(SHARDID.preferredName, shardId)
-        builder.field(DOCCOUNT.preferredName, docCount)
         if (::replayDetails.isInitialized)
             builder.field(REPLAYDETAILS.preferredName, replayDetails)
         if (::restoreDetails.isInitialized)
@@ -77,6 +70,9 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
         return builder
     }
 
+    fun isReplayDetailsInitialized(): Boolean {
+        return ::replayDetails.isInitialized
+    }
 }
 
 class RestoreDetails :  BroadcastResponse, ToXContentObject {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TranportShardsInfoAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TranportShardsInfoAction.kt
@@ -9,14 +9,13 @@ import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.ClusterState
 import org.elasticsearch.cluster.block.ClusterBlockException
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver
-import org.elasticsearch.cluster.routing.PlainShardsIterator
-import org.elasticsearch.cluster.routing.ShardRouting
-import org.elasticsearch.cluster.routing.ShardsIterator
+import org.elasticsearch.cluster.routing.*
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.inject.Inject
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.Writeable
-import org.elasticsearch.index.shard.IndexShard
+import org.elasticsearch.index.IndexNotFoundException
+import org.elasticsearch.index.IndexService
 import org.elasticsearch.indices.IndicesService
 import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.TransportService
@@ -71,25 +70,29 @@ class TranportShardsInfoAction  @Inject constructor(clusterService: ClusterServi
 
     @Throws(IOException::class)
     override fun shardOperation(request: ShardInfoRequest, shardRouting: ShardRouting): ShardInfoResponse {
-        val indexShard: IndexShard = indicesService.indexServiceSafe(shardRouting.shardId().index).getShard(shardRouting.shardId().id())
+        val indexService: IndexService = indicesService.indexServiceSafe(shardRouting.shardId().index)
+        val indexShard = indexService.getShard(shardRouting.shardId().id())
+
         var indexState = indexShard.recoveryState().index
-        var seqNo = indexShard.localCheckpoint + 1
         if (indexShard.recoveryState().recoverySource.type.equals(org.elasticsearch.cluster.routing.RecoverySource.Type.SNAPSHOT) and
                 (indexState.recoveredBytesPercent() <100)) {
-            return ShardInfoResponse(shardRouting.shardId(),indexShard.docStats().count,"BOOTSTRAPPING",
+            return ShardInfoResponse(shardRouting.shardId(),"BOOTSTRAPPING",
                     RestoreDetails(indexState.totalBytes(), indexState.recoveredBytes(),
                             indexState.recoveredBytesPercent(), indexState.totalFileCount(), indexState.recoveredFileCount(),
                             indexState.recoveredFilesPercent(), indexState.startTime(), indexState.time()))
         }
-        return ShardInfoResponse(shardRouting.shardId(),indexShard.docStats().count,"SYNCING", ReplayDetails(indexShard.lastKnownGlobalCheckpoint,
+        var seqNo = indexShard.localCheckpoint + 1
+        return ShardInfoResponse(shardRouting.shardId(),"SYNCING", ReplayDetails(indexShard.lastKnownGlobalCheckpoint,
                 indexShard.lastSyncedGlobalCheckpoint, seqNo))
     }
 
     override fun shards(clusterState: ClusterState, request: ShardInfoRequest?, concreteIndices: Array<String?>?): ShardsIterator? {
-        val activePrimaryShardsGrouped = clusterState.routingTable().activePrimaryShardsGrouped(concreteIndices, false)
+        var shardRoutingList = clusterState.routingTable().allShards(request!!.indexName)
         val shards: MutableList<ShardRouting> = ArrayList()
-        activePrimaryShardsGrouped.forEach {
-            shards.addAll(it.shardRoutings)
+        shardRoutingList.forEach {
+            if(it.primary()) {
+                shards.add(it)
+            }
         }
         return PlainShardsIterator(shards)
     }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
@@ -49,14 +49,18 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
                         var shardResponses = followerResponse.shardInfoResponse
                         leaderResponse.shardInfoResponse.listIterator().forEach {
                             val leaderShardName = it.shardId.toString()
-                            val remoteCheckPoint = it.replayDetails.remoteCheckpoint
-                            shardResponses.listIterator().forEach {
-                                if (leaderShardName.equals(it.shardId.toString()
-                                                .replace(metadata.followerContext.resource, metadata.leaderContext.resource))) {
-                                    it.replayDetails.remoteCheckpoint = remoteCheckPoint
+                            if (it.isReplayDetailsInitialized()) {
+                                val remoteCheckPoint = it.replayDetails.remoteCheckpoint
+                                shardResponses.listIterator().forEach {
+                                    if (it.isReplayDetailsInitialized()) {
+                                        if (leaderShardName.equals(it.shardId.toString()
+                                                        .replace(metadata.followerContext.resource, metadata.leaderContext.resource))) {
+                                            it.replayDetails.remoteCheckpoint = remoteCheckPoint
+                                        }
+                                    }
                                 }
+                                followerResponse.shardInfoResponse = shardResponses
                             }
-                            followerResponse.shardInfoResponse = shardResponses
                         }
                     }
                     followerResponse.connectionAlias = metadata.connectionName

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/PauseReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/PauseReplicationIT.kt
@@ -35,6 +35,7 @@ import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.index.mapper.MapperService
 import org.elasticsearch.test.ESTestCase.assertBusy
+import org.junit.Assert
 import java.util.concurrent.TimeUnit
 
 
@@ -148,6 +149,8 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
         assertThat(createIndexResponse.isAcknowledged).isTrue()
         assertThatThrownBy {
             followerClient.pauseReplication(randomIndex)
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate paused status resposne`(statusResp)
         }.isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("No replication in progress for index:$randomIndex")
     }
@@ -167,6 +170,8 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
             and verify the same
              */
             followerClient.pauseReplication(followerIndexName)
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate paused status resposne`(statusResp)
             // Since, we were still in FOLLOWING phase when pause was called, the index
             // in follower index should not have been deleted in follower cluster
             assertBusy {


### PR DESCRIPTION
### Description
Changes :
1. While fetching status per shard we are filtering for primary and active shards which is leading to missing shard information in response during bootstrap phase, as the shards might be in yellow (inactive) state during bootstrap phase. changed it to only filter on primary shards.
2.  Added integ tests for syncing, paused, resume state in status api.
3. Remove doc count field, which is no longer used by cloudwatch
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
