### PR TITLE
Bug fixes and Improved autofollow task failure handling

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
@@ -156,6 +156,10 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_PARALLEL_READ_POLL_DURATION = Setting.timeSetting ("plugins.replication.parallel_reads_poll_duration", TimeValue.timeValueMillis(50), TimeValue.timeValueMillis(1),
             TimeValue.timeValueSeconds(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
+        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION = Setting.timeSetting ("plugins.replication.autofollow.remote.fetch_poll_duration", TimeValue.timeValueSeconds(60), TimeValue.timeValueSeconds(30),
+                TimeValue.timeValueHours(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
+        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION = Setting.timeSetting ("plugins.replication.autofollow.remote.retry_poll_duration", TimeValue.timeValueHours(1), TimeValue.timeValueMinutes(30),
+                TimeValue.timeValueHours(4), Setting.Property.Dynamic, Setting.Property.NodeScope)
     }
 
     override fun createComponents(client: Client, clusterService: ClusterService, threadPool: ThreadPool,
@@ -248,8 +252,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
         : List<PersistentTasksExecutor<*>> {
         return listOf(
             ShardReplicationExecutor(REPLICATION_EXECUTOR_NAME_FOLLOWER, clusterService, threadPool, client, replicationMetadataManager, replicationSettings),
-            IndexReplicationExecutor(REPLICATION_EXECUTOR_NAME_FOLLOWER, clusterService, threadPool, client, replicationMetadataManager),
-            AutoFollowExecutor(REPLICATION_EXECUTOR_NAME_FOLLOWER, clusterService, threadPool, client, replicationMetadataManager))
+            IndexReplicationExecutor(REPLICATION_EXECUTOR_NAME_FOLLOWER, clusterService, threadPool, client, replicationMetadataManager, replicationSettings),
+            AutoFollowExecutor(REPLICATION_EXECUTOR_NAME_FOLLOWER, clusterService, threadPool, client, replicationMetadataManager, replicationSettings))
     }
 
     override fun getNamedWriteables(): List<NamedWriteableRegistry.Entry> {
@@ -303,7 +307,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
         return listOf(REPLICATED_INDEX_SETTING, REPLICATION_CHANGE_BATCH_SIZE, REPLICATION_LEADER_THREADPOOL_SIZE,
                 REPLICATION_LEADER_THREADPOOL_QUEUE_SIZE, REPLICATION_PARALLEL_READ_PER_SHARD,
                 REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE, REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS,
-                REPLICATION_PARALLEL_READ_POLL_DURATION)
+                REPLICATION_PARALLEL_READ_POLL_DURATION, REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION,
+                REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION)
     }
 
     override fun getInternalRepositories(env: Environment, namedXContentRegistry: NamedXContentRegistry,

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
@@ -12,6 +12,8 @@ class ReplicationSettings(clusterService: ClusterService) {
     @Volatile var readersPerShard = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_PARALLEL_READ_PER_SHARD)
     @Volatile var batchSize = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_CHANGE_BATCH_SIZE)
     @Volatile var pollDuration: TimeValue = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_PARALLEL_READ_POLL_DURATION)
+    @Volatile var autofollowFetchPollDuration = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION)
+    @Volatile var autofollowRetryPollDuration = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION)
 
     init {
         listenForUpdates(clusterService.clusterSettings)
@@ -23,6 +25,7 @@ class ReplicationSettings(clusterService: ClusterService) {
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_PARALLEL_READ_PER_SHARD) { value: Int -> this.readersPerShard = value}
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_CHANGE_BATCH_SIZE) { batchSize = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_PARALLEL_READ_POLL_DURATION) { pollDuration = it }
-
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION) { autofollowFetchPollDuration = it }
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION) { autofollowRetryPollDuration = it }
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/CrossClusterReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/CrossClusterReplicationTask.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.elasticsearch.replication.task
 
+import com.amazon.elasticsearch.replication.ReplicationSettings
 import com.amazon.elasticsearch.replication.metadata.ReplicationMetadataManager
 import com.amazon.elasticsearch.replication.metadata.store.ReplicationMetadata
 import com.amazon.elasticsearch.replication.metadata.store.ReplicationStoreMetadataType
@@ -53,7 +54,8 @@ abstract class CrossClusterReplicationTask(id: Long, type: String, action: Strin
                                            protected val clusterService: ClusterService,
                                            protected val threadPool: ThreadPool,
                                            protected val client: Client,
-                                           protected val replicationMetadataManager: ReplicationMetadataManager) :
+                                           protected val replicationMetadataManager: ReplicationMetadataManager,
+                                           protected val replicationSettings: ReplicationSettings) :
     AllocatedPersistentTask(id, type, action, description, parentTask, headers) {
 
     protected val scope = CoroutineScope(threadPool.coroutineContext(executor))

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowExecutor.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowExecutor.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.elasticsearch.replication.task.autofollow
 
+import com.amazon.elasticsearch.replication.ReplicationSettings
 import com.amazon.elasticsearch.replication.metadata.ReplicationMetadataManager
 import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.service.ClusterService
@@ -27,7 +28,8 @@ import org.elasticsearch.threadpool.ThreadPool
 
 class AutoFollowExecutor(executor: String, private val clusterService: ClusterService,
                          private val threadPool: ThreadPool, private val client: Client,
-                         private val replicationMetadataManager: ReplicationMetadataManager) :
+                         private val replicationMetadataManager: ReplicationMetadataManager,
+                         private val replicationSettings: ReplicationSettings) :
     PersistentTasksExecutor<AutoFollowParams>(TASK_NAME, executor) {
 
     companion object {
@@ -45,8 +47,9 @@ class AutoFollowExecutor(executor: String, private val clusterService: ClusterSe
     override fun createTask(id: Long, type: String, action: String, parentTaskId: TaskId,
                             taskInProgress: PersistentTask<AutoFollowParams>,
                             headers: Map<String, String>): AllocatedPersistentTask {
-        return AutoFollowTask(id, type, action, getDescription(taskInProgress), parentTaskId, headers,
-                              executor, clusterService, threadPool, client, replicationMetadataManager, taskInProgress.params!!)
+        return AutoFollowTask(id, type, action, getDescription(taskInProgress),
+                parentTaskId, headers, executor, clusterService, threadPool, client,
+                replicationMetadataManager, taskInProgress.params!!, replicationSettings)
     }
 
     override fun getDescription(taskInProgress: PersistentTask<AutoFollowParams>): String {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationExecutor.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationExecutor.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.elasticsearch.replication.task.index
 
+import com.amazon.elasticsearch.replication.ReplicationSettings
 import com.amazon.elasticsearch.replication.metadata.ReplicationMetadataManager
 import com.amazon.elasticsearch.replication.metadata.ReplicationOverallState
 import com.amazon.elasticsearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_STATE
@@ -33,7 +34,8 @@ import org.elasticsearch.threadpool.ThreadPool
 
 class IndexReplicationExecutor(executor: String, private val clusterService: ClusterService,
                                private val threadPool: ThreadPool, private val client: Client,
-                               private val replicationMetadataManager: ReplicationMetadataManager)
+                               private val replicationMetadataManager: ReplicationMetadataManager,
+                               private val replicationSettings: ReplicationSettings)
     : PersistentTasksExecutor<IndexReplicationParams>(TASK_NAME, executor) {
 
     companion object {
@@ -66,7 +68,7 @@ class IndexReplicationExecutor(executor: String, private val clusterService: Clu
                             headers: MutableMap<String, String>?): AllocatedPersistentTask {
         return IndexReplicationTask(id, type, action, getDescription(taskInProgress), parentTaskId,
                                     executor, clusterService, threadPool, client, requireNotNull(taskInProgress.params),
-                                    persistentTasksService, replicationMetadataManager)
+                                    persistentTasksService, replicationMetadataManager, replicationSettings)
     }
 
     override fun getDescription(taskInProgress: PersistentTask<IndexReplicationParams>): String {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
@@ -17,6 +17,7 @@ package com.amazon.elasticsearch.replication.task.index
 
 import com.amazon.elasticsearch.replication.ReplicationException
 import com.amazon.elasticsearch.replication.ReplicationPlugin.Companion.REPLICATED_INDEX_SETTING
+import com.amazon.elasticsearch.replication.ReplicationSettings
 import com.amazon.elasticsearch.replication.action.index.block.IndexBlockUpdateType
 import com.amazon.elasticsearch.replication.action.index.block.UpdateIndexBlockAction
 import com.amazon.elasticsearch.replication.action.index.block.UpdateIndexBlockRequest
@@ -89,9 +90,10 @@ class IndexReplicationTask(id: Long, type: String, action: String, description: 
                            client: Client,
                            params: IndexReplicationParams,
                            private val persistentTasksService: PersistentTasksService,
-                           replicationMetadataManager: ReplicationMetadataManager)
+                           replicationMetadataManager: ReplicationMetadataManager,
+                           replicationSettings: ReplicationSettings)
     : CrossClusterReplicationTask(id, type, action, description, parentTask, emptyMap(), executor,
-                                  clusterService, threadPool, client, replicationMetadataManager), ClusterStateListener {
+                                  clusterService, threadPool, client, replicationMetadataManager, replicationSettings), ClusterStateListener {
     private lateinit var currentTaskState : IndexReplicationState
     private lateinit var followingTaskState : IndexReplicationState
 

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
@@ -60,9 +60,9 @@ import org.elasticsearch.transport.NodeNotConnectedException
 class ShardReplicationTask(id: Long, type: String, action: String, description: String, parentTask: TaskId,
                            params: ShardReplicationParams, executor: String, clusterService: ClusterService,
                            threadPool: ThreadPool, client: Client, replicationMetadataManager: ReplicationMetadataManager,
-                           private val replicationSettings: ReplicationSettings)
+                           replicationSettings: ReplicationSettings)
     : CrossClusterReplicationTask(id, type, action, description, parentTask, emptyMap(),
-                                  executor, clusterService, threadPool, client, replicationMetadataManager) {
+                                  executor, clusterService, threadPool, client, replicationMetadataManager, replicationSettings) {
 
     override val remoteCluster: String = params.remoteCluster
     override val followerIndexName: String = params.followerShardId.indexName

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/Extensions.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/Extensions.kt
@@ -186,11 +186,11 @@ fun User.overrideFgacRole(fgacRole: String?): User? {
 }
 
 fun User.toInjectedUser(): String? {
-    return "${name}|${backendRoles.joinToString(separator=",")}"
+    return "${SecurityContext.REPLICATION_PLUGIN_USER}|${backendRoles.joinToString(separator=",")}"
 }
 
 fun User.toInjectedRoles(): String? {
-    return "${name}|${roles.joinToString(separator=",")}"
+    return "${SecurityContext.REPLICATION_PLUGIN_USER}|${roles.joinToString(separator=",")}"
 }
 
 fun Exception.stackTraceToString(): String {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/SecurityContext.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/SecurityContext.kt
@@ -43,8 +43,9 @@ class SecurityContext {
         private val log = LogManager.getLogger(SecurityContext::class.java)
         const val OPENDISTRO_SECURITY_USER = "_opendistro_security_user"
         const val OPENDISTRO_SECURITY_ASSUME_ROLES = "opendistro_security_assume_roles"
+        const val REPLICATION_PLUGIN_USER = "ccr_user"
 
-        val ADMIN_USER = User("ccr_user", null, listOf("all_access"), null)
+        val ADMIN_USER = User(REPLICATION_PLUGIN_USER, null, listOf("all_access"), null)
 
         val ALL_TRANSIENTS = listOf(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_ROLES,
                 ConfigConstants.INJECTED_USER, OPENDISTRO_SECURITY_USER)

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -218,4 +218,3 @@ fun RestHighLevelClient.deleteAutoFollowPattern(connection: String, patternName:
     assertThat(response.isAcknowledged).isTrue()
 }
 
-


### PR DESCRIPTION
Bug fixes and autofollow task resiliency
 - Improved autofollow task failure handling
 - Exposed dynamic setting to poll from remote cluster
 - Tracked failed indices and to prevent log flood based on tracking indices
 - Exposed setting to trigger retry on failed indices for autofollow after configured  time
 - Forced ccr_user as replication user for the actions

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
