### PR TITLE
Validate that soft delete settings is enabled at leader

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -39,6 +39,7 @@ import org.elasticsearch.client.Client
 import org.elasticsearch.common.inject.Inject
 import org.elasticsearch.env.Environment
 import org.elasticsearch.index.IndexNotFoundException
+import org.elasticsearch.index.IndexSettings
 import org.elasticsearch.indices.InvalidIndexNameException
 import org.elasticsearch.tasks.Task
 import org.elasticsearch.threadpool.ThreadPool
@@ -91,6 +92,9 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                 if (leaderSettings.keySet().contains(ReplicationPlugin.REPLICATED_INDEX_SETTING.key) and
                         !leaderSettings.get(ReplicationPlugin.REPLICATED_INDEX_SETTING.key).isNullOrBlank()) {
                     throw IllegalArgumentException("Cannot Replicate a Replicated Index ${request.remoteIndex}")
+                }
+                if (!leaderSettings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.key, true)) {
+                    throw IllegalArgumentException("Cannot Replicate an index where the setting ${IndexSettings.INDEX_SOFT_DELETES_SETTING.key} is disabled")
                 }
                 ValidationUtil.validateAnalyzerSettings(environment, leaderSettings, request.settings)
 


### PR DESCRIPTION
### Description
Replication should occur only when the setting `index.soft_deletes.enabled` is enabled for the leader index. It is enabled by default and can be set only at index creation. Documentation: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/index-modules.html
Adding validation to ensure that this setting is enabled for leader index before starting replication.

Tested by setting this to true while creating index. Got below exception:
```
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "Cannot Replicate an index where the setting index.soft_deletes.enabled is disabled"
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "Cannot Replicate an index where the setting index.soft_deletes.enabled is disabled"
    },
    "status": 400
}
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
