### PR TITLE
Using non null RestoreInProgress value in case of no restore in progress

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -91,7 +91,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                 client.suspendExecute(UpdateIndexBlockAction.INSTANCE, updateIndexBlockRequest, injectSecurityContext = true)
 
                 // Index will be deleted if replication is stopped while it is restoring.  So no need to close/reopen
-                val restoring = clusterService.state().custom<RestoreInProgress>(RestoreInProgress.TYPE).any { entry ->
+                val restoring = clusterService.state().custom<RestoreInProgress>(RestoreInProgress.TYPE, RestoreInProgress.EMPTY).any { entry ->
                     entry.indices().any { it == request.indexName }
                 }
                 if (!restoring &&


### PR DESCRIPTION
### Description

 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/53
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
