### PR TITLE
Adding `reason` while serializing PauseReplication Request

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationRequest.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationRequest.kt
@@ -20,10 +20,13 @@ import org.elasticsearch.action.ActionRequestValidationException
 import org.elasticsearch.action.IndicesRequest
 import org.elasticsearch.action.support.IndicesOptions
 import org.elasticsearch.action.support.master.AcknowledgedRequest
-import org.elasticsearch.common.ParseField
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.StreamOutput
-import org.elasticsearch.common.xcontent.*
+import org.elasticsearch.common.xcontent.ObjectParser
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.ToXContentObject
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
 
 class PauseIndexReplicationRequest : AcknowledgedRequest<PauseIndexReplicationRequest>, IndicesRequest.Replaceable, ToXContentObject {
 
@@ -40,6 +43,7 @@ class PauseIndexReplicationRequest : AcknowledgedRequest<PauseIndexReplicationRe
 
     constructor(inp: StreamInput): super(inp) {
         indexName = inp.readString()
+        reason = inp.readString()
     }
 
     companion object {
@@ -80,6 +84,7 @@ class PauseIndexReplicationRequest : AcknowledgedRequest<PauseIndexReplicationRe
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
         out.writeString(indexName)
+        out.writeString(reason)
     }
 
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
@@ -88,7 +88,7 @@ class TransportUpdateIndexReplicationAction @Inject constructor(transportService
                 ?:
                 throw IllegalArgumentException("No replication in progress for index:${request.indexName}")
         val replicationOverallState = replicationStateParams[REPLICATION_LAST_KNOWN_OVERALL_STATE]
-        if (replicationOverallState == ReplicationOverallState.RUNNING.name)
+        if (replicationOverallState == ReplicationOverallState.RUNNING.name || replicationOverallState == ReplicationOverallState.PAUSED.name)
             return
 
         throw IllegalStateException("Unknown value of replication state:$replicationOverallState")

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
@@ -406,7 +406,6 @@ class IndexReplicationTask(id: Long, type: String, action: String, description: 
                         //Not intended setting on follower side.
                         val setting = indexScopedSettings[key]
                         if (indexScopedSettings.isPrivateSetting(key)) {
-                            log.info("$key is a private setting")
                             continue
                         }
                         if (!setting.isDynamic()) {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -125,7 +125,9 @@ fun `validate not paused status aggregated resposne`(statusResp: Map<String, Any
 fun `validate paused status resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
     Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
-    Assert.assertTrue(!(statusResp.containsKey("shard_replication_details")))
+    Assert.assertFalse(statusResp.containsKey("shard_replication_details"))
+    Assert.assertFalse(statusResp.containsKey("local_checkpoint"))
+    Assert.assertFalse(statusResp.containsKey("remote_checkpoint"))
 }
 
 fun `validate aggregated paused status resposne`(statusResp: Map<String, Any>) {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/ResumeReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/ResumeReplicationIT.kt
@@ -15,7 +15,20 @@
 
 package com.amazon.elasticsearch.replication.integ.rest
 
-import com.amazon.elasticsearch.replication.*
+import com.amazon.elasticsearch.replication.MultiClusterAnnotations
+import com.amazon.elasticsearch.replication.MultiClusterRestTestCase
+import com.amazon.elasticsearch.replication.StartReplicationRequest
+import com.amazon.elasticsearch.replication.`validate aggregated paused status resposne`
+import com.amazon.elasticsearch.replication.`validate not paused status aggregated resposne`
+import com.amazon.elasticsearch.replication.`validate not paused status resposne`
+import com.amazon.elasticsearch.replication.`validate paused status resposne`
+import com.amazon.elasticsearch.replication.`validate status syncing aggregated resposne`
+import com.amazon.elasticsearch.replication.`validate status syncing resposne`
+import com.amazon.elasticsearch.replication.pauseReplication
+import com.amazon.elasticsearch.replication.replicationStatus
+import com.amazon.elasticsearch.replication.resumeReplication
+import com.amazon.elasticsearch.replication.startReplication
+import com.amazon.elasticsearch.replication.stopReplication
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.elasticsearch.action.DocWriteResponse
@@ -27,10 +40,10 @@ import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.ResponseException
 import org.elasticsearch.client.indices.CloseIndexRequest
 import org.elasticsearch.client.indices.CreateIndexRequest
-import org.junit.Assert
 import org.elasticsearch.client.indices.GetMappingsRequest
 import org.elasticsearch.common.io.PathUtils
 import org.elasticsearch.common.settings.Settings
+import org.junit.Assert
 import java.nio.file.Files
 
 


### PR DESCRIPTION
Adding few Integ Tests

### Description
1. Adding `reason` while serializing PauseReplication Request
2. Making removal of retention lease in Stop Replication a best effort 
3. Integ test for _pause, _status API - should be successful even when remote cluster calls fails
4. Integ test for _update on paused index 
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
