### PR TITLE
Integ test: Verify that replication is paused when remote index is deleted

### DIFF
--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -54,6 +54,7 @@ const val REST_REPLICATION_STATUS = "$REST_REPLICATION_PREFIX{index}/_status"
 const val REST_AUTO_FOLLOW_PATTERN = "${REST_REPLICATION_PREFIX}_autofollow"
 
 const val STATUS_REASON_USER_INITIATED = "User initiated"
+const val STATUS_REASON_INDEX_NOT_FOUND = "no such index"
 
 fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
                                          waitFor: TimeValue = TimeValue.timeValueSeconds(10),
@@ -147,6 +148,11 @@ fun `validate aggregated paused status resposne`(statusResp: Map<String, Any>) {
     Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
     Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
     Assert.assertTrue(!(statusResp.containsKey("syncing_details")))
+}
+
+fun `validate paused status response due to leader index deleted`(statusResp: Map<String, Any>) {
+    Assert.assertEquals("PAUSED", statusResp.getValue("status"))
+    Assert.assertTrue(statusResp.getValue("reason").toString().contains(STATUS_REASON_INDEX_NOT_FOUND))
 }
 
 fun RestHighLevelClient.stopReplication(index: String, shouldWait: Boolean = true) {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
@@ -19,6 +19,9 @@ package com.amazon.elasticsearch.replication.integ.rest
 import com.amazon.elasticsearch.replication.MultiClusterAnnotations
 import com.amazon.elasticsearch.replication.MultiClusterRestTestCase
 import com.amazon.elasticsearch.replication.StartReplicationRequest
+import com.amazon.elasticsearch.replication.`validate paused status response due to leader index deleted`
+import com.amazon.elasticsearch.replication.`validate status syncing resposne`
+import com.amazon.elasticsearch.replication.replicationStatus
 import com.amazon.elasticsearch.replication.startReplication
 import com.amazon.elasticsearch.replication.stopReplication
 import com.amazon.elasticsearch.replication.updateReplication
@@ -723,6 +726,36 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 val sourceMap = mapOf("name" to randomAlphaOfLength(5))
                 followerClient.index(IndexRequest(followerIndexName).id("1").source(sourceMap), RequestOptions.DEFAULT)
             }.isInstanceOf(ElasticsearchStatusException::class.java).hasMessageContaining("cluster_block_exception")
+        } finally {
+            followerClient.stopReplication(followerIndexName)
+        }
+    }
+
+    fun `test that replication gets paused if the leader index is deleted`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+            assertBusy {
+                assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
+            }
+            assertBusy {
+                var statusResp = followerClient.replicationStatus(followerIndexName)
+                `validate status syncing resposne`(statusResp)
+            }
+            val deleteIndexResponse = leaderClient.indices().delete(DeleteIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+            assertThat(deleteIndexResponse.isAcknowledged).isTrue()
+
+            assertBusy({
+                var statusResp = followerClient.replicationStatus(followerIndexName)
+                `validate paused status response due to leader index deleted`(statusResp)
+            }, 15, TimeUnit.SECONDS)
         } finally {
             followerClient.stopReplication(followerIndexName)
         }


### PR DESCRIPTION
### Description
Adding integ test to check that replication gets paused if remote cluster is unavailable.
`IndexNotFoundException` is being excluded from retry logic as this is a permanent failure otherwise we would need to wait for 2-3 min(due to exponential backoff) for replication to get paused.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
