### PR TITLE
Blocked k-NN index for replication

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
@@ -153,6 +153,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
     companion object {
         const val REPLICATION_EXECUTOR_NAME_LEADER = "replication_leader"
         const val REPLICATION_EXECUTOR_NAME_FOLLOWER = "replication_follower"
+        const val KNN_INDEX_SETTING = "index.knn"
         val REPLICATED_INDEX_SETTING: Setting<String> = Setting.simpleString("index.plugins.replication.replicated",
             Setting.Property.InternalIndex, Setting.Property.IndexScope)
         val REPLICATION_FOLLOWER_OPS_BATCH_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.follower.index.ops_batch_size", 50000, 16,

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -17,6 +17,7 @@ package com.amazon.elasticsearch.replication.action.index
 
 import com.amazon.elasticsearch.replication.ReplicationException
 import com.amazon.elasticsearch.replication.ReplicationPlugin
+import com.amazon.elasticsearch.replication.ReplicationPlugin.Companion.KNN_INDEX_SETTING
 import com.amazon.elasticsearch.replication.action.setup.SetupChecksAction
 import com.amazon.elasticsearch.replication.action.setup.SetupChecksRequest
 import com.amazon.elasticsearch.replication.metadata.store.ReplicationContext
@@ -95,6 +96,13 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                 if (!leaderSettings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.key, true)) {
                     throw IllegalArgumentException("Cannot Replicate an index where the setting ${IndexSettings.INDEX_SOFT_DELETES_SETTING.key} is disabled")
                 }
+
+                // For k-NN indices, k-NN loads its own engine and this conflicts with the replication follower engine
+                // Blocking k-NN indices for replication
+                if(leaderSettings.getAsBoolean(KNN_INDEX_SETTING, false)) {
+                    throw IllegalArgumentException("Cannot Replicate k-NN index - ${request.leaderIndex}")
+                }
+
                 ValidationUtil.validateAnalyzerSettings(environment, leaderSettings, request.settings)
 
                 // Setup checks are successful and trigger replication for the index


### PR DESCRIPTION
### Description
Blocked k-NN index for replication

UTs - https://github.com/opensearch-project/cross-cluster-replication/issues/159
 
### Issues Resolved

```
amazon.opendistroforelasticsearch.knn.plugin.KNNEngineFactory]]], allocation_status[fetching_shard_data]], expected_shard_size[208], message [failed to create index], failure [IllegalStateException[multiple engine factories provided for [leader-test-knn/XPgNHnwCT_-Yj3QcuxqRyQ]: [com.amazon.elasticsearch.replication.ReplicationPlugin$getEngineFactory$1],[com.amazon.opendistroforelasticsearch.knn.plugin.KNNEngineFactory]]], markAsStale [true]]
java.lang.IllegalStateException: multiple engine factories provided for [leader-test-knn/XPgNHnwCT_-Yj3QcuxqRyQ]: [com.amazon.elasticsearch.replication.ReplicationPlugin$getEngineFactory$1],[com.amazon.opendistroforelasticsearch.knn.plugin.KNNEngineFactory]
        at org.elasticsearch.indices.IndicesService.getEngineFactory(IndicesService.java:705)
        at org.elasticsearch.indices.IndicesService.createIndexService(IndicesService.java:646)
        at org.elasticsearch.indices.IndicesService.createIndex(IndicesService.java:558)
        at org.elasticsearch.indices.IndicesService.createIndex(IndicesService.java:177)
        at org.elasticsearch.indices.cluster.IndicesClusterStateService.createIndices(In
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
