### PR TITLE
Add validation on index name

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
@@ -17,6 +17,7 @@ package com.amazon.elasticsearch.replication.action.autofollow
 
 import com.amazon.elasticsearch.replication.action.index.ReplicateIndexRequest
 import com.amazon.elasticsearch.replication.metadata.store.KEY_SETTINGS
+import com.amazon.elasticsearch.replication.util.ValidationUtil.validateName
 import org.elasticsearch.action.ActionRequestValidationException
 import org.elasticsearch.action.support.master.AcknowledgedRequest
 import org.elasticsearch.common.ParseField
@@ -105,6 +106,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
             validationException.addValidationError("Missing connection or name in the request")
         }
 
+        validateName(patternName, validationException)
         if(assumeRoles != null && (assumeRoles!!.size < 2 || assumeRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] == null ||
                         assumeRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] == null)) {
             validationException.addValidationError("Need roles for ${ReplicateIndexRequest.LEADER_CLUSTER_ROLE} and " +

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexRequest.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexRequest.kt
@@ -16,6 +16,7 @@
 package com.amazon.elasticsearch.replication.action.index
 
 import com.amazon.elasticsearch.replication.metadata.store.KEY_SETTINGS
+import com.amazon.elasticsearch.replication.util.ValidationUtil.validateName
 import org.elasticsearch.action.ActionRequestValidationException
 import org.elasticsearch.action.IndicesRequest
 import org.elasticsearch.action.support.IndicesOptions
@@ -101,6 +102,9 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
             !this::followerIndex.isInitialized) {
             validationException.addValidationError("Mandatory params are missing for the request")
         }
+
+        validateName(leaderIndex, validationException)
+        validateName(followerIndex, validationException)
 
         if(assumeRoles != null && (assumeRoles!!.size < 2 || assumeRoles!![LEADER_CLUSTER_ROLE] == null ||
                 assumeRoles!![FOLLOWER_CLUSTER_ROLE] == null)) {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -63,9 +63,6 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
         val user = SecurityContext.fromSecurityThreadContext(threadPool.threadContext)
         launch(threadPool.coroutineContext()) {
             listener.completeWith {
-                if(request.leaderIndex.startsWith(".")) {
-                    throw InvalidIndexNameException(request.leaderIndex,"Cannot start replication for an index starting with '.'")
-                }
 
                 val followerReplContext = ReplicationContext(request.followerIndex,
                         user?.overrideFgacRole(request.assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)))


### PR DESCRIPTION
### Description
Add validation logic for index name during start replication.

References: 
- https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
- https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java#L192-L267
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
