### PR TITLE
Integ test : Stop replication when remote cluster is unreachable

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -144,7 +144,7 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
         shards.forEach {
             val followerShardId = it.value.shardId
             log.debug("Removing lease for $followerShardId.id ")
-            retentionLeaseHelper.removeRetentionLease(ShardId(params.remoteIndex, followerShardId.id), followerShardId)
+            retentionLeaseHelper.attemptRetentionLeaseRemoval(ShardId(params.remoteIndex, followerShardId.id), followerShardId)
         }
 
         return false

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -147,7 +147,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
             shards.forEach {
                 val followerShardId = it.value.shardId
                 log.debug("Removing lease for $followerShardId.id ")
-                retentionLeaseHelper.removeRetentionLease(ShardId(params.remoteIndex, followerShardId.id), followerShardId)
+                retentionLeaseHelper.attemptRetentionLeaseRemoval(ShardId(params.remoteIndex, followerShardId.id), followerShardId)
             }
         } catch (e: Exception) {
             log.error("Exception while trying to remove Retention Lease ", e )

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
@@ -669,7 +669,7 @@ class IndexReplicationTask(id: Long, type: String, action: String, description: 
         val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName)?.shards()
         shards?.forEach {
             val followerShardId = it.value.shardId
-            retentionLeaseHelper.removeRetentionLease(ShardId(remoteIndex, followerShardId.id), followerShardId)
+            retentionLeaseHelper.attemptRetentionLeaseRemoval(ShardId(remoteIndex, followerShardId.id), followerShardId)
         }
 
         /* As given here

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
@@ -166,7 +166,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
             logDebug("Pausing and not removing lease for index $followerIndexName and shard $followerShardId task")
             return
         }
-        retentionLeaseHelper.removeRetentionLease(remoteShardId, followerShardId)
+        retentionLeaseHelper.attemptRetentionLeaseRemoval(remoteShardId, followerShardId)
     }
 
     private fun addListenerToInterruptTask() {


### PR DESCRIPTION
Signed-off-by: Sooraj Sinha <soosinha@amazon.com>

### Description
Stop replication should work even when remote cluster is unavailable. Currently, stop replication errors out if remote cluster is unavailable because remove retention lease method throws an exception.
This change catches the error error thrown by remove retention lease method so the stop replication API can go through. Also, added an integ test to verify the same
 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
