### PR TITLE
Blocked k-NN index for replication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,6 @@ def securityPluginFile = new Callable<RegularFile>() {
         }
     }
 
-
 // Clone of WaitForHttpResource with updated code to support Cross cluster usecase
 class CrossClusterWaitForHttpResource {
 

--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -151,6 +151,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
     companion object {
         const val REPLICATION_EXECUTOR_NAME_LEADER = "replication_leader"
         const val REPLICATION_EXECUTOR_NAME_FOLLOWER = "replication_follower"
+        const val KNN_INDEX_SETTING = "index.knn"
         val REPLICATED_INDEX_SETTING: Setting<String> = Setting.simpleString("index.plugins.replication.replicated",
             Setting.Property.InternalIndex, Setting.Property.IndexScope)
         val REPLICATION_FOLLOWER_OPS_BATCH_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.follower.index.ops_batch_size", 50000, 16,

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -35,6 +35,7 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.env.Environment
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.IndexSettings
+import org.opensearch.replication.ReplicationPlugin.Companion.KNN_INDEX_SETTING
 import org.opensearch.tasks.Task
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
@@ -89,6 +90,13 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                 if (!leaderSettings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.key, true)) {
                     throw IllegalArgumentException("Cannot Replicate an index where the setting ${IndexSettings.INDEX_SOFT_DELETES_SETTING.key} is disabled")
                 }
+
+                // For k-NN indices, k-NN loads its own engine and this conflicts with the replication follower engine
+                // Blocking k-NN indices for replication
+                if(leaderSettings.getAsBoolean(KNN_INDEX_SETTING, false)) {
+                    throw IllegalArgumentException("Cannot Replicate k-NN index - ${request.leaderIndex}")
+                }
+
                 ValidationUtil.validateAnalyzerSettings(environment, leaderSettings, request.settings)
 
                 // Setup checks are successful and trigger replication for the index

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -94,7 +94,7 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                 // For k-NN indices, k-NN loads its own engine and this conflicts with the replication follower engine
                 // Blocking k-NN indices for replication
                 if(leaderSettings.getAsBoolean(KNN_INDEX_SETTING, false)) {
-                    throw IllegalArgumentException("Cannot Replicate k-NN index - ${request.leaderIndex}")
+                    throw IllegalArgumentException("Cannot replicate k-NN index - ${request.leaderIndex}")
                 }
 
                 ValidationUtil.validateAnalyzerSettings(environment, leaderSettings, request.settings)

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -105,7 +105,7 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
                 // k-NN Setting is a static setting. In case the setting is changed at the leader index before resume,
                 // block the resume.
                 if(leaderSettings.getAsBoolean(KNN_INDEX_SETTING, false)) {
-                    throw IllegalStateException("Index setting (index.knn) changed. Cannot resume k-NN index - ${params.leaderIndex.name}")
+                    throw IllegalStateException("Cannot resume replication for k-NN enabled index ${params.leaderIndex.name}.")
                 }
 
                 ValidationUtil.validateAnalyzerSettings(environment, leaderSettings, replMetdata.settings)


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Blocked k-NN index for replication

UTs - https://github.com/opensearch-project/cross-cluster-replication/issues/159
 
### Issues Resolved
```
amazon.opendistroforelasticsearch.knn.plugin.KNNEngineFactory]]], allocation_status[fetching_shard_data]], expected_shard_size[208], message [failed to create index], failure [IllegalStateException[multiple engine factories provided for [leader-test-knn/XPgNHnwCT_-Yj3QcuxqRyQ]: [com.amazon.elasticsearch.replication.ReplicationPlugin$getEngineFactory$1],[com.amazon.opendistroforelasticsearch.knn.plugin.KNNEngineFactory]]], markAsStale [true]]
java.lang.IllegalStateException: multiple engine factories provided for [leader-test-knn/XPgNHnwCT_-Yj3QcuxqRyQ]: [com.amazon.elasticsearch.replication.ReplicationPlugin$getEngineFactory$1],[com.amazon.opendistroforelasticsearch.knn.plugin.KNNEngineFactory]
        at org.elasticsearch.indices.IndicesService.getEngineFactory(IndicesService.java:705)
        at org.elasticsearch.indices.IndicesService.createIndexService(IndicesService.java:646)
        at org.elasticsearch.indices.IndicesService.createIndex(IndicesService.java:558)
        at org.elasticsearch.indices.IndicesService.createIndex(IndicesService.java:177)
        at org.elasticsearch.indices.cluster.IndicesClusterStateService.createIndices(In

```
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
