### PR TITLE
Bugfix: Changes to restore default threadcontext after co-routine is suspended

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -77,6 +77,8 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                     }
                 }
 
+                // Any checks on the settings is followed by setup checks to ensure all relevant changes are
+                // present across the plugins
                 val remoteClient = client.getRemoteClusterClient(request.leaderAlias)
                 val getSettingsRequest = GetSettingsRequest().includeDefaults(false).indices(request.leaderIndex)
                 val settingsResponse = remoteClient.suspending(remoteClient.admin().indices()::getSettings, injectSecurityContext = true)(getSettingsRequest)

--- a/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
@@ -197,30 +197,34 @@ class OpenSearchClientThreadContextElement(private val threadContext: ThreadCont
                                               private val replicationMetadata: ReplicationMetadata?,
                                               private val action: String,
                                               private val injectSecurityContext: Boolean,
-                                              private val defaultContext: Boolean) : ThreadContextElement<ThreadContext.StoredContext> {
+                                              private val defaultContext: Boolean) : ThreadContextElement<Unit> {
 
     companion object Key : CoroutineContext.Key<OpenSearchThreadContextElement>
+
+    private var context: ThreadContext.StoredContext = threadContext.newStoredContext(true)
+    private var init = false
 
     override val key: CoroutineContext.Key<*>
         get() = Key
 
-    override fun restoreThreadContext(context: CoroutineContext, oldState: ThreadContext.StoredContext) {
-        oldState.close()
+    override fun restoreThreadContext(cc: CoroutineContext, oldState: Unit) {
+        this.context = threadContext.stashContext()
+        init = true
     }
 
-    override fun updateThreadContext(context: CoroutineContext): ThreadContext.StoredContext {
-        var storedContext = setThreadContext()
-        if(injectSecurityContext) {
-            // Populate relevant transients from replication metadata
-            SecurityContext.setBasedOnActions(replicationMetadata, action, threadContext)
+    override fun updateThreadContext(cc: CoroutineContext) {
+        this.context.close()
+        if(!init) {
+            // To ensure, we initialize security related transients only once
+            this.context = if(injectSecurityContext || defaultContext)
+                threadContext.stashContext()
+            else
+                threadContext.newStoredContext(true)
+            if(injectSecurityContext) {
+                // Populate relevant transients from replication metadata
+                SecurityContext.setBasedOnActions(replicationMetadata, action, threadContext)
+            }
         }
-        return storedContext
-    }
-
-    private fun setThreadContext(): ThreadContext.StoredContext {
-        if(injectSecurityContext || defaultContext)
-            return threadContext.stashContext()
-        return threadContext.newStoredContext(false)
     }
 }
 


### PR DESCRIPTION
### Description
Bugfix: Changes to restore default threadcontext after co-routine is suspended
 Signed-off-by: Sai <karanas@amazon.com>

### Issues Resolved
N/A

### Testing
```
Hit 100K requests on the test endpoint and ensured that the threadcontext is not corrupted and
response is as expected for the corresponding requests.
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
