### PR TITLE
Async metadata update. Separated metadata reader and updater

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
@@ -14,7 +14,7 @@ class ReplicationSettings(clusterService: ClusterService) {
     @Volatile var pollDuration: TimeValue = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_PARALLEL_READ_POLL_DURATION)
     @Volatile var autofollowFetchPollDuration = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION)
     @Volatile var autofollowRetryPollDuration = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION)
-
+    @Volatile var metadataSyncInterval = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL)
     init {
         listenForUpdates(clusterService.clusterSettings)
     }
@@ -27,5 +27,6 @@ class ReplicationSettings(clusterService: ClusterService) {
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_PARALLEL_READ_POLL_DURATION) { pollDuration = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION) { autofollowFetchPollDuration = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION) { autofollowRetryPollDuration = it }
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL) { metadataSyncInterval = it }
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
@@ -49,6 +49,7 @@ class TransportUpdateIndexReplicationAction @Inject constructor(transportService
                                                               actionFilters: ActionFilters,
                                                               indexNameExpressionResolver:
                                                               IndexNameExpressionResolver,
+                                                              val indexScopedSettings: IndexScopedSettings,
                                                               val client: Client,
                                                               val replicationMetadataManager: ReplicationMetadataManager) :
     TransportMasterNodeAction<UpdateIndexReplicationRequest, AcknowledgedResponse> (UpdateIndexReplicationAction.NAME,
@@ -79,9 +80,8 @@ class TransportUpdateIndexReplicationAction @Inject constructor(transportService
     }
 
     private fun validateUpdateReplicationRequest(request: UpdateIndexReplicationRequest) {
-        IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.validate(
-                request.settings,  // don't validate wildcards
-                false,  // don't validate dependencies here we check it below never allow to change the number of shards
+        indexScopedSettings.validate(request.settings,
+                false,
                 false)
 
         val replicationStateParams = getReplicationStateParamsForIndex(clusterService, request.indexName)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/ReplicationMetadataManager.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/ReplicationMetadataManager.kt
@@ -32,22 +32,23 @@ class ReplicationMetadataManager constructor(private val clusterService: Cluster
                                             overallState: ReplicationOverallState,
                                             user: User?,
                                             follower_fgac_role: String?,
-                                            leader_fgac_role: String?) {
+                                            leader_fgac_role: String?,
+    settings: Settings) {
         val replicationMetadata = ReplicationMetadata(connectionName,
                 ReplicationStoreMetadataType.INDEX.name, overallState.name, CUSTOMER_INITIATED_ACTION,
                 ReplicationContext(followerIndex, user?.overrideFgacRole(follower_fgac_role)),
-                ReplicationContext(leaderIndex, user?.overrideFgacRole(leader_fgac_role)))
+                ReplicationContext(leaderIndex, user?.overrideFgacRole(leader_fgac_role)), settings)
         addMetadata(AddReplicationMetadataRequest(replicationMetadata))
         updateReplicationState(followerIndex, overallState)
     }
 
     suspend fun addAutofollowMetadata(patternName: String, connectionName: String, pattern: String,
                                       overallState: ReplicationOverallState, user: User?,
-                                      follower_fgac_role: String?, leader_fgac_role: String?) {
+                                      follower_fgac_role: String?, leader_fgac_role: String?, settings: Settings) {
         val replicationMetadata = ReplicationMetadata(connectionName,
                 ReplicationStoreMetadataType.AUTO_FOLLOW.name, overallState.name, CUSTOMER_INITIATED_ACTION,
                 ReplicationContext(patternName, user?.overrideFgacRole(follower_fgac_role)),
-                ReplicationContext(pattern, user?.overrideFgacRole(leader_fgac_role)))
+                ReplicationContext(pattern, user?.overrideFgacRole(leader_fgac_role)), settings)
         addMetadata(AddReplicationMetadataRequest(replicationMetadata))
     }
 

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/store/ReplicationMetadata.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/store/ReplicationMetadata.kt
@@ -81,7 +81,7 @@ class ReplicationMetadata: ToXContent {
                 reason: String,
                 followerContext: ReplicationContext,
                 leaderContext: ReplicationContext,
-                settings: Settings = Settings.EMPTY) {
+                settings: Settings) {
         this.connectionName = connectionName
         this.metadataType = metadataType
         this.overallState = overallState

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
@@ -134,7 +134,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
 
         try {
             log.info("Auto follow starting replication from ${remoteCluster}:$remoteIndex -> $remoteIndex")
-            val request = ReplicateIndexRequest(remoteIndex, remoteCluster, remoteIndex)
+            val request = ReplicateIndexRequest(remoteIndex, remoteCluster, remoteIndex )
             request.isAutoFollowRequest = true
             val followerRole = replicationMetadata.followerContext?.user?.roles?.get(0)
             val leaderRole = replicationMetadata.leaderContext?.user?.roles?.get(0)
@@ -143,6 +143,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
                 request.assumeRoles!![ReplicateIndexRequest.FOLLOWER_FGAC_ROLE] = followerRole
                 request.assumeRoles!![ReplicateIndexRequest.LEADER_FGAC_ROLE] = leaderRole
             }
+            request.settings = replicationMetadata.settings
             val response = client.suspendExecute(replicationMetadata, ReplicateIndexAction.INSTANCE, request)
             if (!response.isAcknowledged) {
                 throw ReplicationException("Failed to auto follow remote index $remoteIndex")

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationExecutor.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationExecutor.kt
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager
 import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.ClusterState
 import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.common.settings.SettingsModule
 import org.elasticsearch.persistent.AllocatedPersistentTask
 import org.elasticsearch.persistent.PersistentTaskState
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask
@@ -35,7 +36,8 @@ import org.elasticsearch.threadpool.ThreadPool
 class IndexReplicationExecutor(executor: String, private val clusterService: ClusterService,
                                private val threadPool: ThreadPool, private val client: Client,
                                private val replicationMetadataManager: ReplicationMetadataManager,
-                               private val replicationSettings: ReplicationSettings)
+                               private val replicationSettings: ReplicationSettings,
+                               var settingsModule: SettingsModule)
     : PersistentTasksExecutor<IndexReplicationParams>(TASK_NAME, executor) {
 
     companion object {
@@ -68,7 +70,7 @@ class IndexReplicationExecutor(executor: String, private val clusterService: Clu
                             headers: MutableMap<String, String>?): AllocatedPersistentTask {
         return IndexReplicationTask(id, type, action, getDescription(taskInProgress), parentTaskId,
                                     executor, clusterService, threadPool, client, requireNotNull(taskInProgress.params),
-                                    persistentTasksService, replicationMetadataManager, replicationSettings)
+                                    persistentTasksService, replicationMetadataManager, replicationSettings, settingsModule)
     }
 
     override fun getDescription(taskInProgress: PersistentTask<IndexReplicationParams>): String {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/task/shard/TranslogSequencerTests.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/task/shard/TranslogSequencerTests.kt
@@ -25,7 +25,6 @@ import com.amazon.elasticsearch.replication.metadata.store.ReplicationMetadata
 import com.amazon.elasticsearch.replication.metadata.store.ReplicationStoreMetadataType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.elasticsearch.action.ActionListener
@@ -33,6 +32,7 @@ import org.elasticsearch.action.ActionRequest
 import org.elasticsearch.action.ActionResponse
 import org.elasticsearch.action.ActionType
 import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo
+import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.index.shard.ShardId
 import org.elasticsearch.index.translog.Translog
 import org.elasticsearch.tasks.TaskId.EMPTY_TASK_ID
@@ -71,7 +71,7 @@ class TranslogSequencerTests : ESTestCase() {
     val remoteIndex = "remoteIndex"
     val followerShardId = ShardId("follower", "follower_uuid", 0)
     val replicationMetadata = ReplicationMetadata(remoteCluster, ReplicationStoreMetadataType.INDEX.name, ReplicationOverallState.RUNNING.name, "test user",
-            ReplicationContext(followerShardId.indexName, null), ReplicationContext(remoteIndex, null))
+            ReplicationContext(followerShardId.indexName, null), ReplicationContext(remoteIndex, null), Settings.EMPTY)
     val client = RequestCapturingClient()
     init {
         closeAfterSuite(client)


### PR DESCRIPTION
Added settings param to AutoFollow and Start Replication

### Description
Two changes :

1. Metadata fetch is spawned task which will run at a configurable frequency . The application of that fetch will be done whenever we find a metadata setting to apply 
2. Added  optional `settings` object in AutoFollow and Start API
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/51
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
