### PR TITLE
Add OpenSearch build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,16 @@ import java.util.stream.Collectors
 import org.opensearch.gradle.testclusters.OpenSearchCluster
 
 buildscript {
+
     ext {
-        opensearch_version = System.getProperty("opensearch_version", "1.1.0")
+        isSnapshot = "true" == System.getProperty("build.snapshot", "false")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
+        // Taken from https://github.com/opensearch-project/alerting/blob/main/build.gradle#L33
+        // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
+        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.3.72")
+
     }
 
     repositories {
@@ -47,10 +54,16 @@ buildscript {
     }
 }
 
-
 plugins {
     id 'nebula.ospackage' version "8.3.0"
     id "com.dorongold.task-tree" version "1.5"
+}
+
+allprojects {
+    group = "org.opensearch"
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
 }
 
 apply plugin: 'java'
@@ -93,7 +106,7 @@ dependencies {
     compile "org.jetbrains:annotations:13.0"
     compile "com.github.seancfoley:ipaddress:5.3.3"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5"
-    compile "org.opensearch:common-utils:${version}"
+    compile "org.opensearch:common-utils:${common_utils_version}"
 
     testCompile "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.assertj:assertj-core:3.17.2"
@@ -107,6 +120,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
+    jcenter()
 }
 
 compileKotlin {
@@ -135,6 +149,12 @@ opensearchplugin {
     classname = "org.opensearch.replication.ReplicationPlugin"
 }
 
+java {
+    if (!isSnapshot) {
+        withJavadocJar()
+        withSourcesJar()
+    }
+}
 
 javadoc.enabled = false
 licenseHeaders.enabled = false


### PR DESCRIPTION
### Description
This change  adds the changes required for the plugin to be built & published as part of opensearch.

Openserach-build PR: https://github.com/opensearch-project/opensearch-build/pull/315
###Testing done
- brazil-build.
- verified by running the build workflow from opensearch-build repo. `./bundle-workflow/build.sh manifests/opensearch-1.1.0.yml --snapshot --component cross-cluster-replication` 
- Verified the artifact published for snapshot and release usecase.
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
