### PR TITLE
renamed connection alias and changed exception handling.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
@@ -62,7 +62,7 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
         if (::status.isInitialized)
             builder.field("status",status)
         if (::connectionAlias.isInitialized)
-            builder.field("connection_alias",connectionAlias)
+            builder.field("remote_cluster",connectionAlias)
         if (::leaderIndexName.isInitialized)
             builder.field("leader_index",leaderIndexName)
         if (::followerIndexName.isInitialized)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
@@ -1,12 +1,14 @@
 package com.amazon.elasticsearch.replication.action.status
 
 
+import com.amazon.elasticsearch.replication.ReplicationException
 import com.amazon.elasticsearch.replication.metadata.ReplicationMetadataManager
 import com.amazon.elasticsearch.replication.util.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ResourceNotFoundException
 import org.elasticsearch.action.ActionListener
 import org.elasticsearch.action.support.ActionFilters
 import org.elasticsearch.action.support.HandledTransportAction
@@ -68,10 +70,12 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
                     followerResponse.leaderIndexName = metadata.leaderContext.resource
                     followerResponse.status = status
                     followerResponse
-                } catch(e : Exception) {
-                    // TODO : when we get resoucenotfound exception show replication status
-                    //  as not in progess and in case of generic excpetion, throw replication_exception.
+                } catch (e : ResourceNotFoundException) {
+                    log.error("got ResourceNotFoundException while querying for status ",e)
                     ReplicationStatusResponse("REPLICATION NOT IN PROGRESS")
+                } catch(e : Exception) {
+                    log.error("got Exception while querying for status ",e)
+                    throw ReplicationException("failed to fetch replication status")
                 }
             }
         }


### PR DESCRIPTION
### Description
1. Renamed connection_alias to remote_cluster.
2. Started capturing resource not found exception while querying metadata in replication status.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
