### PR TITLE
Add Handling of IndexReplicationTask cancellation and corresponding ITs

### DIFF
--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -17,7 +17,6 @@ package com.amazon.elasticsearch.replication
 
 import com.amazon.elasticsearch.replication.task.index.IndexReplicationExecutor
 import com.amazon.elasticsearch.replication.task.shard.ShardReplicationExecutor
-import org.apache.http.message.BasicHeader
 import org.assertj.core.api.Assertions.assertThat
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest
@@ -34,9 +33,8 @@ import org.elasticsearch.common.xcontent.XContentType
 import org.elasticsearch.test.ESTestCase.assertBusy
 import org.elasticsearch.test.rest.ESRestTestCase
 import org.junit.Assert
-import java.nio.charset.StandardCharsets
-import java.util.*
 import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
 
 data class AssumeRoles(val remoteClusterRole: String = "leader_role", val localClusterRole: String = "follower_role")
 
@@ -52,9 +50,12 @@ const val REST_REPLICATION_UPDATE = "$REST_REPLICATION_PREFIX{index}/_update"
 const val REST_REPLICATION_STATUS_VERBOSE = "$REST_REPLICATION_PREFIX{index}/_status?verbose=true"
 const val REST_REPLICATION_STATUS = "$REST_REPLICATION_PREFIX{index}/_status"
 const val REST_AUTO_FOLLOW_PATTERN = "${REST_REPLICATION_PREFIX}_autofollow"
-
+const val REST_REPLICATION_TASKS = "_tasks?actions=*replication*&detailed&pretty"
+const val INDEX_TASK_CANCELLATION_REASON = "Index replication task was cancelled by user"
 const val STATUS_REASON_USER_INITIATED = "User initiated"
+const val STATUS_REASON_SHARD_TASK_CANCELLED = "Shard task killed or cancelled."
 const val STATUS_REASON_INDEX_NOT_FOUND = "no such index"
+
 
 fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
                                          waitFor: TimeValue = TimeValue.timeValueSeconds(10),
@@ -106,53 +107,91 @@ fun RestHighLevelClient.replicationStatus(index: String,verbose: Boolean = true)
     return statusResponse
 }
 
-fun `validate status syncing resposne`(statusResp: Map<String, Any>) {
-    Assert.assertEquals(statusResp.getValue("status"),"SYNCING")
-    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
+fun RestHighLevelClient.getReplicationTasks(): Map<String, Map<String, String>>? {
+    var lowLevelStopRequest = Request("GET", REST_REPLICATION_TASKS)
+    lowLevelStopRequest.setJsonEntity("{}")
+    val lowLevelStatusResponse = lowLevelClient.performRequest(lowLevelStopRequest)
+    val tasks = ESRestTestCase.entityAsMap(lowLevelStatusResponse) as
+                    Map<String, Map<String, Map<String, String>>>
+    return tasks["nodes"]?.values?.stream()?.flatMap { node ->
+        (node["tasks"] as Map<String, Map<String, String>>).entries.stream()
+    }?.collect(Collectors.toMap({ t -> t.key}, { t -> t.value}))
+}
+
+fun RestHighLevelClient.getIndexReplicationTask(index: String): String {
+    val tasks = getReplicationTasks()?.entries?.stream()?.filter {
+            t -> (t.value["action"].equals("cluster:indices/admin/replication[c]")
+            && t.value["description"]?.contains(index) ?: false)
+    }?.map {e -> e.key}?.collect(Collectors.toList()) as List<String>
+    return if (tasks.isNotEmpty()) tasks[0] else ""
+}
+
+fun RestHighLevelClient.getShardReplicationTasks(index: String): List<String> {
+    return getReplicationTasks()?.entries?.stream()?.filter {
+            t -> (t.value["action"].equals("cluster:indices/shards/replication[c]")
+            && t.value["description"]?.contains(index) ?: false)
+    }?.map {e -> e.key}?.collect(Collectors.toList()) as List<String>
+}
+
+fun `validate status syncing response`(statusResp: Map<String, Any>) {
+    Assert.assertEquals("SYNCING", statusResp.getValue("status"))
+    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("syncing_task_details"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("remote_checkpoint"))
 }
 
-fun `validate status syncing aggregated resposne`(statusResp: Map<String, Any>) {
-    Assert.assertEquals(statusResp.getValue("status"),"SYNCING")
-    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
+fun `validate status syncing aggregated response`(statusResp: Map<String, Any>) {
+    Assert.assertEquals("SYNCING", statusResp.getValue("status"))
+    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("remote_checkpoint"))
 }
 
-fun `validate not paused status resposne`(statusResp: Map<String, Any>) {
+fun `validate not paused status response`(statusResp: Map<String, Any>) {
     Assert.assertNotEquals(statusResp.getValue("status"),"PAUSED")
-    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
+    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("syncing_task_details"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("shard_replication_details")).toString().contains("remote_checkpoint"))
 }
 
-fun `validate not paused status aggregated resposne`(statusResp: Map<String, Any>) {
-    Assert.assertNotEquals(statusResp.getValue("status"),"PAUSED")
-    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
+fun `validate not paused status aggregated response`(statusResp: Map<String, Any>) {
+    Assert.assertNotEquals("PAUSED", statusResp.getValue("status"))
+    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("local_checkpoint"))
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("remote_checkpoint"))
 }
 
-fun `validate paused status resposne`(statusResp: Map<String, Any>) {
-    Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
-    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
+fun `validate paused status response`(statusResp: Map<String, Any>) {
+    Assert.assertEquals("PAUSED", statusResp.getValue("status"))
+    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
     Assert.assertFalse(statusResp.containsKey("shard_replication_details"))
     Assert.assertFalse(statusResp.containsKey("local_checkpoint"))
     Assert.assertFalse(statusResp.containsKey("remote_checkpoint"))
 }
 
 fun `validate paused status on closed index`(statusResp: Map<String, Any>) {
-    Assert.assertEquals(statusResp.getValue("status"), "PAUSED")
+    Assert.assertEquals("PAUSED", statusResp.getValue("status"))
     assertThat(statusResp.getValue("reason").toString()).contains("org.elasticsearch.indices.IndexClosedException")
     assertThat(statusResp).doesNotContainKeys("shard_replication_details","follower_checkpoint","leader_checkpoint")
 }
 
-fun `validate aggregated paused status resposne`(statusResp: Map<String, Any>) {
-    Assert.assertEquals(statusResp.getValue("status"),"PAUSED")
-    Assert.assertEquals(statusResp.getValue("reason"), STATUS_REASON_USER_INITIATED)
+fun `validate aggregated paused status response`(statusResp: Map<String, Any>) {
+    Assert.assertEquals("PAUSED", statusResp.getValue("status"))
+    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
+    Assert.assertTrue(!(statusResp.containsKey("syncing_details")))
+}
+
+fun `validate status due shard task cancellation`(statusResp: Map<String, Any>) {
+    Assert.assertEquals("PAUSED", statusResp.getValue("status"))
+    Assert.assertTrue((statusResp.getValue("reason") as String).contains(STATUS_REASON_SHARD_TASK_CANCELLED))
+    Assert.assertTrue(!(statusResp.containsKey("syncing_details")))
+}
+
+fun `validate status due index task cancellation`(statusResp: Map<String, Any>) {
+    Assert.assertEquals("PAUSED", statusResp.getValue("status"))
+    Assert.assertEquals(INDEX_TASK_CANCELLATION_REASON, statusResp.getValue("reason"))
     Assert.assertTrue(!(statusResp.containsKey("syncing_details")))
 }
 

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/PauseReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/PauseReplicationIT.kt
@@ -18,8 +18,8 @@ package com.amazon.elasticsearch.replication.integ.rest
 import com.amazon.elasticsearch.replication.MultiClusterAnnotations
 import com.amazon.elasticsearch.replication.MultiClusterRestTestCase
 import com.amazon.elasticsearch.replication.StartReplicationRequest
-import com.amazon.elasticsearch.replication.`validate aggregated paused status resposne`
-import com.amazon.elasticsearch.replication.`validate paused status resposne`
+import com.amazon.elasticsearch.replication.`validate aggregated paused status response`
+import com.amazon.elasticsearch.replication.`validate paused status response`
 import com.amazon.elasticsearch.replication.pauseReplication
 import com.amazon.elasticsearch.replication.replicationStatus
 import com.amazon.elasticsearch.replication.resumeReplication
@@ -163,9 +163,9 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
         assertThatThrownBy {
             followerClient.pauseReplication(randomIndex)
             var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate paused status resposne`(statusResp)
+            `validate paused status response`(statusResp)
             statusResp = followerClient.replicationStatus(followerIndexName,false)
-            `validate aggregated paused status resposne`(statusResp)
+            `validate aggregated paused status response`(statusResp)
         }.isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("No replication in progress for index:$randomIndex")
     }
@@ -185,9 +185,9 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
              */
             followerClient.pauseReplication(followerIndexName)
             var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate paused status resposne`(statusResp)
+            `validate paused status response`(statusResp)
             statusResp = followerClient.replicationStatus(followerIndexName,false)
-            `validate aggregated paused status resposne`(statusResp)
+            `validate aggregated paused status response`(statusResp)
             // Since, we were still in FOLLOWING phase when pause was called, the index
             // in follower index should not have been deleted in follower cluster
             assertBusy {
@@ -230,7 +230,7 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
 
             followerClient.replicationStatus(followerIndexName, verbose = false)
             var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate paused status resposne`(statusResp)
+            `validate paused status response`(statusResp)
 
         } finally {
             followerClient.stopReplication(followerIndexName)

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/ResumeReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/ResumeReplicationIT.kt
@@ -18,12 +18,12 @@ package com.amazon.elasticsearch.replication.integ.rest
 import com.amazon.elasticsearch.replication.MultiClusterAnnotations
 import com.amazon.elasticsearch.replication.MultiClusterRestTestCase
 import com.amazon.elasticsearch.replication.StartReplicationRequest
-import com.amazon.elasticsearch.replication.`validate aggregated paused status resposne`
-import com.amazon.elasticsearch.replication.`validate not paused status aggregated resposne`
-import com.amazon.elasticsearch.replication.`validate not paused status resposne`
-import com.amazon.elasticsearch.replication.`validate paused status resposne`
-import com.amazon.elasticsearch.replication.`validate status syncing aggregated resposne`
-import com.amazon.elasticsearch.replication.`validate status syncing resposne`
+import com.amazon.elasticsearch.replication.`validate aggregated paused status response`
+import com.amazon.elasticsearch.replication.`validate not paused status aggregated response`
+import com.amazon.elasticsearch.replication.`validate not paused status response`
+import com.amazon.elasticsearch.replication.`validate paused status response`
+import com.amazon.elasticsearch.replication.`validate status syncing aggregated response`
+import com.amazon.elasticsearch.replication.`validate status syncing response`
 import com.amazon.elasticsearch.replication.pauseReplication
 import com.amazon.elasticsearch.replication.replicationStatus
 import com.amazon.elasticsearch.replication.resumeReplication
@@ -76,9 +76,9 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
              */
             followerClient.pauseReplication(followerIndexName)
             var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate paused status resposne`(statusResp)
+            `validate paused status response`(statusResp)
             statusResp = followerClient.replicationStatus(followerIndexName,false)
-            `validate aggregated paused status resposne`(statusResp)
+            `validate aggregated paused status response`(statusResp)
             followerClient.resumeReplication(followerIndexName)
         } finally {
             followerClient.stopReplication(followerIndexName)
@@ -98,14 +98,14 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
 
             assertThatThrownBy {
                 var statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate status syncing resposne`(statusResp)
+                `validate status syncing response`(statusResp)
                 statusResp = followerClient.replicationStatus(followerIndexName,false)
-                `validate status syncing aggregated resposne`(statusResp)
+                `validate status syncing aggregated response`(statusResp)
                 followerClient.resumeReplication(followerIndexName)
                 statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate not paused status resposne`(statusResp)
+                `validate not paused status response`(statusResp)
                 statusResp = followerClient.replicationStatus(followerIndexName,false)
-                `validate not paused status aggregated resposne`(statusResp)
+                `validate not paused status aggregated response`(statusResp)
             }.isInstanceOf(ResponseException::class.java)
                     .hasMessageContaining("Replication on Index ${followerIndexName} is already running")
         } finally {
@@ -279,7 +279,7 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
 
             followerClient.resumeReplication(followerIndexName)
             var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate status syncing resposne`(statusResp)
+            `validate status syncing response`(statusResp)
         } finally {
             if (Files.exists(synonymPath)) {
                 Files.delete(synonymPath)
@@ -331,7 +331,7 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
 
             followerClient.resumeReplication(followerIndexName)
             var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate status syncing resposne`(statusResp)
+            `validate status syncing response`(statusResp)
         } finally {
             if (Files.exists(synonymPath)) {
                 Files.delete(synonymPath)

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
@@ -19,13 +19,13 @@ package com.amazon.elasticsearch.replication.integ.rest
 import com.amazon.elasticsearch.replication.MultiClusterAnnotations
 import com.amazon.elasticsearch.replication.MultiClusterRestTestCase
 import com.amazon.elasticsearch.replication.StartReplicationRequest
-import com.amazon.elasticsearch.replication.`validate not paused status resposne`
+import com.amazon.elasticsearch.replication.`validate not paused status response`
 import com.amazon.elasticsearch.replication.`validate paused status on closed index`
 import com.amazon.elasticsearch.replication.pauseReplication
 import com.amazon.elasticsearch.replication.replicationStatus
 import com.amazon.elasticsearch.replication.resumeReplication
 import com.amazon.elasticsearch.replication.`validate paused status response due to leader index deleted`
-import com.amazon.elasticsearch.replication.`validate status syncing resposne`
+import com.amazon.elasticsearch.replication.`validate status syncing response`
 import com.amazon.elasticsearch.replication.startReplication
 import com.amazon.elasticsearch.replication.stopReplication
 import com.amazon.elasticsearch.replication.updateReplication
@@ -169,7 +169,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             leaderClient.lowLevelClient.performRequest(Request("POST", "/" + leaderIndexName + "/_open"))
             followerClient.resumeReplication(followerIndexName)
             var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate not paused status resposne`(statusResp)
+            `validate not paused status response`(statusResp)
 
         } finally {
             followerClient.stopReplication(followerIndexName)
@@ -797,7 +797,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             }
             assertBusy {
                 var statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate status syncing resposne`(statusResp)
+                `validate status syncing response`(statusResp)
             }
             val deleteIndexResponse = leaderClient.indices().delete(DeleteIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
             assertThat(deleteIndexResponse.isAcknowledged).isTrue()

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/task/TaskCancellationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/task/TaskCancellationIT.kt
@@ -1,0 +1,111 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.elasticsearch.replication.task
+
+import com.amazon.elasticsearch.replication.MultiClusterAnnotations
+import com.amazon.elasticsearch.replication.MultiClusterRestTestCase
+import com.amazon.elasticsearch.replication.StartReplicationRequest
+import com.amazon.elasticsearch.replication.`validate status due index task cancellation`
+import com.amazon.elasticsearch.replication.`validate status due shard task cancellation`
+import com.amazon.elasticsearch.replication.replicationStatus
+import com.amazon.elasticsearch.replication.startReplication
+import com.amazon.elasticsearch.replication.stopReplication
+import com.amazon.elasticsearch.replication.getIndexReplicationTask
+import com.amazon.elasticsearch.replication.getShardReplicationTasks
+import org.assertj.core.api.Assertions.assertThat
+import org.elasticsearch.client.RequestOptions
+import org.elasticsearch.client.indices.CreateIndexRequest
+import org.elasticsearch.client.tasks.CancelTasksRequest
+import org.elasticsearch.client.tasks.TaskId
+import java.util.Collections
+
+
+const val LEADER = "leaderCluster"
+const val FOLLOWER = "followCluster"
+const val leaderIndexName = "leader_index"
+const val followerIndexName = "follower_index"
+
+@MultiClusterAnnotations.ClusterConfigurations(
+    MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER),
+    MultiClusterAnnotations.ClusterConfiguration(clusterName = FOLLOWER)
+)
+class TaskCancellationIT : MultiClusterRestTestCase() {
+    fun `test user triggering cancel on a shard task`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+            // Wait for Shard tasks to come up.
+            var tasks = Collections.emptyList<String>()
+            assertBusy {
+                tasks = followerClient.getShardReplicationTasks(followerIndexName)
+                assertThat(tasks.isEmpty()).isEqualTo(false)
+            }
+
+            // Cancel one shard task
+            val cancelTasksRequest = CancelTasksRequest.Builder().withTaskId(TaskId(tasks[0])).
+                withWaitForCompletion(true).build()
+            followerClient.tasks().cancel(cancelTasksRequest, RequestOptions.DEFAULT)
+
+            // Verify that replication has paused.
+            assertBusy {
+                assertThat(followerClient.getShardReplicationTasks(followerIndexName).isEmpty()).isTrue()
+                assertThat(followerClient.getIndexReplicationTask(followerIndexName).isNullOrBlank()).isTrue()
+                `validate status due shard task cancellation`(followerClient.replicationStatus(followerIndexName))
+            }
+        } finally {
+            followerClient.stopReplication(followerIndexName)
+        }
+    }
+
+    fun `test user triggering cancel on an index task`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+            // Wait for Shard tasks to come up.
+            assertBusy {
+                assertThat(followerClient.getShardReplicationTasks(followerIndexName).isEmpty()).isEqualTo(false)
+            }
+
+            // Cancel the index replication task
+            var task = followerClient.getIndexReplicationTask(followerIndexName)
+            assertThat(task.isNullOrBlank()).isFalse()
+            val cancelTasksRequest = CancelTasksRequest.Builder().withTaskId(TaskId(task)).
+            withWaitForCompletion(true).build()
+            followerClient.tasks().cancel(cancelTasksRequest, RequestOptions.DEFAULT)
+
+            // Verify that replication has paused.
+            assertBusy {
+                assertThat(followerClient.getShardReplicationTasks(followerIndexName).isEmpty()).isTrue()
+                assertThat(followerClient.getIndexReplicationTask(followerIndexName).isNullOrBlank()).isTrue()
+                `validate status due index task cancellation`(followerClient.replicationStatus(followerIndexName))
+            }
+        } finally {
+            followerClient.stopReplication(followerIndexName)
+        }
+    }
+}


### PR DESCRIPTION
### Description
This change handles the cases where user cancels the `IndexReplicationTask` via ES task API. With this change, we ensure that replication is paused for the index before the task gets cancelled.

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
