### PR TITLE
Reverting "5a64bc0" - OS Translog Setting name

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/index/IndexReplicationTask.kt
@@ -136,7 +136,7 @@ class IndexReplicationTask(id: Long, type: String, action: String, description: 
     private var metadataPoller: Job? = null
     companion object {
         val blSettings  : Set<Setting<*>> = setOf(
-                INDEX_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING,
+                IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING,
                 IndexMetadata.INDEX_READ_ONLY_SETTING,
                 IndexMetadata.INDEX_BLOCKS_READ_SETTING,
                 IndexMetadata.INDEX_BLOCKS_WRITE_SETTING,


### PR DESCRIPTION
### Description
Reverting "5a64bc0" - OS Translog Setting name
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
