### PR TITLE
Integ test: forcemerge and snapshot on leader during bootstrap

### DIFF
--- a/src/test/kotlin/com/amazon/elasticsearch/replication/IndexUtil.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/IndexUtil.kt
@@ -1,0 +1,31 @@
+package com.amazon.elasticsearch.replication
+
+import org.apache.logging.log4j.LogManager
+import org.assertj.core.api.Assertions
+import org.elasticsearch.action.DocWriteResponse
+import org.elasticsearch.action.admin.indices.flush.FlushRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.client.RequestOptions
+import org.elasticsearch.client.RestHighLevelClient
+import org.elasticsearch.test.ESTestCase
+
+object IndexUtil {
+    private val log = LogManager.getLogger(IndexUtil::class.java)
+
+    fun fillIndex(clusterClient: RestHighLevelClient,
+                          indexName : String,
+                          nFields: Int,
+                          fieldLength: Int,
+                          stepSize: Int) {
+        for (i in nFields downTo 1 step stepSize) {
+            val sourceMap : MutableMap<String, String> = HashMap()
+            for (j in stepSize downTo 1)
+                sourceMap[(i-j).toString()] = ESTestCase.randomAlphaOfLength(fieldLength)
+            log.info("Updating index with map of size:${sourceMap.size}")
+            val indexResponse = clusterClient.index(IndexRequest(indexName).id(i.toString()).source(sourceMap), RequestOptions.DEFAULT)
+            Assertions.assertThat(indexResponse.result).isIn(DocWriteResponse.Result.CREATED, DocWriteResponse.Result.UPDATED)
+        }
+        //flush the index
+        clusterClient.indices().flush(FlushRequest(indexName), RequestOptions.DEFAULT)
+    }
+}


### PR DESCRIPTION
### Description
Add integ tests
- verify that replication is not affected if forcemerge API is called on leader during bootstrap
- verify that replication is not affected if snapshot is taken on leader during bootstrap
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
