### PR TITLE
Pause API should allow reason to be specified in the REST call.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationRequest.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/PauseIndexReplicationRequest.kt
@@ -20,6 +20,7 @@ import org.elasticsearch.action.ActionRequestValidationException
 import org.elasticsearch.action.IndicesRequest
 import org.elasticsearch.action.support.IndicesOptions
 import org.elasticsearch.action.support.master.AcknowledgedRequest
+import org.elasticsearch.common.ParseField
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.StreamOutput
 import org.elasticsearch.common.xcontent.ObjectParser
@@ -49,6 +50,10 @@ class PauseIndexReplicationRequest : AcknowledgedRequest<PauseIndexReplicationRe
     companion object {
         private val PARSER = ObjectParser<PauseIndexReplicationRequest, Void>("PauseReplicationRequestParser") {
             PauseIndexReplicationRequest()
+        }
+
+        init {
+            PARSER.declareString(PauseIndexReplicationRequest::reason::set, ParseField("reason"))
         }
 
         fun fromXContent(parser: XContentParser, followerIndex: String): PauseIndexReplicationRequest {

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -170,9 +170,9 @@ fun `validate not paused status aggregated response`(statusResp: Map<String, Any
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("leader_checkpoint"))
 }
 
-fun `validate paused status response`(statusResp: Map<String, Any>) {
+fun `validate paused status response`(statusResp: Map<String, Any>, reason: String? = null) {
     Assert.assertEquals("PAUSED", statusResp.getValue("status"))
-    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
+    Assert.assertEquals(reason ?: STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
     Assert.assertFalse(statusResp.containsKey("shard_replication_details"))
     Assert.assertFalse(statusResp.containsKey("follower_checkpoint"))
     Assert.assertFalse(statusResp.containsKey("leader_checkpoint"))
@@ -217,9 +217,13 @@ fun RestHighLevelClient.stopReplication(index: String, shouldWait: Boolean = tru
 }
 
 
-fun RestHighLevelClient.pauseReplication(index: String, shouldWait: Boolean = true, requestOptions: RequestOptions = RequestOptions.DEFAULT) {
+fun RestHighLevelClient.pauseReplication(index: String, reason:String? = null, shouldWait: Boolean = true, requestOptions: RequestOptions = RequestOptions.DEFAULT) {
     val lowLevelPauseRequest = Request("POST", REST_REPLICATION_PAUSE.replace("{index}", index,true))
-    lowLevelPauseRequest.setJsonEntity("{}")
+    if (null == reason) {
+        lowLevelPauseRequest.setJsonEntity("{}")
+    } else {
+        lowLevelPauseRequest.setJsonEntity("{\"reason\":\"$reason\"}")
+    }
     lowLevelPauseRequest.setOptions(requestOptions)
     val lowLevelPauseResponse = lowLevelClient.performRequest(lowLevelPauseRequest)
     val response = getAckResponse(lowLevelPauseResponse)


### PR DESCRIPTION
### Description
Pause API should allow reason to be specified in the REST call.
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
