### PR TITLE
Handle case when leader index mapping is not available

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/MappingNotAvailableException.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/MappingNotAvailableException.kt
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package com.amazon.elasticsearch.replication;
+
+import org.elasticsearch.ElasticsearchException
+
+public class MappingNotAvailableException: ElasticsearchException {
+
+    constructor(message: String, vararg args: Any) : super(message, *args)
+
+    constructor(message: String, cause: Throwable, vararg args: Any) : super(message,  cause, *args)
+}


### PR DESCRIPTION
### Description
In case of large documents, leader mapping is not immediately available which causes an NPE in the TranslogSequencer and fails the shard task. The replication gets autopaused as a result. Adding handling to check whether mapping is available.If mapping is not available, throwing an Exception so that the call can be retried.

ES Logs from the testing below:
```
[2021-09-29T07:33:18,485][ERROR][c.a.e.r.a.r.TransportReplayChangesAction] [8a8f101a677b853ca27a2b05ca2f5038] Mapping response: {"gd-autofollow-1":{"mappings":{}}}
[2021-09-29T07:33:18,486][WARN ][c.a.e.r.t.s.TranslogSequencer] [8a8f101a677b853ca27a2b05ca2f5038] [gd-autofollow-1][0] Encountered a failure while executing in ReplayChangesRequest[changes=<[Index{id='9Or5MXwBrtWOcEpCXXVa', type='_doc', seqNo=0, primaryTerm=1, version=1, autoGeneratedIdTimestamp=1632925998426}, Index{id='9er5MXwBrtWOcEpCXXVa', type='_doc', seqNo=1, primaryTerm=1, version=1, autoGeneratedIdTimestamp=1632925998426}, Index{id='9ur5MXwBrtWOcEpCXXVa', type='_doc', seqNo=2, primaryTerm=1, version=1, autoGeneratedIdTimestamp=1632925998426}]]. Retrying in 10 seconds.
MappingNotAvailableException[Mapping for the index gd-autofollow-1 is not available]
        at com.amazon.elasticsearch.replication.action.replay.TransportReplayChangesAction.syncRemoteMapping(TransportReplayChangesAction.kt:185)
        at com.amazon.elasticsearch.replication.action.replay.TransportReplayChangesAction$syncRemoteMapping$1.invokeSuspend(TransportReplayChangesAction.kt)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.UndispatchedCoroutine.afterResume(Builders.common.kt:207)
        at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:113)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:44)
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:752)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
```
Replication status:
```
curl -u $CREDS -H 'Content-Type: application/json' -XGET "$FOLLOWER/_plugins/_replication/gd-autofollow-1/_status?pretty"
{
  "status" : "SYNCING",
  "reason" : "User initiated",
  "leader_alias" : "remote-cluster",
  "leader_index" : "gd-autofollow-1",
  "follower_index" : "gd-autofollow-1",
  "syncing_details" : {
    "leader_checkpoint" : 299,
    "follower_checkpoint" : 299,
    "seq_no" : 299
  }
}
```
 
### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
