### PR TITLE
Doing stop after shard tasks are up .

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -254,6 +254,18 @@ fun RestHighLevelClient.waitForReplicationStart(index: String, waitFor : TimeVal
         }, waitFor.seconds, TimeUnit.SECONDS)
 }
 
+fun RestHighLevelClient.waitForShardTaskStart(index: String, waitFor : TimeValue = TimeValue.timeValueSeconds(10)) {
+    assertBusy(
+            {
+                // Persistent tasks service appends identifiers like '[c]' to indicate child task hence the '*' wildcard
+                val request = ListTasksRequest().setDetailed(true).setActions(ShardReplicationExecutor.TASK_NAME + "*")
+                val response = tasks().list(request,RequestOptions.DEFAULT)
+                assertThat(response.tasks)
+                        .withFailMessage("replication shard tasks not started")
+                        .isNotEmpty
+            }, waitFor.seconds, TimeUnit.SECONDS)
+}
+
 fun RestHighLevelClient.leaderStats() : Map<String, Any>  {
     var request = Request("GET", REST_LEADER_STATS)
     request.setJsonEntity("{}")


### PR DESCRIPTION
Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>

### Description
Fixing integ tests which are broken due to https://github.com/opensearch-project/cross-cluster-replication/issues/152 
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
