### PR TITLE
change to stop showing replication related metrics in case of non running (syncing and bootstrap) state.

### DIFF
--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -125,16 +125,13 @@ fun `validate not paused status aggregated resposne`(statusResp: Map<String, Any
 fun `validate paused status resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
     Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
-    Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("syncing_task_details"))
-    Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("local_checkpoint"))
-    Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("remote_checkpoint"))
+    Assert.assertTrue(!(statusResp.containsKey("shard_replication_details")))
 }
 
 fun `validate aggregated paused status resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
     Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
-    Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("local_checkpoint"))
-    Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("remote_checkpoint"))
+    Assert.assertTrue(!(statusResp.containsKey("syncing_details")))
 }
 
 fun RestHighLevelClient.stopReplication(index: String, shouldWait: Boolean = true) {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/PauseReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/PauseReplicationIT.kt
@@ -160,7 +160,6 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
     fun `test pause replication and stop replication`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)


### PR DESCRIPTION
Signed-off-by: naveen pajjuri <nppajjur@amazon.com>

### Description
Stopped calling leader index in case of replication in non running (syncing and bootstrap) state 


 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
