### PR TITLE
Handling disallowed index settings

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
@@ -15,6 +15,9 @@ class ReplicationSettings(clusterService: ClusterService) {
     @Volatile var autofollowFetchPollDuration = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION)
     @Volatile var autofollowRetryPollDuration = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION)
     @Volatile var metadataSyncInterval = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL)
+    @Volatile var disallowedKeys: List<String> = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_DISALLOWED_KEYS)
+    @Volatile var disallowedValues: List<String> = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_DISALLOWED_VALUES)
+
     init {
         listenForUpdates(clusterService.clusterSettings)
     }
@@ -28,5 +31,7 @@ class ReplicationSettings(clusterService: ClusterService) {
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_DURATION) { autofollowFetchPollDuration = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_DURATION) { autofollowRetryPollDuration = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL) { metadataSyncInterval = it }
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_DISALLOWED_KEYS) { disallowedKeys = it }
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_DISALLOWED_VALUES) { disallowedValues = it }
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexMasterNodeAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexMasterNodeAction.kt
@@ -95,7 +95,7 @@ class TransportReplicateIndexMasterNodeAction @Inject constructor(transportServi
 
                 if (state.routingTable.hasIndex(replicateIndexReq.followerIndex)) {
                     throw IllegalArgumentException("Cant use same index again for replication. " +
-                    "Delete the index:${replicateIndexReq.followerIndex}")
+                            "Delete the index:${replicateIndexReq.followerIndex}")
                 }
 
                 indexScopedSettings.validate(replicateIndexReq.settings,

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/DisallowedState.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/DisallowedState.kt
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.elasticsearch.replication.util
+
+import com.amazon.elasticsearch.replication.ReplicationSettings
+import org.elasticsearch.common.settings.Settings
+import java.util.Locale
+import kotlin.math.max
+
+public fun getDisallowedSettings(leaderSettings: Settings, replicationSettings: ReplicationSettings): List<Pair<String, String>> {
+    val disallowedSettings = mutableListOf<Pair<String, String>>()
+
+    val maxLen = max(replicationSettings.disallowedKeys.size, replicationSettings.disallowedValues.size)
+    val disallowedKeys = fillToLength(replicationSettings.disallowedKeys, maxLen)
+    val disallowedValues = fillToLength(replicationSettings.disallowedValues, maxLen)
+    for (i in 0 until maxLen) {
+        val key = disallowedKeys[i]
+        val value = disallowedValues[i]
+        val fetchedValue = leaderSettings.get(key) ?: continue
+        if (fetchedValue.toLowerCase(Locale.ROOT) == value.toLowerCase(Locale.ROOT)) {
+            disallowedSettings.add(Pair(key, value))
+        }
+    }
+    return disallowedSettings
+}
+
+private fun fillToLength(list: List<String>, len: Int): List<String> {
+    val newList = list.toMutableList()
+    if (list.size < len) {
+        for (i in 0 until len - list.size) {
+            newList += list.last()
+        }
+    }
+    return newList
+}


### PR DESCRIPTION
### Description
This change allows the plugin to not start replication for indices which have a particular setting. 
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
