### PR TITLE
Captured reason for API invocation and added to the replication metadata store

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationRequest.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationRequest.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.elasticsearch.replication.action.pause
 
+import com.amazon.elasticsearch.replication.metadata.ReplicationMetadataManager
 import org.elasticsearch.action.ActionRequestValidationException
 import org.elasticsearch.action.IndicesRequest
 import org.elasticsearch.action.support.IndicesOptions
@@ -27,7 +28,7 @@ import org.elasticsearch.common.xcontent.*
 class PauseIndexReplicationRequest : AcknowledgedRequest<PauseIndexReplicationRequest>, IndicesRequest.Replaceable, ToXContentObject {
 
     lateinit var indexName: String
-    var reason = "User initiated"
+    var reason = ReplicationMetadataManager.CUSTOMER_INITIATED_ACTION
 
     constructor(indexName: String, reason: String) {
         this.indexName = indexName

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
@@ -84,7 +84,7 @@ class TransportPauseIndexReplicationAction @Inject constructor(transportService:
                 }
 
                 // If the index is not in bootstrap phase, bring down the tasks and persist the info
-                replicationMetadataManager.updateIndexReplicationState(request.indexName, ReplicationOverallState.PAUSED)
+                replicationMetadataManager.updateIndexReplicationState(request.indexName, ReplicationOverallState.PAUSED, request.reason)
 
                 AcknowledgedResponse(true)
             }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ReplicationStatusResponse.kt
@@ -14,6 +14,7 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
 
     lateinit var shardInfoResponse: MutableList<ShardInfoResponse>
     lateinit var status: String
+    lateinit var reason: String
     lateinit var connectionAlias: String
     lateinit var leaderIndexName: String
     lateinit var followerIndexName: String
@@ -51,12 +52,14 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
             failedShards: Int,
             shardFailures: List<DefaultShardOperationFailedException>,
             shardInfoResponse: List<ShardInfoResponse>,
-            status : String
+            status : String,
+            reason: String
     ) : super(
             totalShards, successfulShards, failedShards, shardFailures
     ) {
         this.shardInfoResponse = shardInfoResponse.toMutableList()
         this.status = status
+        this.reason = reason
     }
 
     @Throws(IOException::class)
@@ -64,6 +67,8 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
         builder.startObject()
         if (::status.isInitialized)
             builder.field("status",status)
+        if (::reason.isInitialized)
+            builder.field("reason", reason)
         if (::connectionAlias.isInitialized)
             builder.field("remote_cluster",connectionAlias)
         if (::leaderIndexName.isInitialized)
@@ -83,10 +88,13 @@ class ReplicationStatusResponse : BroadcastResponse, ToXContentObject {
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
+        // TODO: Modify this to have predictable fields
         if (::shardInfoResponse.isInitialized)
             out.writeList(shardInfoResponse)
         if (::status.isInitialized)
             out.writeString(status)
+        if (::reason.isInitialized)
+            out.writeString(reason)
         if (::connectionAlias.isInitialized)
             out.writeString(connectionAlias)
         if (::leaderIndexName.isInitialized)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
@@ -39,6 +39,7 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
                     val metadata = replicationMetadataManager.getIndexReplicationMetadata(request!!.indices()[0])
                     val remoteClient = client.getRemoteClusterClient(metadata.connectionName)
                     var status = if (metadata.overallState.isNullOrEmpty()) "STOPPED" else metadata.overallState
+                    var reason = metadata.reason
                     var followerResponse = client.suspendExecute(ShardsInfoAction.INSTANCE,
                             ShardInfoRequest(metadata.followerContext.resource),true)
                     var leaderResponse = remoteClient.suspendExecute(ShardsInfoAction.INSTANCE,
@@ -69,6 +70,7 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
                     followerResponse.followerIndexName = metadata.followerContext.resource
                     followerResponse.leaderIndexName = metadata.leaderContext.resource
                     followerResponse.status = status
+                    followerResponse.reason = reason
                     populateAggregatedResponse(followerResponse)
                     if (!request.verbose) {
                         followerResponse.isVerbose = false

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/store/ReplicationMetadata.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/metadata/store/ReplicationMetadata.kt
@@ -69,6 +69,7 @@ class ReplicationMetadata: ToXContent {
     lateinit var connectionName: String
     lateinit var metadataType: String
     lateinit var overallState: String
+    lateinit var reason: String
     lateinit var followerContext: ReplicationContext
     lateinit var leaderContext: ReplicationContext
     lateinit var settings: Settings
@@ -77,12 +78,14 @@ class ReplicationMetadata: ToXContent {
     constructor(connectionName: String,
                 metadataType: String,
                 overallState: String,
+                reason: String,
                 followerContext: ReplicationContext,
                 leaderContext: ReplicationContext,
                 settings: Settings = Settings.EMPTY) {
         this.connectionName = connectionName
         this.metadataType = metadataType
         this.overallState = overallState
+        this.reason = reason
         this.followerContext = followerContext
         this.leaderContext = leaderContext
         this.settings = settings
@@ -97,6 +100,7 @@ class ReplicationMetadata: ToXContent {
             METADATA_PARSER.declareString(ReplicationMetadata::connectionName::set, ParseField( "connection_name"))
             METADATA_PARSER.declareString(ReplicationMetadata::metadataType::set, ParseField( "metadata_type"))
             METADATA_PARSER.declareString(ReplicationMetadata::overallState::set, ParseField( "overall_state"))
+            METADATA_PARSER.declareString(ReplicationMetadata::reason::set, ParseField( "reason"))
             METADATA_PARSER.declareObject(BiConsumer { metadata: ReplicationMetadata, context: ReplicationContext -> metadata.followerContext = context},
                     ReplicationContext.REPLICATION_CONTEXT_PARSER, ParseField("follower_context"))
             METADATA_PARSER.declareObject(BiConsumer { metadata: ReplicationMetadata, context: ReplicationContext -> metadata.leaderContext = context},
@@ -116,6 +120,7 @@ class ReplicationMetadata: ToXContent {
         builder.field("connection_name", connectionName)
         builder.field("metadata_type", metadataType)
         builder.field("overall_state", overallState)
+        builder.field("reason", reason)
 
         builder.field("follower_context")
         builder.startObject()
@@ -142,7 +147,7 @@ class ReplicationMetadata: ToXContent {
 
     override fun toString(): String {
         return "ReplicationMetadata - [connection_name: $connectionName, metadata_type: $metadataType, " +
-                "overall_state: $overallState, follower_context: ${followerContext.resource}, leader_context: ${leaderContext.resource}, " +
+                "overall_state: $overallState, reason: $reason, follower_context: ${followerContext.resource}, leader_context: ${leaderContext.resource}, " +
                 " settings: ${settings} ]"
     }
 }

--- a/src/main/resources/mappings/replication-metadata-store.json
+++ b/src/main/resources/mappings/replication-metadata-store.json
@@ -31,6 +31,15 @@
         }
       }
     },
+    "reason": {
+      "type" : "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 1024
+        }
+      }
+    },
     "follower_context": {
       "type": "nested",
       "properties": {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -47,6 +47,8 @@ const val REST_REPLICATION_STATUS_VERBOSE = "$REST_REPLICATION_PREFIX{index}/_st
 const val REST_REPLICATION_STATUS = "$REST_REPLICATION_PREFIX{index}/_status"
 const val REST_AUTO_FOLLOW_PATTERN = "${REST_REPLICATION_PREFIX}_autofollow"
 
+const val STATUS_REASON_USER_INITIATED = "User initiated"
+
 fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
                                          waitFor: TimeValue = TimeValue.timeValueSeconds(10),
                                          waitForShardsInit: Boolean = true,
@@ -82,6 +84,7 @@ fun RestHighLevelClient.replicationStatus(index: String,verbose: Boolean = true)
 
 fun `validate status syncing resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"SYNCING")
+    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("syncing_task_details"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("remote_checkpoint"))
@@ -89,12 +92,14 @@ fun `validate status syncing resposne`(statusResp: Map<String, Any>) {
 
 fun `validate status syncing aggregated resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"SYNCING")
+    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("remote_checkpoint"))
 }
 
 fun `validate not paused status resposne`(statusResp: Map<String, Any>) {
     Assert.assertNotEquals(statusResp.getValue("status"),"PAUSED")
+    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("syncing_task_details"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("remote_checkpoint"))
@@ -102,12 +107,14 @@ fun `validate not paused status resposne`(statusResp: Map<String, Any>) {
 
 fun `validate not paused status aggregated resposne`(statusResp: Map<String, Any>) {
     Assert.assertNotEquals(statusResp.getValue("status"),"PAUSED")
+    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("remote_checkpoint"))
 }
 
 fun `validate paused status resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
+    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("syncing_task_details"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("remote_checkpoint"))
@@ -115,6 +122,7 @@ fun `validate paused status resposne`(statusResp: Map<String, Any>) {
 
 fun `validate aggregated paused status resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
+    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("remote_checkpoint"))
 }

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/task/shard/TranslogSequencerTests.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/task/shard/TranslogSequencerTests.kt
@@ -70,7 +70,7 @@ class TranslogSequencerTests : ESTestCase() {
     val remoteCluster = "remoteCluster"
     val remoteIndex = "remoteIndex"
     val followerShardId = ShardId("follower", "follower_uuid", 0)
-    val replicationMetadata = ReplicationMetadata(remoteCluster, ReplicationStoreMetadataType.INDEX.name, ReplicationOverallState.RUNNING.name,
+    val replicationMetadata = ReplicationMetadata(remoteCluster, ReplicationStoreMetadataType.INDEX.name, ReplicationOverallState.RUNNING.name, "test user",
             ReplicationContext(followerShardId.indexName, null), ReplicationContext(remoteIndex, null))
     val client = RequestCapturingClient()
     init {


### PR DESCRIPTION
### Description
Captured reason for API invocation and added to the replication metadata store
 
### Issues Resolved
N/A

### Testing
```
./gradlew clean release 
```
```
Tested status API locally

curl -X GET -k "localhost:9201/_plugins/_replication/remote-index-1/_status?pretty" -H 'Content-Type: application/json' -d '{}'
{
  "status" : "PAUSED",
  "reason" : "User initiated",
  "remote_cluster" : "remote-cluster",
  "leader_index" : "remote-index",
  "follower_index" : "remote-index-1",
  "syncing_details" : {
    "remote_checkpoint" : -1,
    "local_checkpoint" : -1,
    "seq_no" : 0
  }
}
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
