### PR TITLE
Increase wait time for snapshot/forcemerge integ tests

### DIFF
--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
@@ -850,10 +850,12 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 var statusResp = followerClient.replicationStatus(followerIndexName)
                 `validate status syncing response`(statusResp)
             }
-            assertBusy {
+            assertBusy ({
                 Assert.assertEquals(leaderClient.count(CountRequest(leaderIndexName), RequestOptions.DEFAULT).toString(),
                     followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).toString())
-            }
+                },
+                30, TimeUnit.SECONDS
+            )
         } finally {
             followerClient.stopReplication(followerIndexName)
         }
@@ -903,12 +905,13 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 var statusResp = followerClient.replicationStatus(followerIndexName)
                 `validate status syncing response`(statusResp)
             }
-            assertBusy {
+            assertBusy({
                 Assert.assertEquals(
                     leaderClient.count(CountRequest(leaderIndexName), RequestOptions.DEFAULT).toString(),
                     followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).toString()
-                )
-            }
+                )},
+                30, TimeUnit.SECONDS
+            )
         } finally {
             followerClient.stopReplication(followerIndexName)
         }


### PR DESCRIPTION
### Description
The below integ tests fail sometimes:
- StartReplicationIT. test forcemerge on leader during replication bootstrap
- StartReplicationIT. test that snapshot on leader does not affect replication during bootstrap

This is happening because a lot of data is indexed on the leader and it sometime takes more than 10 seconds for the changes to get propagated to the follower. So increasing the assert busy time to 30 seconds to make sure these tests pass.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
