### PR TITLE
Throw exception if replication is not enabled on the remote domain

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -60,7 +60,7 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                 }
                 val remoteClient = client.getRemoteClusterClient(request.remoteCluster)
                 val getSettingsRequest = GetSettingsRequest().includeDefaults(false).indices(request.remoteIndex)
-                val settingsResponse = remoteClient.suspending(remoteClient.admin().indices()::getSettings, injectSecurityContext = true)(getSettingsRequest)
+                val settingsResponse = remoteClient.suspending(remoteClient.admin().indices()::getSettings)(getSettingsRequest)
                 val leaderSettings = settingsResponse.indexToSettings.get(request.remoteIndex)
                 if (leaderSettings.keySet().contains(REPLICATED_INDEX_SETTING.key) and !leaderSettings.get(REPLICATED_INDEX_SETTING.key).isNullOrBlank()) {
                     throw IllegalArgumentException("Cannot Replicate a Replicated Index ${request.remoteIndex}")


### PR DESCRIPTION
### Description
If replication is installed on the remote domain, currently the start API fails with `ActionNotFoundTransportException`. This CR is to surface an explicit message to say that the remote does not have replication enabled

### Testing

Tested it on a setup with remote cluster without replication artefacts.

```
{
    "error": {
        "root_cause": [
            {
                "type": "unsupported_operation_exception",
                "reason": "Replication is not enabled on the remote domain"
            }
        ],
        "type": "unsupported_operation_exception",
        "reason": "Replication is not enabled on the remote domain"
    },
    "status": 500
}
``` 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
