### PR TITLE
Validate analyzer path when starting/resuming replication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,8 @@ integTest {
             systemProperty "tests.cluster.${cluster.name}.transport_hosts", "${-> cluster.allTransportPortURI.join(',')}"
         }
     }
+    systemProperty "build.dir", "${buildDir}"
+    systemProperty "java.security.policy", "file://${projectDir}/src/test/resources/plugin-security.policy"
 }
 
 run {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
@@ -142,8 +142,7 @@ class IndexReplicationTask(id: Long, type: String, action: String, description: 
                 IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
                 EnableAllocationDecider.INDEX_ROUTING_REBALANCE_ENABLE_SETTING,
                 EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING,
-                IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING,
-                Setting.groupSetting("index.analysis.", Setting.Property.IndexScope)
+                IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING
         )
 
         val blockListedSettings :Set<String> = blSettings.stream().map { k -> k.key }.collect(Collectors.toSet())
@@ -700,6 +699,8 @@ class IndexReplicationTask(id: Long, type: String, action: String, description: 
             restoreRequest.renamePattern(remoteIndex.name)
                 .renameReplacement(followerIndexName)
         }
+        val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(this.followerIndexName)
+        restoreRequest.indexSettings(replMetadata.settings)
 
         val response = client.suspending(client.admin().cluster()::restoreSnapshot, defaultContext = true)(restoreRequest)
         if (response.restoreInfo != null) {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/ValidationUtil.kt
@@ -1,0 +1,26 @@
+package com.amazon.elasticsearch.replication.util
+
+import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ResourceNotFoundException
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.env.Environment
+import java.nio.file.Files
+import java.nio.file.Path
+
+object ValidationUtil {
+
+    private val log = LogManager.getLogger(ValidationUtil::class.java)
+
+    fun validateAnalyzerSettings(environment: Environment, leaderSettings: Settings, overriddenSettings: Settings) {
+        val analyserSettings = leaderSettings.filter { k: String? -> k!!.matches(Regex("index.analysis.*path")) }
+        for (analyserSetting in analyserSettings.keySet()) {
+            val settingValue = if (overriddenSettings.hasValue(analyserSetting)) overriddenSettings.get(analyserSetting) else analyserSettings.get(analyserSetting)
+            val path: Path = environment.configFile().resolve(settingValue)
+            if (!Files.exists(path)) {
+                val message = "IOException while reading ${analyserSetting}: ${path.toString()}"
+                log.error(message)
+                throw ResourceNotFoundException(message)
+            }
+        }
+    }
+}

--- a/src/test/resources/analyzers/synonym_setting.json
+++ b/src/test/resources/analyzers/synonym_setting.json
@@ -1,0 +1,18 @@
+{
+    "index":{
+        "analysis":{
+            "analyzer":{
+                "my_analyzer":{
+                    "tokenizer":"standard",
+                    "filter":[ "my_filter" ]
+                }
+            },
+            "filter":{
+                "my_filter":{
+                    "type":"synonym",
+                    "synonyms_path":"synonyms.txt"
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/analyzers/synonyms.txt
+++ b/src/test/resources/analyzers/synonyms.txt
@@ -1,0 +1,4 @@
+danish, croissant, pastry
+ice cream, gelato, frozen custard
+sneaker, tennis shoe, running shoe
+basketball shoe, hightop

--- a/src/test/resources/plugin-security.policy
+++ b/src/test/resources/plugin-security.policy
@@ -1,0 +1,3 @@
+grant {
+  permission java.io.FilePermission "${build.dir}/-", "read,write,delete";
+};


### PR DESCRIPTION
Signed-off-by: Sooraj Sinha <soosinha@amazon.com>

### Description
If a custom analyzer is present in the leader index, then the replication would silently fail if the same analyzer is not present in the follower cluster as well.
So this change validates the presence of analyzer on the follower cluster before starting or resuming the replication. If the analyzer is not present, the we will fail the replication upfront.
Also, the user input settings in the replication request are now set to the restore request so that the follower index is created with the bootstrapped settings.

### Testing
Normal IT are passing.
Manual testing as below:

- Start the replication for an index which has analyzer on the leader index but the analyzer file is not present on follower
```
{{LOCAL_FOLLOWER}}/_plugins/_replication/{{FOLLOWER_INDEX}}/_start?pretty
{
    "remote_cluster":"remote-cluster-1",
    "remote_index": "{{LEADER_INDEX}}"
}

{
    "error": {
        "root_cause": [
            {
                "type": "resource_not_found_exception",
                "reason": "IOException while reading index.analysis.filter.my_filter.synonyms_path: /Volumes/workplace/replication_oss/cross-cluster-replication/build/testclusters/followCluster-0/config/analysis/synonyms.txt"
            }
        ],
        "type": "resource_not_found_exception",
        "reason": "IOException while reading index.analysis.filter.my_filter.synonyms_path: /Volumes/workplace/replication_oss/cross-cluster-replication/build/testclusters/followCluster-0/config/analysis/synonyms.txt"
    },
    "status": 404
}
```
- Copied the analyzer file to the follower cluster and started the replication again.
```
{
    "acknowledged": true
}
```

- Resume the replication for an index where the analyzer has been added at the leader
```
{{LOCAL_FOLLOWER}}/_plugins/_replication/{{FOLLOWER_INDEX}}/_resume?pretty
{
    "error": {
        "root_cause": [
            {
                "type": "resource_not_found_exception",
                "reason": "IOException while reading index.analysis.filter.my_filter.synonyms_path: /Volumes/workplace/replication_oss/cross-cluster-replication/build/testclusters/followCluster-0/config/analysis/synonyms.txt"
            }
        ],
        "type": "resource_not_found_exception",
        "reason": "IOException while reading index.analysis.filter.my_filter.synonyms_path: /Volumes/workplace/replication_oss/cross-cluster-replication/build/testclusters/followCluster-0/config/analysis/synonyms.txt"
    },
    "status": 404
}
```
- Resume the replication after copying the analyzer to the follower
```
{
    "acknowledged": true
}
```

- Exception occurs in autofollow if the analyzer is not found
```
[2021-07-21T12:30:27,015][WARN ][c.a.e.r.t.a.AutoFollowTask] [followCluster-0][remote-cluster-1] Failed to start replication for remote-cluster-1:af2 -> af2.
org.elasticsearch.ResourceNotFoundException: IOException while reading index.analysis.filter.my_filter.synonyms_path: /Volumes/workplace/replication_oss/cross-cluster-replication/build/testclusters/followCluster-0/config/analysis/synonyms1.txt
        at com.amazon.elasticsearch.replication.action.index.TransportReplicateIndexAction.validateAnalyzerSettings(TransportReplicateIndexAction.kt:108) ~[?:?]
        at com.amazon.elasticsearch.replication.action.index.TransportReplicateIndexAction.access$validateAnalyzerSettings(TransportReplicateIndexAction.kt:44) ~[?:?]
        at com.amazon.elasticsearch.replication.action.index.TransportReplicateIndexAction$doExecute$1.invokeSuspend(TransportReplicateIndexAction.kt:72) ~[?:?]
```

- For user override settings, created index with `synonyms.txt` on leader then placed `synonyms1.txt` and follower. Then while starting the replication, overrode the setting with `synonyms1.txt` and the replication was successful

```
{
    "remote_cluster":"remote-cluster-1",
    "remote_index": "{{LEADER_INDEX}}",
    "settings": {
        "index":{
            "analysis": {
                "filter":{
                    "my_filter":{
                        "synonyms_path":"synonyms1.txt"
                    }
                }
            }
        }
    }
}
{
    "acknowledged": true
}
```

### Issues Resolved
#63 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
