### PR TITLE
Rename to useroles in all the request payloads instead of assumeroles

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowMasterNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowMasterNodeAction.kt
@@ -11,7 +11,6 @@
 
 package org.opensearch.replication.action.autofollow
 
-import org.opensearch.replication.ReplicationException
 import org.opensearch.replication.action.index.ReplicateIndexRequest
 import org.opensearch.replication.metadata.ReplicationMetadataManager
 import org.opensearch.replication.metadata.ReplicationOverallState
@@ -79,8 +78,8 @@ class TransportAutoFollowMasterNodeAction @Inject constructor(transportService: 
                         throw org.opensearch.replication.ReplicationException("Failed to update empty autofollow pattern")
                     }
                     // Pattern is same for leader and follower
-                    val followerClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
-                    val leaderClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
+                    val followerClusterRole = request.useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
+                    val leaderClusterRole = request.useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
 
                     indexScopedSettings.validate(request.settings,
                             false,

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportUpdateAutoFollowPatternAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportUpdateAutoFollowPatternAction.kt
@@ -11,7 +11,6 @@
 
 package org.opensearch.replication.action.autofollow
 
-import org.opensearch.replication.ReplicationException
 import org.opensearch.replication.action.index.ReplicateIndexRequest
 import org.opensearch.replication.action.setup.SetupChecksAction
 import org.opensearch.replication.action.setup.SetupChecksRequest
@@ -54,8 +53,8 @@ class TransportUpdateAutoFollowPatternAction @Inject constructor(transportServic
             listener.completeWith {
                 if (request.action == UpdateAutoFollowPatternRequest.Action.ADD) {
                     // Pattern is same for leader and follower
-                    val followerClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
-                    val leaderClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
+                    val followerClusterRole = request.useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
+                    val leaderClusterRole = request.useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
                     val setupChecksRequest = SetupChecksRequest(ReplicationContext(request.pattern!!, user?.overrideFgacRole(followerClusterRole)),
                             ReplicationContext(request.pattern!!, user?.overrideFgacRole(leaderClusterRole)),
                             request.connection)

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
@@ -35,7 +35,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
     lateinit var connection: String
     lateinit var patternName: String
     var pattern: String? = null
-    var assumeRoles: HashMap<String, String>? = null // roles to assume - {leader_fgac_role: role1, follower_fgac_role: role2}
+    var useRoles: HashMap<String, String>? = null // roles to use - {leader_fgac_role: role1, follower_fgac_role: role2}
     var settings : Settings = Settings.EMPTY
 
     enum class Action {
@@ -53,16 +53,16 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
             AUTOFOLLOW_REQ_PARSER.declareString(UpdateAutoFollowPatternRequest::pattern::set, ParseField("pattern"))
 
             AUTOFOLLOW_REQ_PARSER.declareObjectOrDefault(BiConsumer { reqParser: UpdateAutoFollowPatternRequest,
-                                                                      roles: HashMap<String, String> -> reqParser.assumeRoles = roles},
-                    ReplicateIndexRequest.FGAC_ROLES_PARSER, null, ParseField("assume_roles"))
+                                                                      roles: HashMap<String, String> -> reqParser.useRoles = roles},
+                    ReplicateIndexRequest.FGAC_ROLES_PARSER, null, ParseField("use_roles"))
             AUTOFOLLOW_REQ_PARSER.declareObjectOrDefault(BiConsumer{ request: UpdateAutoFollowPatternRequest, settings: Settings -> request.settings = settings}, BiFunction{ p: XContentParser?, c: Void? -> Settings.fromXContent(p) },
                     null, ParseField(KEY_SETTINGS))
         }
         fun fromXContent(xcp: XContentParser, action: Action) : UpdateAutoFollowPatternRequest {
             val updateAutofollowReq = AUTOFOLLOW_REQ_PARSER.parse(xcp, null)
             updateAutofollowReq.action = action
-            if(updateAutofollowReq.assumeRoles?.size == 0) {
-                updateAutofollowReq.assumeRoles = null
+            if(updateAutofollowReq.useRoles?.size == 0) {
+                updateAutofollowReq.useRoles = null
             }
             if (updateAutofollowReq.settings == null) {
                 updateAutofollowReq.settings = Settings.EMPTY
@@ -87,9 +87,9 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         action = inp.readEnum(Action::class.java)
         var leaderClusterRole = inp.readOptionalString()
         var followerClusterRole = inp.readOptionalString()
-        assumeRoles = HashMap()
-        if(leaderClusterRole != null) assumeRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] = leaderClusterRole
-        if(followerClusterRole != null) assumeRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerClusterRole
+        useRoles = HashMap()
+        if(leaderClusterRole != null) useRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] = leaderClusterRole
+        if(followerClusterRole != null) useRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerClusterRole
         settings = Settings.readSettingsFromStream(inp)
     }
 
@@ -103,8 +103,8 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         }
 
         validateName(patternName, validationException)
-        if(assumeRoles != null && (assumeRoles!!.size < 2 || assumeRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] == null ||
-                        assumeRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] == null)) {
+        if(useRoles != null && (useRoles!!.size < 2 || useRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] == null ||
+                        useRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] == null)) {
             validationException.addValidationError("Need roles for ${ReplicateIndexRequest.LEADER_CLUSTER_ROLE} and " +
                     "${ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE}")
         }
@@ -126,8 +126,8 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         out.writeString(patternName)
         out.writeOptionalString(pattern)
         out.writeEnum(action)
-        out.writeOptionalString(assumeRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE))
-        out.writeOptionalString(assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE))
+        out.writeOptionalString(useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE))
+        out.writeOptionalString(useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE))
         Settings.writeSettingsToStream(settings, out)
     }
 
@@ -137,11 +137,11 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         builder.field("pattern_name", patternName)
         builder.field("pattern", pattern)
         builder.field("action", action.name)
-        if(assumeRoles != null) {
-            builder.field("assume_roles")
+        if(useRoles != null) {
+            builder.field("use_roles")
             builder.startObject()
-            builder.field("leader_cluster_role", assumeRoles!!.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE))
-            builder.field("follower_cluster_role", assumeRoles!!.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE))
+            builder.field("leader_cluster_role", useRoles!!.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE))
+            builder.field("follower_cluster_role", useRoles!!.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE))
             builder.endObject()
         }
 

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -11,7 +11,6 @@
 
 package org.opensearch.replication.action.index
 
-import org.opensearch.replication.ReplicationException
 import org.opensearch.replication.ReplicationPlugin
 import org.opensearch.replication.action.setup.SetupChecksAction
 import org.opensearch.replication.action.setup.SetupChecksRequest
@@ -36,7 +35,6 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.env.Environment
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.IndexSettings
-import org.opensearch.indices.InvalidIndexNameException
 import org.opensearch.tasks.Task
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
@@ -61,9 +59,9 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
             listener.completeWith {
 
                 val followerReplContext = ReplicationContext(request.followerIndex,
-                        user?.overrideFgacRole(request.assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)))
+                        user?.overrideFgacRole(request.useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)))
                 val leaderReplContext = ReplicationContext(request.leaderIndex,
-                        user?.overrideFgacRole(request.assumeRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)))
+                        user?.overrideFgacRole(request.useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)))
 
                 // For autofollow request, setup checks are already made during addition of the pattern with
                 // original user

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexMasterNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexMasterNodeAction.kt
@@ -102,8 +102,8 @@ class TransportReplicateIndexMasterNodeAction @Inject constructor(transportServi
 
                 replicationMetadataManager.addIndexReplicationMetadata(replicateIndexReq.followerIndex,
                         replicateIndexReq.leaderAlias, replicateIndexReq.leaderIndex,
-                        ReplicationOverallState.RUNNING, user, replicateIndexReq.assumeRoles?.getOrDefault(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE, null),
-                        replicateIndexReq.assumeRoles?.getOrDefault(ReplicateIndexRequest.LEADER_CLUSTER_ROLE, null), replicateIndexReq.settings)
+                        ReplicationOverallState.RUNNING, user, replicateIndexReq.useRoles?.getOrDefault(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE, null),
+                        replicateIndexReq.useRoles?.getOrDefault(ReplicateIndexRequest.LEADER_CLUSTER_ROLE, null), replicateIndexReq.settings)
 
                 val task = persistentTasksService.startTask("replication:index:${replicateIndexReq.followerIndex}",
                         IndexReplicationExecutor.TASK_NAME, params)

--- a/src/main/kotlin/org/opensearch/replication/action/setup/TransportSetupChecksAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/setup/TransportSetupChecksAction.kt
@@ -151,21 +151,21 @@ class TransportSetupChecksAction @Inject constructor(transportService: Transport
     private fun triggerPermissionsValidation(client: Client,
                                              cluster: String,
                                              replContext: ReplicationContext,
-                                             shouldAssumeRole: Boolean,
+                                             shouldValidateRole: Boolean,
                                              permissionListener: ActionListener<AcknowledgedResponse>) {
 
         var storedContext: ThreadContext.StoredContext? = null
         try {
             // Remove the assume roles transient from the previous call
             storedContext = client.threadPool().threadContext.newStoredContext(false,
-                    listOf(SecurityContext.OPENDISTRO_SECURITY_ASSUME_ROLES))
-            val assumeRole = replContext.user?.roles?.get(0)
-            val inThreadContextRole = client.threadPool().threadContext.getTransient<String?>(SecurityContext.OPENDISTRO_SECURITY_ASSUME_ROLES)
-            log.debug("assume role is $inThreadContextRole for $cluster")
-            if(shouldAssumeRole) {
-                client.threadPool().threadContext.putTransient(SecurityContext.OPENDISTRO_SECURITY_ASSUME_ROLES, assumeRole)
+                    listOf(SecurityContext.OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION))
+            val validateRole = replContext.user?.roles?.get(0)
+            val inThreadContextRole = client.threadPool().threadContext.getTransient<String?>(SecurityContext.OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION)
+            log.debug("Validation role in threadcontect is $inThreadContextRole for $cluster")
+            if(shouldValidateRole) {
+                client.threadPool().threadContext.putTransient(SecurityContext.OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION, validateRole)
             }
-            val validateReq = ValidatePermissionsRequest(cluster, replContext.resource, assumeRole)
+            val validateReq = ValidatePermissionsRequest(cluster, replContext.resource, validateRole)
             client.execute(ValidatePermissionsAction.INSTANCE, validateReq, permissionListener)
         } finally {
             storedContext?.close()

--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -11,7 +11,6 @@
 
 package org.opensearch.replication.task.autofollow
 
-import org.opensearch.replication.ReplicationException
 import org.opensearch.replication.ReplicationSettings
 import org.opensearch.replication.action.index.ReplicateIndexAction
 import org.opensearch.replication.action.index.ReplicateIndexRequest
@@ -135,9 +134,9 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
             val followerRole = replicationMetadata.followerContext?.user?.roles?.get(0)
             val leaderRole = replicationMetadata.leaderContext?.user?.roles?.get(0)
             if(followerRole != null && leaderRole != null) {
-                request.assumeRoles = HashMap<String, String>()
-                request.assumeRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerRole
-                request.assumeRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] = leaderRole
+                request.useRoles = HashMap<String, String>()
+                request.useRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerRole
+                request.useRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] = leaderRole
             }
             request.settings = replicationMetadata.settings
             val response = client.suspendExecute(replicationMetadata, ReplicateIndexAction.INSTANCE, request)

--- a/src/main/kotlin/org/opensearch/replication/util/SecurityContext.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/SecurityContext.kt
@@ -38,7 +38,7 @@ class SecurityContext {
     companion object {
         private val log = LogManager.getLogger(SecurityContext::class.java)
         const val OPENDISTRO_SECURITY_USER = "_opendistro_security_user"
-        const val OPENDISTRO_SECURITY_ASSUME_ROLES = "opendistro_security_assume_roles"
+        const val OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION = "opendistro_security_injected_roles_validation"
         const val REPLICATION_PLUGIN_USER = "ccr_user"
 
         val ADMIN_USER = User(REPLICATION_PLUGIN_USER, null, listOf("all_access"), null)

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -17,7 +17,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest
 import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.client.HttpAsyncResponseConsumerFactory.HeapBufferedResponseConsumerFactory
 import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response
@@ -30,14 +29,13 @@ import org.opensearch.common.xcontent.XContentType
 import org.opensearch.test.OpenSearchTestCase.assertBusy
 import org.opensearch.test.rest.OpenSearchRestTestCase
 import org.junit.Assert
-import org.opensearch.replication.task.index.IndexReplicationExecutor.Companion.log
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
-data class AssumeRoles(val leaderClusterRole: String = "leader_role", val followerClusterRole: String = "follower_role")
+data class UseRoles(val leaderClusterRole: String = "leader_role", val followerClusterRole: String = "follower_role")
 
 data class StartReplicationRequest(val leaderAlias: String, val leaderIndex: String, val toIndex: String,
-                                   val settings: Settings = Settings.EMPTY, val assumeRoles: AssumeRoles = AssumeRoles())
+                                   val settings: Settings = Settings.EMPTY, val useRoles: UseRoles = UseRoles())
 
 const val REST_REPLICATION_PREFIX = "/_plugins/_replication/"
 const val REST_REPLICATION_START = "$REST_REPLICATION_PREFIX{index}/_start"
@@ -68,9 +66,9 @@ fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
         lowLevelRequest.setJsonEntity("""{
                                        "leader_alias" : "${request.leaderAlias}",
                                        "leader_index": "${request.leaderIndex}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${request.assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${request.assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${request.useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${request.useRoles.followerClusterRole}"
                                        }
                                      }            
                                   """)
@@ -78,9 +76,9 @@ fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
         lowLevelRequest.setJsonEntity("""{
                                        "leader_alias" : "${request.leaderAlias}",
                                        "leader_index": "${request.leaderIndex}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${request.assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${request.assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${request.useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${request.useRoles.followerClusterRole}"
                                        },
                                        "settings": ${request.settings}
                                      }            
@@ -305,7 +303,7 @@ fun RestHighLevelClient.waitForReplicationStop(index: String, waitFor : TimeValu
 
 fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName: String, pattern: String,
                                                 settings: Settings = Settings.EMPTY,
-                                                assumeRoles: AssumeRoles = AssumeRoles(),
+                                                useRoles: UseRoles = UseRoles(),
                                                 requestOptions: RequestOptions = RequestOptions.DEFAULT) {
     val lowLevelRequest = Request("POST", REST_AUTO_FOLLOW_PATTERN)
     if (settings == Settings.EMPTY) {
@@ -313,9 +311,9 @@ fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName:
                                        "leader_alias" : "${connection}",
                                        "name" : "${patternName}",
                                        "pattern": "${pattern}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${useRoles.followerClusterRole}"
                                        }
                                      }""")
     } else {
@@ -323,9 +321,9 @@ fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName:
                                        "leader_alias" : "${connection}",
                                        "name" : "${patternName}",
                                        "pattern": "${pattern}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${useRoles.followerClusterRole}"
                                        },
                                        "settings": $settings
                                      }""")

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -58,7 +58,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -80,7 +80,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password")) }
@@ -118,7 +118,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = requestOptions)
@@ -149,7 +149,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -175,7 +175,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest,  waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -199,7 +199,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -231,7 +231,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
                 requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
@@ -283,7 +283,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
@@ -326,7 +326,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"),
+                    assumeRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"),
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
 
             // Verify that existing index matching the pattern are replicated.
@@ -360,7 +360,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         Assertions.assertThatThrownBy {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"),
+                    assumeRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"),
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
@@ -392,7 +392,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
@@ -47,7 +47,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleNoPerms",followerClusterRole = "followerRoleValidPerms"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleNoPerms",followerClusterRole = "followerRoleValidPerms"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser6","password")) }
@@ -66,7 +66,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -110,7 +110,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             updateFileChunkPermissions("","leaderRoleValidPerms", false)
             followerClient.startReplication(startReplicationRequest,

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
@@ -25,7 +25,6 @@ import org.opensearch.test.OpenSearchTestCase
 import org.junit.Assert
 import org.junit.Assume
 import org.junit.Before
-import org.junit.BeforeClass
 
 @MultiClusterAnnotations.ClusterConfigurations(
         MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER, forceInitSecurityConfiguration = true),
@@ -51,7 +50,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerDlsRole"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerDlsRole"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password")) }
@@ -81,7 +80,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -107,7 +106,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -140,7 +139,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
@@ -182,7 +181,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFlsRole"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFlsRole"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser4","password")) }
@@ -202,7 +201,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser5","password")) }
@@ -222,7 +221,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole2"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole2"))
         followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser7","password"))
 


### PR DESCRIPTION
### Description
Rename to useroles in all the request payloads instead of assumeroles
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
