### PR TITLE
Propagate shard failures to index task and auto-pause on failures.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
@@ -22,6 +22,7 @@ import com.amazon.elasticsearch.replication.task.CrossClusterReplicationTask
 import com.amazon.elasticsearch.replication.task.ReplicationState
 import com.amazon.elasticsearch.replication.util.suspendExecute
 import com.amazon.elasticsearch.replication.util.suspending
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest
@@ -56,7 +57,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         val AUTO_FOLLOW_CHECK_DELAY = TimeValue.timeValueSeconds(30)!!
     }
 
-    override suspend fun execute(initialState: PersistentTaskState?) {
+    override suspend fun execute(scope: CoroutineScope, initialState: PersistentTaskState?) {
         while (scope.isActive) {
             autoFollow()
             delay(AUTO_FOLLOW_CHECK_DELAY.millis)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/Extensions.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/Extensions.kt
@@ -193,7 +193,7 @@ fun User.toInjectedRoles(): String? {
     return "${name}|${roles.joinToString(separator=",")}"
 }
 
-fun Exception.stackTraceToString(): String {
+fun Throwable.stackTraceToString(): String {
     val sw = StringWriter()
     val pw = PrintWriter(sw)
     printStackTrace(pw)


### PR DESCRIPTION
### Description
This commit introduces FailedState for ShardTask. Any failure in
shard-replication task (even via nested coroutine) are caught and captured as
FailedState.

The IndexReplicationTask notices the failure while it is in MonitoringState and
triggers a pause. If the pause fails, it marks the overall replication state as
failed.

This also required fixing the nesting of coroutines. The outer coroutine
was being used to trigger actor and waiting for cancellation, which was
breaking intuitive parent-child coroutine relationship via nesting.

Signed-off-by: Gopala Krishna Ambareesh <gopalak@amazon.com>

### Testing

Since there is no failure injection framework yet, resorted to manual testing. Ran the following manual tests

1. Ensured existing integ tests passed fully
2. Injected failure in TranslogSequencer and ensured replication paused and verified the logging.
3. Verified replication resumes after resuming post step 2.
3. Injected failure in TranslogSequencer and in TransportPauseIndexReplicationAction. Verified that the pause is attempted and moves the overall replication to FAILED state.
4. Injected failure in ShardReplicationTask and ensured replication paused.
5. Verified replication resumes after resuming post step 4.


### Example output

#### Paused due to failure

```bash
$ curl "$FOLLOWER/_plugins/_replication/$FOLLOWER_INDEX/_status?pretty"
{
  "status" : "PAUSED",
  "reason" : "[[fdgexbtoaq][0] - com.amazon.elasticsearch.replication.ReplicationException - \"failed to replay changes\"], ",
  "remote_cluster" : "source",
  "leader_index" : "ohxnmlauwx",
  "follower_index" : "fdgexbtoaq",
  "syncing_details" : {
    "remote_checkpoint" : 0,
    "local_checkpoint" : 0,
    "seq_no" : 1
  }
}
```

#### Failure to pause on failure

```bash
# gopalak@a483e760d759.ant.amazon.com K M in ~/code
$ curl "$FOLLOWER/_plugins/_replication/$FOLLOWER_INDEX/_status?pretty"
{
  "status" : "FAILED",
  "reason" : "Pause failed with \"Index is in restore phase currently for index: zmptafwtwc. You can pause after restore completes.\". Original failure for initiating pause - [[zmptafwtwc][0] - com.amazon.elasticsearch.replication.ReplicationException - \"failed to replay changes\"], ",
  "remote_cluster" : "source",
  "leader_index" : "rzsrrcncmx",
  "follower_index" : "xfpdeazkrx",
  "syncing_details" : {
    "remote_checkpoint" : 1,
    "local_checkpoint" : 0,
    "seq_no" : 1
  }
}
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
