### PR TITLE
Add setting to enable/disable replication plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -293,6 +293,7 @@ testClusters {
         if (_numNodes > 1) numberOfNodes = _numNodes
         //numberOfNodes = 3
         setting 'path.repo', repo.absolutePath
+        setting 'plugins.replication.enabled', "true"
         if(_numNodes == 1) jvmArgs "${-> getDebugJvmArgs(debugPort++)}"
     }
     followCluster {
@@ -306,6 +307,7 @@ testClusters {
         if (_numNodes > 1) numberOfNodes = _numNodes
         //numberOfNodes = 3
         setting 'path.repo', repo.absolutePath
+        setting 'plugins.replication.enabled', "true"
         if(_numNodes == 1) jvmArgs "${-> getDebugJvmArgs(debugPort++)}"
     }
 }


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
This change adds a setting to enable/disable the replication plugin 

###Testing done
- Manual testing with plugin enabled.
- Plugin's UT and ITs.
- Manual tested spinning up cluster with replication plugin disabled. Verified that OS comes up without any issues.

 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
