### PR TITLE
Pause API should allow reason to be specified in the REST call.

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationRequest.kt
@@ -16,6 +16,7 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.common.ParseField
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.xcontent.ObjectParser
@@ -45,6 +46,10 @@ class PauseIndexReplicationRequest : AcknowledgedRequest<PauseIndexReplicationRe
     companion object {
         private val PARSER = ObjectParser<PauseIndexReplicationRequest, Void>("PauseReplicationRequestParser") {
             PauseIndexReplicationRequest()
+        }
+
+        init {
+            PARSER.declareString(PauseIndexReplicationRequest::reason::set, ParseField("reason"))
         }
 
         fun fromXContent(parser: XContentParser, followerIndex: String): PauseIndexReplicationRequest {

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -165,9 +165,9 @@ fun `validate not paused status aggregated response`(statusResp: Map<String, Any
     Assert.assertTrue((statusResp.getValue("syncing_details")).toString().contains("leader_checkpoint"))
 }
 
-fun `validate paused status response`(statusResp: Map<String, Any>) {
+fun `validate paused status response`(statusResp: Map<String, Any>, reason: String? = null) {
     Assert.assertEquals("PAUSED", statusResp.getValue("status"))
-    Assert.assertEquals(STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
+    Assert.assertEquals(reason ?: STATUS_REASON_USER_INITIATED, statusResp.getValue("reason"))
     Assert.assertFalse(statusResp.containsKey("shard_replication_details"))
     Assert.assertFalse(statusResp.containsKey("follower_checkpoint"))
     Assert.assertFalse(statusResp.containsKey("leader_checkpoint"))
@@ -212,9 +212,13 @@ fun RestHighLevelClient.stopReplication(index: String, shouldWait: Boolean = tru
 }
 
 
-fun RestHighLevelClient.pauseReplication(index: String, shouldWait: Boolean = true, requestOptions: RequestOptions = RequestOptions.DEFAULT) {
+fun RestHighLevelClient.pauseReplication(index: String, reason:String? = null, shouldWait: Boolean = true, requestOptions: RequestOptions = RequestOptions.DEFAULT) {
     val lowLevelPauseRequest = Request("POST", REST_REPLICATION_PAUSE.replace("{index}", index,true))
-    lowLevelPauseRequest.setJsonEntity("{}")
+    if (null == reason) {
+        lowLevelPauseRequest.setJsonEntity("{}")
+    } else {
+        lowLevelPauseRequest.setJsonEntity("{\"reason\":\"$reason\"}")
+    }
     lowLevelPauseRequest.setOptions(requestOptions)
     val lowLevelPauseResponse = lowLevelClient.performRequest(lowLevelPauseRequest)
     val response = getAckResponse(lowLevelPauseResponse)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/PauseReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/PauseReplicationIT.kt
@@ -59,10 +59,12 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
 
+            val myReason = "I want to pause!"
+
             /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
             and verify the same
              */
-            followerClient.pauseReplication(followerIndexName)
+            followerClient.pauseReplication(followerIndexName, myReason)
             // Since, we were still in FOLLOWING phase when pause was called, the index
             // in follower index should not have been deleted in follower cluster
             assertBusy {
@@ -70,6 +72,9 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
                         .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
                         .isEqualTo(true)
             }
+
+            val statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate paused status response`(statusResp, myReason)
 
             var settings = Settings.builder()
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
@@ -203,8 +208,7 @@ class PauseReplicationIT: MultiClusterRestTestCase() {
 
             followerClient.pauseReplication(followerIndexName)
 
-            followerClient.replicationStatus(followerIndexName, verbose = false)
-            var statusResp = followerClient.replicationStatus(followerIndexName)
+            val statusResp = followerClient.replicationStatus(followerIndexName)
             `validate paused status response`(statusResp)
 
         } finally {


### PR DESCRIPTION
Pause API should allow reason to be specified in the REST call.

Signed-off-by: Gopala Krishna Ambareesh <gopalak@amazon.com>
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
