### PR TITLE
Updated assume_roles to use_roles in all the request payloads

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/TransportAutoFollowMasterNodeAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/TransportAutoFollowMasterNodeAction.kt
@@ -68,8 +68,8 @@ class TransportAutoFollowMasterNodeAction @Inject constructor(transportService: 
                         throw ReplicationException("Failed to update empty autofollow pattern")
                     }
                     // Pattern is same for leader and follower
-                    val followerClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
-                    val leaderClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
+                    val followerClusterRole = request.useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
+                    val leaderClusterRole = request.useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
 
                     indexScopedSettings.validate(request.settings,
                             false,

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/TransportUpdateAutoFollowPatternAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/autofollow/TransportUpdateAutoFollowPatternAction.kt
@@ -58,8 +58,8 @@ class TransportUpdateAutoFollowPatternAction @Inject constructor(transportServic
             listener.completeWith {
                 if (request.action == UpdateAutoFollowPatternRequest.Action.ADD) {
                     // Pattern is same for leader and follower
-                    val followerClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
-                    val leaderClusterRole = request.assumeRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
+                    val followerClusterRole = request.useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)
+                    val leaderClusterRole = request.useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)
                     val setupChecksRequest = SetupChecksRequest(ReplicationContext(request.pattern!!, user?.overrideFgacRole(followerClusterRole)),
                             ReplicationContext(request.pattern!!, user?.overrideFgacRole(leaderClusterRole)),
                             request.connection)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexRequest.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/ReplicateIndexRequest.kt
@@ -42,7 +42,7 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
     lateinit var followerIndex: String
     lateinit var leaderAlias: String
     lateinit var leaderIndex: String
-    var assumeRoles: HashMap<String, String>? = null // roles to assume - {leader_fgac_role: role1, follower_fgac_role: role2}
+    var useRoles: HashMap<String, String>? = null // roles to use - {leader_fgac_role: role1, follower_fgac_role: role2}
     // Used for integ tests to wait until the restore from leader cluster completes
     var waitForRestore: Boolean = false
     // Triggered from autofollow to skip permissions check based on user as this is already validated
@@ -64,17 +64,17 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
         const val LEADER_CLUSTER_ROLE = "leader_cluster_role"
         const val FOLLOWER_CLUSTER_ROLE = "follower_cluster_role"
         private val INDEX_REQ_PARSER = ObjectParser<ReplicateIndexRequest, Void>("FollowIndexRequestParser") { ReplicateIndexRequest() }
-        val FGAC_ROLES_PARSER = ObjectParser<HashMap<String, String>, Void>("AssumeRolesParser") { HashMap() }
+        val FGAC_ROLES_PARSER = ObjectParser<HashMap<String, String>, Void>("UseRolesParser") { HashMap() }
         init {
-            FGAC_ROLES_PARSER.declareStringOrNull({assumeRoles: HashMap<String, String>, role: String -> assumeRoles[LEADER_CLUSTER_ROLE] = role},
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[LEADER_CLUSTER_ROLE] = role},
                     ParseField(LEADER_CLUSTER_ROLE))
-            FGAC_ROLES_PARSER.declareStringOrNull({assumeRoles: HashMap<String, String>, role: String -> assumeRoles[FOLLOWER_CLUSTER_ROLE] = role},
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[FOLLOWER_CLUSTER_ROLE] = role},
                     ParseField(FOLLOWER_CLUSTER_ROLE))
 
             INDEX_REQ_PARSER.declareString(ReplicateIndexRequest::leaderAlias::set, ParseField("leader_alias"))
             INDEX_REQ_PARSER.declareString(ReplicateIndexRequest::leaderIndex::set, ParseField("leader_index"))
-            INDEX_REQ_PARSER.declareObjectOrDefault(BiConsumer {reqParser: ReplicateIndexRequest, roles: HashMap<String, String> -> reqParser.assumeRoles = roles},
-                    FGAC_ROLES_PARSER, null, ParseField("assume_roles"))
+            INDEX_REQ_PARSER.declareObjectOrDefault(BiConsumer {reqParser: ReplicateIndexRequest, roles: HashMap<String, String> -> reqParser.useRoles = roles},
+                    FGAC_ROLES_PARSER, null, ParseField("use_roles"))
             INDEX_REQ_PARSER.declareObjectOrDefault(BiConsumer{ request: ReplicateIndexRequest, settings: Settings -> request.settings = settings}, BiFunction{ p: XContentParser?, c: Void? -> Settings.fromXContent(p) },
                     null, ParseField(KEY_SETTINGS))
         }
@@ -83,8 +83,8 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
         fun fromXContent(parser: XContentParser, followerIndex: String): ReplicateIndexRequest {
             val followIndexRequest = INDEX_REQ_PARSER.parse(parser, null)
             followIndexRequest.followerIndex = followerIndex
-            if(followIndexRequest.assumeRoles?.size == 0) {
-                followIndexRequest.assumeRoles = null
+            if(followIndexRequest.useRoles?.size == 0) {
+                followIndexRequest.useRoles = null
             }
 
             if (followIndexRequest.settings == null) {
@@ -106,8 +106,8 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
         validateName(leaderIndex, validationException)
         validateName(followerIndex, validationException)
 
-        if(assumeRoles != null && (assumeRoles!!.size < 2 || assumeRoles!![LEADER_CLUSTER_ROLE] == null ||
-                assumeRoles!![FOLLOWER_CLUSTER_ROLE] == null)) {
+        if(useRoles != null && (useRoles!!.size < 2 || useRoles!![LEADER_CLUSTER_ROLE] == null ||
+                useRoles!![FOLLOWER_CLUSTER_ROLE] == null)) {
             validationException.addValidationError("Need roles for $LEADER_CLUSTER_ROLE and $FOLLOWER_CLUSTER_ROLE")
         }
         return if(validationException.validationErrors().isEmpty()) return null else validationException
@@ -132,9 +132,9 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
 
         var leaderClusterRole = inp.readOptionalString()
         var followerClusterRole = inp.readOptionalString()
-        assumeRoles = HashMap()
-        if(leaderClusterRole != null) assumeRoles!![LEADER_CLUSTER_ROLE] = leaderClusterRole
-        if(followerClusterRole != null) assumeRoles!![FOLLOWER_CLUSTER_ROLE] = followerClusterRole
+        useRoles = HashMap()
+        if(leaderClusterRole != null) useRoles!![LEADER_CLUSTER_ROLE] = leaderClusterRole
+        if(followerClusterRole != null) useRoles!![FOLLOWER_CLUSTER_ROLE] = followerClusterRole
 
         waitForRestore = inp.readBoolean()
         isAutoFollowRequest = inp.readBoolean()
@@ -147,8 +147,8 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
         out.writeString(leaderAlias)
         out.writeString(leaderIndex)
         out.writeString(followerIndex)
-        out.writeOptionalString(assumeRoles?.get(LEADER_CLUSTER_ROLE))
-        out.writeOptionalString(assumeRoles?.get(FOLLOWER_CLUSTER_ROLE))
+        out.writeOptionalString(useRoles?.get(LEADER_CLUSTER_ROLE))
+        out.writeOptionalString(useRoles?.get(FOLLOWER_CLUSTER_ROLE))
         out.writeBoolean(waitForRestore)
         out.writeBoolean(isAutoFollowRequest)
 
@@ -161,11 +161,11 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
         builder.field("leader_alias", leaderAlias)
         builder.field("leader_index", leaderIndex)
         builder.field("follower_index", followerIndex)
-        if(assumeRoles != null && assumeRoles!!.size == 2) {
-            builder.field("assume_roles")
+        if(useRoles != null && useRoles!!.size == 2) {
+            builder.field("use_roles")
             builder.startObject()
-            builder.field(LEADER_CLUSTER_ROLE, assumeRoles!![LEADER_CLUSTER_ROLE])
-            builder.field(FOLLOWER_CLUSTER_ROLE, assumeRoles!![FOLLOWER_CLUSTER_ROLE])
+            builder.field(LEADER_CLUSTER_ROLE, useRoles!![LEADER_CLUSTER_ROLE])
+            builder.field(FOLLOWER_CLUSTER_ROLE, useRoles!![FOLLOWER_CLUSTER_ROLE])
             builder.endObject()
         }
         builder.field("wait_for_restore", waitForRestore)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -40,7 +40,6 @@ import org.elasticsearch.common.inject.Inject
 import org.elasticsearch.env.Environment
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.index.IndexSettings
-import org.elasticsearch.indices.InvalidIndexNameException
 import org.elasticsearch.tasks.Task
 import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.TransportService
@@ -65,9 +64,9 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
             listener.completeWith {
 
                 val followerReplContext = ReplicationContext(request.followerIndex,
-                        user?.overrideFgacRole(request.assumeRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)))
+                        user?.overrideFgacRole(request.useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE)))
                 val leaderReplContext = ReplicationContext(request.leaderIndex,
-                        user?.overrideFgacRole(request.assumeRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)))
+                        user?.overrideFgacRole(request.useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE)))
 
                 // For autofollow request, setup checks are already made during addition of the pattern with
                 // original user

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexMasterNodeAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexMasterNodeAction.kt
@@ -106,8 +106,8 @@ class TransportReplicateIndexMasterNodeAction @Inject constructor(transportServi
 
                 replicationMetadataManager.addIndexReplicationMetadata(replicateIndexReq.followerIndex,
                         replicateIndexReq.leaderAlias, replicateIndexReq.leaderIndex,
-                        ReplicationOverallState.RUNNING, user, replicateIndexReq.assumeRoles?.getOrDefault(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE, null),
-                        replicateIndexReq.assumeRoles?.getOrDefault(ReplicateIndexRequest.LEADER_CLUSTER_ROLE, null), replicateIndexReq.settings)
+                        ReplicationOverallState.RUNNING, user, replicateIndexReq.useRoles?.getOrDefault(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE, null),
+                        replicateIndexReq.useRoles?.getOrDefault(ReplicateIndexRequest.LEADER_CLUSTER_ROLE, null), replicateIndexReq.settings)
 
                 val task = persistentTasksService.startTask("replication:index:${replicateIndexReq.followerIndex}",
                         IndexReplicationExecutor.TASK_NAME, params)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/setup/TransportSetupChecksAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/setup/TransportSetupChecksAction.kt
@@ -140,21 +140,21 @@ class TransportSetupChecksAction @Inject constructor(transportService: Transport
     private fun triggerPermissionsValidation(client: Client,
                                              cluster: String,
                                              replContext: ReplicationContext,
-                                             shouldAssumeRole: Boolean,
+                                             shouldUseRole: Boolean,
                                              permissionListener: ActionListener<AcknowledgedResponse>) {
 
         var storedContext: ThreadContext.StoredContext? = null
         try {
-            // Remove the assume roles transient from the previous call
+            // Remove the use roles transient from the previous call
             storedContext = client.threadPool().threadContext.newStoredContext(false,
-                    listOf(SecurityContext.OPENDISTRO_SECURITY_ASSUME_ROLES))
-            val assumeRole = replContext.user?.roles?.get(0)
-            val inThreadContextRole = client.threadPool().threadContext.getTransient<String?>(SecurityContext.OPENDISTRO_SECURITY_ASSUME_ROLES)
-            log.debug("assume role is $inThreadContextRole for $cluster")
-            if(shouldAssumeRole) {
-                client.threadPool().threadContext.putTransient(SecurityContext.OPENDISTRO_SECURITY_ASSUME_ROLES, assumeRole)
+                    listOf(SecurityContext.OPENDISTRO_SECURITY_ROLES_VALIDATION))
+            val useRole = replContext.user?.roles?.get(0)
+            val inThreadContextRole = client.threadPool().threadContext.getTransient<String?>(SecurityContext.OPENDISTRO_SECURITY_ROLES_VALIDATION)
+            log.debug("use_role is $inThreadContextRole for $cluster")
+            if(shouldUseRole) {
+                client.threadPool().threadContext.putTransient(SecurityContext.OPENDISTRO_SECURITY_ROLES_VALIDATION, useRole)
             }
-            val validateReq = ValidatePermissionsRequest(cluster, replContext.resource, assumeRole)
+            val validateReq = ValidatePermissionsRequest(cluster, replContext.resource, useRole)
             client.execute(ValidatePermissionsAction.INSTANCE, validateReq, permissionListener)
         } finally {
             storedContext?.close()

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
@@ -139,9 +139,9 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
             val followerRole = replicationMetadata.followerContext?.user?.roles?.get(0)
             val leaderRole = replicationMetadata.leaderContext?.user?.roles?.get(0)
             if(followerRole != null && leaderRole != null) {
-                request.assumeRoles = HashMap<String, String>()
-                request.assumeRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerRole
-                request.assumeRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] = leaderRole
+                request.useRoles = HashMap<String, String>()
+                request.useRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerRole
+                request.useRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] = leaderRole
             }
             request.settings = replicationMetadata.settings
             val response = client.suspendExecute(replicationMetadata, ReplicateIndexAction.INSTANCE, request)

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/SecurityContext.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/SecurityContext.kt
@@ -42,7 +42,7 @@ class SecurityContext {
     companion object {
         private val log = LogManager.getLogger(SecurityContext::class.java)
         const val OPENDISTRO_SECURITY_USER = "_opendistro_security_user"
-        const val OPENDISTRO_SECURITY_ASSUME_ROLES = "opendistro_security_assume_roles"
+        const val OPENDISTRO_SECURITY_ROLES_VALIDATION = "opendistro_security_injected_roles_validation"
         const val REPLICATION_PLUGIN_USER = "ccr_user"
 
         val ADMIN_USER = User(REPLICATION_PLUGIN_USER, null, listOf("all_access"), null)

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -21,7 +21,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
-import org.elasticsearch.client.HttpAsyncResponseConsumerFactory.HeapBufferedResponseConsumerFactory
 import org.elasticsearch.client.Request
 import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.Response
@@ -37,10 +36,10 @@ import org.junit.Assert
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
-data class AssumeRoles(val leaderClusterRole: String = "leader_role", val followerClusterRole: String = "follower_role")
+data class UseRoles(val leaderClusterRole: String = "leader_role", val followerClusterRole: String = "follower_role")
 
 data class StartReplicationRequest(val leaderAlias: String, val leaderIndex: String, val toIndex: String,
-                                   val settings: Settings = Settings.EMPTY, val assumeRoles: AssumeRoles = AssumeRoles())
+                                   val settings: Settings = Settings.EMPTY, val useRoles: UseRoles = UseRoles())
 
 const val REST_REPLICATION_PREFIX = "/_plugins/_replication/"
 const val REST_REPLICATION_START = "$REST_REPLICATION_PREFIX{index}/_start"
@@ -71,9 +70,9 @@ fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
         lowLevelRequest.setJsonEntity("""{
                                        "leader_alias" : "${request.leaderAlias}",
                                        "leader_index": "${request.leaderIndex}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${request.assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${request.assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${request.useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${request.useRoles.followerClusterRole}"
                                        }
                                      }            
                                   """)
@@ -81,9 +80,9 @@ fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
         lowLevelRequest.setJsonEntity("""{
                                        "leader_alias" : "${request.leaderAlias}",
                                        "leader_index": "${request.leaderIndex}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${request.assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${request.assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${request.useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${request.useRoles.followerClusterRole}"
                                        },
                                        "settings": ${request.settings}
                                      }            
@@ -312,7 +311,7 @@ fun RestHighLevelClient.waitForReplicationStop(index: String, waitFor : TimeValu
 
 fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName: String, pattern: String,
                                                 settings: Settings = Settings.EMPTY,
-                                                assumeRoles: AssumeRoles = AssumeRoles(),
+                                                useRoles: UseRoles = UseRoles(),
                                                 requestOptions: RequestOptions = RequestOptions.DEFAULT) {
     val lowLevelRequest = Request("POST", REST_AUTO_FOLLOW_PATTERN)
     if (settings == Settings.EMPTY) {
@@ -320,9 +319,9 @@ fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName:
                                        "leader_alias" : "${connection}",
                                        "name" : "${patternName}",
                                        "pattern": "${pattern}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${useRoles.followerClusterRole}"
                                        }
                                      }""")
     } else {
@@ -330,9 +329,9 @@ fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName:
                                        "leader_alias" : "${connection}",
                                        "name" : "${patternName}",
                                        "pattern": "${pattern}",
-                                       "assume_roles": {
-                                        "leader_cluster_role": "${assumeRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${assumeRoles.followerClusterRole}"
+                                       "use_roles": {
+                                        "leader_cluster_role": "${useRoles.leaderClusterRole}",
+                                        "follower_cluster_role": "${useRoles.followerClusterRole}"
                                        },
                                        "settings": $settings
                                      }""")

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -47,7 +47,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -69,7 +69,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password")) }
@@ -107,7 +107,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = requestOptions)
@@ -138,7 +138,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -164,7 +164,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest,  waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -188,7 +188,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -220,7 +220,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
                 requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
@@ -272,7 +272,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
@@ -315,7 +315,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"),
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"),
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
 
             // Verify that existing index matching the pattern are replicated.
@@ -349,7 +349,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         Assertions.assertThatThrownBy {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"),
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"),
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
@@ -381,7 +381,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
@@ -36,7 +36,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleNoPerms",followerClusterRole = "followerRoleValidPerms"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleNoPerms",followerClusterRole = "followerRoleValidPerms"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser6","password")) }
@@ -55,7 +55,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -99,7 +99,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             updateFileChunkPermissions("","leaderRoleValidPerms", false)
             followerClient.startReplication(startReplicationRequest,

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/SecurityDlsFlsIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/SecurityDlsFlsIT.kt
@@ -14,7 +14,6 @@ import org.elasticsearch.test.ESTestCase
 import org.junit.Assert
 import org.junit.Assume
 import org.junit.Before
-import org.junit.BeforeClass
 
 @MultiClusterAnnotations.ClusterConfigurations(
         MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER, forceInitSecurityConfiguration = true),
@@ -40,7 +39,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerDlsRole"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerDlsRole"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password")) }
@@ -70,7 +69,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -96,7 +95,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
@@ -129,7 +128,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                    assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
@@ -171,7 +170,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFlsRole"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFlsRole"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser4","password")) }
@@ -191,7 +190,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser5","password")) }
@@ -211,7 +210,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                assumeRoles = AssumeRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole2"))
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole2"))
         followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser7","password"))
 


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Updated assume_roles to use_roles in all the request payloads
- Backport to https://github.com/opensearch-project/cross-cluster-replication/pull/136
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
