### PR TITLE
AutoFollow Stats API Addition

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowMasterNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowMasterNodeAction.kt
@@ -41,6 +41,7 @@ import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.settings.IndexScopedSettings
+import org.opensearch.replication.ReplicationException
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 
@@ -75,7 +76,7 @@ class TransportAutoFollowMasterNodeAction @Inject constructor(transportService: 
                 if (request.action == UpdateAutoFollowPatternRequest.Action.ADD) {
                     // Should start the task if there were no follow patterns before adding this
                     if(request.pattern == null) {
-                        throw org.opensearch.replication.ReplicationException("Failed to update empty autofollow pattern")
+                        throw ReplicationException("Failed to update empty autofollow pattern")
                     }
                     // Pattern is same for leader and follower
                     val followerClusterRole = request.useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)

--- a/src/main/kotlin/org/opensearch/replication/action/stats/AutoFollowStatsAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stats/AutoFollowStatsAction.kt
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.stats
+
+import org.opensearch.action.ActionType
+import org.opensearch.action.FailedNodeException
+import org.opensearch.action.TaskOperationFailure
+import org.opensearch.action.support.tasks.BaseTasksResponse
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS
+import org.opensearch.common.xcontent.ToXContentObject
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.replication.task.autofollow.AutoFollowStat
+import java.io.IOException
+
+class AutoFollowStatsAction : ActionType<AutoFollowStatsResponses>(NAME, reader) {
+    companion object {
+        const val NAME = "indices:admin/plugins/replication/autofollow/stats"
+        val INSTANCE = AutoFollowStatsAction()
+        val reader = Writeable.Reader { inp -> AutoFollowStatsResponses(inp) }
+    }
+
+    override fun getResponseReader(): Writeable.Reader<AutoFollowStatsResponses> = reader
+}
+
+
+class AutoFollowStatsResponse : Writeable , ToXContentObject {
+    val stat: AutoFollowStat
+
+    constructor(inp: StreamInput) {
+        stat = AutoFollowStat(inp)
+    }
+
+    constructor(status: AutoFollowStat) {
+        this.stat = status
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        stat.writeTo(out)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return stat.toXContent(builder, params)
+    }
+}
+
+
+class AutoFollowStatsResponses : BaseTasksResponse, ToXContentObject {
+    val statsResponses: List<AutoFollowStatsResponse>
+    var aggResponse = AutoFollowStat("", "")
+
+    constructor(
+            autoFollowStatsResponse: List<AutoFollowStatsResponse>,
+            nodeFailures: List<FailedNodeException>,
+            taskFailures: List<TaskOperationFailure>) : super(taskFailures, nodeFailures) {
+        statsResponses = autoFollowStatsResponse
+        for (resp in statsResponses) {
+            aggResponse.failedLeaderCall += resp.stat.failedLeaderCall
+            aggResponse.failCount += resp.stat.failCount
+            aggResponse.failedIndices.addAll(resp.stat.failedIndices)
+            aggResponse.successCount += resp.stat.successCount
+        }
+    }
+
+    constructor(inp: StreamInput) : super(inp) {
+        aggResponse = AutoFollowStat(inp)
+        statsResponses = inp.readList { AutoFollowStatsResponse(inp) }
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        aggResponse.writeTo(out)
+        out.writeList(statsResponses)
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params?): XContentBuilder {
+        builder.startObject()
+        builder.field("num_success_start_replication", aggResponse.successCount)
+        builder.field("num_failed_start_replication", aggResponse.failCount)
+        builder.field("num_failed_leader_calls", aggResponse.failedLeaderCall)
+        builder.field("failed_indices", aggResponse.failedIndices)
+        builder.startArray("autofollow_stats");
+        for (response in statsResponses) {
+            response.toXContent(builder, EMPTY_PARAMS)
+        }
+        builder.endArray(   )
+        builder.endObject()
+        return builder
+    }
+
+}
+
+

--- a/src/main/kotlin/org/opensearch/replication/action/stats/AutoFollowStatsRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stats/AutoFollowStatsRequest.kt
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.stats
+
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.support.tasks.BaseTasksRequest
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.replication.task.autofollow.AutoFollowTask
+import org.opensearch.tasks.Task
+import java.io.IOException
+
+/**
+ * A request to get  replication autofollow stats.
+ */
+class AutoFollowStatsRequest : BaseTasksRequest<AutoFollowStatsRequest> {
+
+    constructor(inp: StreamInput) : super(inp)
+
+    constructor():super()
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+    }
+
+    override fun validate(): ActionRequestValidationException? {
+        return null
+    }
+
+    override fun match(task: Task?): Boolean {
+        if (task is AutoFollowTask) {
+            return true
+        }
+        return false
+    }
+
+}
+

--- a/src/main/kotlin/org/opensearch/replication/action/stats/TransportAutoFollowStatsAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stats/TransportAutoFollowStatsAction.kt
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.stats
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.ActionListener
+import org.opensearch.action.FailedNodeException
+import org.opensearch.action.TaskOperationFailure
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.tasks.TransportTasksAction
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.replication.task.autofollow.AutoFollowTask
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+
+class TransportAutoFollowStatsAction @Inject constructor(transportService: TransportService,
+                                                         clusterService: ClusterService,
+                                                         actionFilters: ActionFilters
+                                                            ) :
+        TransportTasksAction<AutoFollowTask, AutoFollowStatsRequest, AutoFollowStatsResponses, AutoFollowStatsResponse>(AutoFollowStatsAction.NAME,
+              clusterService, transportService,  actionFilters,
+                ::AutoFollowStatsRequest,  ::AutoFollowStatsResponses, ::AutoFollowStatsResponse, ThreadPool.Names.MANAGEMENT), CoroutineScope by GlobalScope {
+
+    companion object {
+        private val log = LogManager.getLogger(TransportAutoFollowStatsAction::class.java)
+    }
+
+
+    override fun newResponse(request: AutoFollowStatsRequest, resp: MutableList<AutoFollowStatsResponse>, failure: MutableList<TaskOperationFailure>, failedNode: MutableList<FailedNodeException>): AutoFollowStatsResponses {
+       return AutoFollowStatsResponses(resp,failedNode, failure )
+    }
+
+    override fun taskOperation(req: AutoFollowStatsRequest, task: AutoFollowTask, listener: ActionListener<AutoFollowStatsResponse>) {
+        listener.onResponse(AutoFollowStatsResponse(task.status))
+    }
+}
+

--- a/src/main/kotlin/org/opensearch/replication/rest/AutoFollowStatsHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/AutoFollowStatsHandler.kt
@@ -1,0 +1,50 @@
+package org.opensearch.replication.rest
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.client.node.NodeClient
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.replication.action.stats.AutoFollowStatsAction
+import org.opensearch.replication.action.stats.AutoFollowStatsRequest
+import org.opensearch.replication.action.stats.AutoFollowStatsResponses
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestResponse
+import org.opensearch.rest.RestStatus
+import org.opensearch.rest.action.RestResponseListener
+import java.io.IOException
+
+class AutoFollowStatsHandler : BaseRestHandler() {
+    companion object {
+        private val log = LogManager.getLogger(AutoFollowStatsHandler::class.java)
+    }
+
+    override fun routes(): List<RestHandler.Route> {
+        return listOf(RestHandler.Route(RestRequest.Method.GET, "/_plugins/_replication/autofollow_stats"))
+    }
+
+    override fun getName(): String {
+        return "plugins_autofollow_replication_stats"
+    }
+
+    @Throws(IOException::class)
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        val statsRequest = AutoFollowStatsRequest()
+        return RestChannelConsumer { channel: RestChannel? ->
+            client.admin().cluster()
+                    .execute(AutoFollowStatsAction.INSTANCE, statsRequest, object : RestResponseListener<AutoFollowStatsResponses>(channel) {
+                        @Throws(Exception::class)
+                        override fun buildResponse(nodesStatsResponses: AutoFollowStatsResponses): RestResponse? {
+                            val builder: XContentBuilder = XContentFactory.jsonBuilder().prettyPrint()
+                            return BytesRestResponse(RestStatus.OK, nodesStatsResponses.toXContent(builder, ToXContent.EMPTY_PARAMS))
+                        }
+                    })
+        }
+    }
+}
+

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -49,6 +49,7 @@ const val REST_AUTO_FOLLOW_PATTERN = "${REST_REPLICATION_PREFIX}_autofollow"
 const val REST_REPLICATION_TASKS = "_tasks?actions=*replication*&detailed&pretty"
 const val REST_LEADER_STATS = "${REST_REPLICATION_PREFIX}leader_stats"
 const val REST_FOLLOWER_STATS = "${REST_REPLICATION_PREFIX}follower_stats"
+const val REST_AUTO_FOLLOW_STATS = "${REST_REPLICATION_PREFIX}autofollow_stats"
 const val INDEX_TASK_CANCELLATION_REASON = "Index replication task was cancelled by user"
 const val STATUS_REASON_USER_INITIATED = "User initiated"
 const val STATUS_REASON_SHARD_TASK_CANCELLED = "Shard task killed or cancelled."
@@ -348,6 +349,14 @@ fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName:
     val lowLevelResponse = lowLevelClient.performRequest(lowLevelRequest)
     val response = getAckResponse(lowLevelResponse)
     assertThat(response.isAcknowledged).isTrue()
+}
+
+fun RestHighLevelClient.AutoFollowStats() : Map<String, Any>  {
+    var request = Request("GET", REST_AUTO_FOLLOW_STATS)
+    request.setJsonEntity("{}")
+    val lowLevelStatusResponse = lowLevelClient.performRequest(request)
+    val response: Map<String, Any> = OpenSearchRestTestCase.entityAsMap(lowLevelStatusResponse)
+    return response
 }
 
 fun RestHighLevelClient.deleteAutoFollowPattern(connection: String, patternName: String) {


### PR DESCRIPTION
Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>

### Description
An API to list out all auto follow jobs and its success, failure counters
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/130

### Sample Request , Response
```
➜  scripts curl -XGET  "${FOLLOWER}/_plugins/_replication/autofollow_stats" -d'{}'  -H 'Content-Type: application/json'
{
  "num_success_start_replication" : 3,
  "num_failed_start_replication" : 0,
  "num_failed_leader_calls" : 0,
  "failed_indices" : [ ],
  "autofollow_stats" : [
    {
      "name" : "my-replication",
      "pattern" : "leader-*",
      "num_success_start_replication" : 2,
      "num_failed_start_replication" : 0,
      "num_failed_leader_calls" : 0,
      "failed_indices" : [ ]
    },
    {
      "name" : "my-replication-2",
      "pattern" : "lead-*",
      "num_success_start_replication" : 1,
      "num_failed_start_replication" : 0,
      "num_failed_leader_calls" : 0,
      "failed_indices" : [ ]
    }
  ]
}
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
