### PR TITLE
[Backport of PR#166] Gracefully fail replication on bootstrap failure.

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
@@ -99,7 +99,7 @@ class TransportPauseIndexReplicationAction @Inject constructor(transportService:
         if (replicationOverallState == ReplicationOverallState.PAUSED.name)
             throw ResourceAlreadyExistsException("Index ${request.indexName} is already paused")
         else if (replicationOverallState != ReplicationOverallState.RUNNING.name)
-            throw IllegalStateException("Unknown value of replication state:$replicationOverallState")
+            throw IllegalStateException("Cannot pause when in $replicationOverallState state")
     }
 
     override fun executor(): String {

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/TransportReplicationStatusAction.kt
@@ -37,7 +37,6 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
             listener.completeWith {
                 try {
                     val metadata = replicationMetadataManager.getIndexReplicationMetadata(request!!.indices()[0])
-                    val remoteClient = client.getRemoteClusterClient(metadata.connectionName)
                     var status = if (metadata.overallState.isNullOrEmpty()) "STOPPED" else metadata.overallState
                     var reason = metadata.reason
                     if (!status.equals("RUNNING")) {
@@ -51,6 +50,7 @@ class TransportReplicationStatusAction @Inject constructor(transportService: Tra
                     }
                     var followerResponse = client.suspendExecute(ShardsInfoAction.INSTANCE,
                             ShardInfoRequest(metadata.followerContext.resource),true)
+                    val remoteClient = client.getRemoteClusterClient(metadata.connectionName)
                     var leaderResponse = remoteClient.suspendExecute(ShardsInfoAction.INSTANCE,
                             ShardInfoRequest(metadata.leaderContext.resource),true)
 

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -94,13 +94,16 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
         launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
             try {
                 log.info("Stopping index replication on index:" + request.indexName)
-                val isPaused = validateStopReplicationRequest(request)
 
+                // NOTE: We remove the block first before validation since it is harmless idempotent operations and
+                //       gives back control of the index even if any failure happens in one of the steps post this.
                 val updateIndexBlockRequest = UpdateIndexBlockRequest(request.indexName,IndexBlockUpdateType.REMOVE_BLOCK)
                 val updateIndexBlockResponse = client.suspendExecute(UpdateIndexBlockAction.INSTANCE, updateIndexBlockRequest, injectSecurityContext = true)
                 if(!updateIndexBlockResponse.isAcknowledged) {
                     throw ElasticsearchException("Failed to remove index block on ${request.indexName}")
                 }
+
+                val isPaused = validateStopReplicationRequest(request)
 
                 // Index will be deleted if replication is stopped while it is restoring.  So no need to close/reopen
                 val restoring = clusterService.state().custom<RestoreInProgress>(RestoreInProgress.TYPE, RestoreInProgress.EMPTY).any { entry ->
@@ -184,10 +187,12 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                 ?:
             throw IllegalArgumentException("No replication in progress for index:${request.indexName}")
         val replicationOverallState = replicationStateParams[REPLICATION_LAST_KNOWN_OVERALL_STATE]
-        if (replicationOverallState == ReplicationOverallState.RUNNING.name)
-            return false
-        else if (replicationOverallState == ReplicationOverallState.PAUSED.name)
+        if (replicationOverallState == ReplicationOverallState.PAUSED.name)
             return true
+        else if (replicationOverallState == ReplicationOverallState.RUNNING.name ||
+            replicationOverallState == ReplicationOverallState.STOPPED.name ||
+            replicationOverallState == ReplicationOverallState.FAILED.name)
+            return false
         throw IllegalStateException("Unknown value of replication state:$replicationOverallState")
     }
 

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
@@ -91,7 +91,7 @@ class TransportUpdateIndexReplicationAction @Inject constructor(transportService
         if (replicationOverallState == ReplicationOverallState.RUNNING.name || replicationOverallState == ReplicationOverallState.PAUSED.name)
             return
 
-        throw IllegalStateException("Unknown value of replication state:$replicationOverallState")
+        throw IllegalStateException("Cannot update settings when in $replicationOverallState state")
     }
 
     override fun executor(): String {


### PR DESCRIPTION
[Backport of [PR#166](https://github.com/opensearch-project/cross-cluster-replication/pull/166)] Gracefully fail replication on bootstrap failure.

While at it, also support Stopping FAILED index (mainly cleanup) and
handle FAILED state in other actions.

Signed-off-by: Gopala Krishna Ambareesh <gopalak@amazon.com>
 
### Check List
- [ ] New functionality includes testing. (Manually tested as we don't have primitives to simulate failed replication) 
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
