### PR TITLE
Do not add retention lease inside ShardReplicationTask

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -123,7 +123,6 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
     override val log = Loggers.getLogger(javaClass, Index(params.followerIndexName, ClusterState.UNKNOWN_UUID))
     private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
-
     private var shouldCallEvalMonitoring = true
     private var updateSettingsContinuousFailCount = 0
     private var updateAliasContinousFailCount = 0

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -70,7 +70,6 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
     private val followerShardId = params.followerShardId
     private val remoteClient = client.getRemoteClusterClient(leaderAlias)
     private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
-    private var paused = false
     private var lastLeaseRenewalMillis = System.currentTimeMillis()
 
     //Start backOff for exceptions with a second
@@ -169,11 +168,6 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
          */
         clusterService.removeListener(clusterStateListenerForTaskInterruption)
         this.followerClusterStats.stats.remove(followerShardId)
-        if (paused) {
-            logDebug("Pausing and not removing lease for index $followerIndexName and shard $followerShardId task")
-            return
-        }
-        retentionLeaseHelper.attemptRetentionLeaseRemoval(leaderShardId, followerShardId)
     }
 
     private fun addListenerToInterruptTask() {
@@ -190,7 +184,6 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                         cancelTask("Shard replication task received an interrupt.")
                 } else if (replicationStateParams[REPLICATION_LAST_KNOWN_OVERALL_STATE] == ReplicationOverallState.PAUSED.name){
                     logInfo("Pause state received for index $followerIndexName. Cancelling $followerShardId task")
-                    paused = true
                     cancelTask("Shard replication task received pause.")
                 }
             }
@@ -204,14 +197,15 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
         updateTaskState(FollowingState)
         val followerIndexService = indicesService.indexServiceSafe(followerShardId.index)
         val indexShard = followerIndexService.getShard(followerShardId.id)
-        // Adding retention lease at lastSyncedGlobalCheckpoint. This makes sure
-        // new tasks spawned after node changes/shard movements are handled properly
+
         try {
-            logInfo("Adding retention lease")
-            retentionLeaseHelper.addRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint, followerShardId)
-        } catch (e: RetentionLeaseInvalidRetainingSeqNoException) {
-            logInfo("Retention lease add failed. Ignoring ${e.stackTraceToString()}")
+            retentionLeaseHelper.renewRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint, followerShardId)
+        } catch (ex: Exception) {
+            // In case of a failure, we just log it and move on. All failures scenarios are being handled below with
+            // retries and backoff depending on exception.
+            log.error("Retention lease renewal failed: ${ex.stackTraceToString()}")
         }
+
         addListenerToInterruptTask()
         this.followerClusterStats.stats[followerShardId] = FollowerShardMetric()
 


### PR DESCRIPTION
### Description
Removing the redundant addRetentionLease in ShardReplicationTask.

Since we add retention lease during bootstrap, we shouldn't ever have to addRetentionLease in ShardReplicationTask.

Motivation behind this change is an edge case where the leader index get restored using snapshot while follower's master node is down. In this case, ShardReplication would fail as soon as leader index gets closed. But failed state for the task won't be logged as master is unreachable. Thus whenever follower's master node comes up, IndexReplicationTask will respawn the failed shard replication task. At this stage leader checkpoint(let's say X) can even be at a lower checkpoint than follower shard(lets say Y) as leader has been restore to a previous state. On top of that, if there were any operations replayed on leader while follower's ShardReplicationTask is down, part of those changes won't ever be fetched on the follower(from X+1 to Y) leading to data inconsistency. 

Ideally we should be failing the replication whenever the snapshot restore happens on the leader. With this change, we're banking on the fact that retention lease would be cleared up with snapshot restore and follower index would take up new lease only if it again goes through bootstrap phase.


### Changes done
- Remove retention lease add in Shard Replication task initialisation.
- Remove retention lease removal in Shard Replication task cancellation workflow.
- Add retention lease removal on IndexReplicationTask cancellation(except for paused state)

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
