### PR TITLE
Retrying for transport exceptions and letting other exceptions fail replication as necessary

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/TranslogSequencer.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/shard/TranslogSequencer.kt
@@ -20,7 +20,7 @@ import com.amazon.elasticsearch.replication.action.changes.GetChangesResponse
 import com.amazon.elasticsearch.replication.action.replay.ReplayChangesAction
 import com.amazon.elasticsearch.replication.action.replay.ReplayChangesRequest
 import com.amazon.elasticsearch.replication.metadata.store.ReplicationMetadata
-import com.amazon.elasticsearch.replication.util.suspendExecute
+import com.amazon.elasticsearch.replication.util.suspendExecuteWithRetries
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -66,7 +66,7 @@ class TranslogSequencer(scope: CoroutineScope, private val replicationMetadata: 
                                                          leaderAlias, leaderIndexName)
                 replayRequest.parentTask = parentTaskId
                 launch {
-                    val replayResponse = client.suspendExecute(replicationMetadata, ReplayChangesAction.INSTANCE, replayRequest)
+                    val replayResponse = client.suspendExecuteWithRetries(replicationMetadata, ReplayChangesAction.INSTANCE, replayRequest, log = log)
                     if (replayResponse.shardInfo.failed > 0) {
                         replayResponse.shardInfo.failures.forEachIndexed { i, failure ->
                             log.error("Failed replaying changes. Failure:$i:$failure")


### PR DESCRIPTION
Retrying for transport exceptions and letting other exceptions fail replication as necessary

### Description
Retrying for transport exceptions and letting other exceptions fail replication as necessary
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
