### PR TITLE
Adding exp backoff for retryable exceptions

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
@@ -238,6 +238,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                         //reset backoff after every successful getChanges call
                         backOffForRetry = initialBackoffMillis
                     } catch (e: ElasticsearchTimeoutException) {
+                        //TimeoutException is thrown if leader fails to send new changes in 1 minute, so we dont need a backoff again here for this exception
                         logInfo("Timed out waiting for new changes. Current seqNo: $fromSeqNo. $e")
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                     } catch (e: NodeNotConnectedException) {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/ShardReplicationTask.kt
@@ -74,7 +74,15 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
     private val remoteClient = client.getRemoteClusterClient(leaderAlias)
     private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
     private var paused = false
-    private val backOffForNodeDiscovery = 1000L
+
+    //Start backOff for exceptions with a second
+    private val initialBackoffMillis = 1000L
+    //Start backOff for exceptions with a second
+    private var backOffForRetry = initialBackoffMillis
+    //Max timeout for backoff
+    private val maxTimeOut = 60000L
+    //Backoff factor after every retry
+    private val factor = 2.0
 
     private val clusterStateListenerForTaskInterruption = ClusterStateListenerForTaskInterruption()
 
@@ -218,6 +226,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                     val batchToFetch = changeTracker.requestBatchToFetch()
                     val fromSeqNo = batchToFetch.first
                     val toSeqNo = batchToFetch.second
+
                     try {
                         logDebug("Getting changes $fromSeqNo-$toSeqNo")
                         val changesResponse = getChanges(fromSeqNo, toSeqNo)
@@ -226,12 +235,15 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                         logDebug("pushed to sequencer $fromSeqNo-$toSeqNo")
                         changeTracker.updateBatchFetched(true, fromSeqNo, toSeqNo, changesResponse.changes.lastOrNull()?.seqNo() ?: fromSeqNo - 1,
                             changesResponse.lastSyncedGlobalCheckpoint)
+                        //reset backoff after every successful getChanges call
+                        backOffForRetry = initialBackoffMillis
                     } catch (e: ElasticsearchTimeoutException) {
                         logInfo("Timed out waiting for new changes. Current seqNo: $fromSeqNo. $e")
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                     } catch (e: NodeNotConnectedException) {
                         logInfo("Node not connected. Retrying request using a different node. ${e.stackTraceToString()}")
-                        delay(backOffForNodeDiscovery)
+                        delay(backOffForRetry)
+                        backOffForRetry = (backOffForRetry * factor).toLong().coerceAtMost(maxTimeOut)
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                     } catch (e: Exception) {
                         logInfo("Unable to get changes from seqNo: $fromSeqNo. ${e.stackTraceToString()}")
@@ -244,6 +256,8 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                             e.status().status != RestStatus.TOO_MANY_REQUESTS.status) {
                             throw e
                         }
+                        delay(backOffForRetry)
+                        backOffForRetry = (backOffForRetry * factor).toLong().coerceAtMost(maxTimeOut)
                     } finally {
                         rateLimiter.release()
                     }


### PR DESCRIPTION
### Description
Adding exponential backoff by 2x factor for a max of 1 minute.
 
### Issues Resolved
Adding exponential backoff by 2x factor for a max of 1 minute.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
