### PR TITLE
Prevent starting replication directly on the leader index alias.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
@@ -134,7 +134,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                 // After marking FailedState, IndexReplicationTask will action on it by pausing or stopping all shard
                 // replication tasks. This ShardReplicationTask should also thus receive the pause/stop via
                 // cancellation. We thus wait for waitMillis duration.
-                val waitMillis = Duration.ofMinutes(1).toMillis()
+                val waitMillis = Duration.ofMinutes(10).toMillis()
                 logInfo("Waiting $waitMillis millis for IndexReplicationTask to respond to failure of shard task")
                 delay(waitMillis)
 


### PR DESCRIPTION
Prevent starting replication directly on the leader index alias.

(This was previously resulting in NPE)

The rationale is to avoid complexity for now since an alias can be
associated with multiple indices, although an extension could be to
allow replication if there is a single match.

Added an integration test to validate the case.

While at it, also expanded BasicReplicationIT to incorporate force merge
and ensure that doesn't impact replication.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
