### PR TITLE
Bugfix: Changes to restore default threadcontext after co-routine is suspended

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -84,6 +84,8 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                     }
                 }
 
+                // Any checks on the settings is followed by setup checks to ensure all relevant changes are
+                // present across the plugins
                 val remoteClient = client.getRemoteClusterClient(request.leaderAlias)
                 val getSettingsRequest = GetSettingsRequest().includeDefaults(false).indices(request.leaderIndex)
                 val settingsResponse = remoteClient.suspending(remoteClient.admin().indices()::getSettings, injectSecurityContext = true)(getSettingsRequest)


### PR DESCRIPTION

### Description
Bugfix: Changes to restore default threadcontext after co-routine is suspended
 
### Issues Resolved
N/A
 
### Testing
```
Hit 100K requests on the test endpoint and ensured that the threadcontext is not corrupted and
response is as expected for the corresponding requests.
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
