### PR TITLE
Gracefully fail replication on bootstrap failure.

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
@@ -95,7 +95,7 @@ class TransportPauseIndexReplicationAction @Inject constructor(transportService:
         if (replicationOverallState == ReplicationOverallState.PAUSED.name)
             throw ResourceAlreadyExistsException("Index ${request.indexName} is already paused")
         else if (replicationOverallState != ReplicationOverallState.RUNNING.name)
-            throw IllegalStateException("Unknown value of replication state:$replicationOverallState")
+            throw IllegalStateException("Cannot pause when in $replicationOverallState state")
     }
 
     override fun executor(): String {

--- a/src/main/kotlin/org/opensearch/replication/action/status/TransportReplicationStatusAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/status/TransportReplicationStatusAction.kt
@@ -48,7 +48,6 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
             listener.completeWith {
                 try {
                     val metadata = replicationMetadataManager.getIndexReplicationMetadata(request!!.indices()[0])
-                    val remoteClient = client.getRemoteClusterClient(metadata.connectionName)
                     var status = if (metadata.overallState.isNullOrEmpty()) "STOPPED" else metadata.overallState
                     var reason = metadata.reason
                     if (!status.equals("RUNNING")) {
@@ -62,6 +61,7 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
                     }
                     var followerResponse = client.suspendExecute(ShardsInfoAction.INSTANCE,
                             ShardInfoRequest(metadata.followerContext.resource),true)
+                    val remoteClient = client.getRemoteClusterClient(metadata.connectionName)
                     var leaderResponse = remoteClient.suspendExecute(ShardsInfoAction.INSTANCE,
                             ShardInfoRequest(metadata.leaderContext.resource),true)
 

--- a/src/main/kotlin/org/opensearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
@@ -87,7 +87,7 @@ class TransportUpdateIndexReplicationAction @Inject constructor(transportService
         if (replicationOverallState == ReplicationOverallState.RUNNING.name || replicationOverallState == ReplicationOverallState.PAUSED.name)
             return
 
-        throw IllegalStateException("Unknown value of replication state:$replicationOverallState")
+        throw IllegalStateException("Cannot update settings when in $replicationOverallState state")
     }
 
     override fun executor(): String {


### PR DESCRIPTION
Gracefully fail replication on bootstrap failure.

While at it, also support Stopping FAILED index (mainly cleanup) and
handle FAILED state in other actions.

Signed-off-by: Gopala Krishna Ambareesh <gopalak@amazon.com>
 
### Check List
- [ ] New functionality includes testing. (Manually tested as we don't have primitives to simulate failed replication)
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
