### PR TITLE
Handle case when leader index mapping is not available

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/MappingNotAvailableException.kt
+++ b/src/main/kotlin/org/opensearch/replication/MappingNotAvailableException.kt
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication;
+
+import org.opensearch.OpenSearchException
+
+public class MappingNotAvailableException: OpenSearchException {
+
+    constructor(message: String, vararg args: Any) : super(message, *args)
+
+    constructor(message: String, cause: Throwable, vararg args: Any) : super(message,  cause, *args)
+}


### PR DESCRIPTION
### Description
In case of large documents, leader mapping is not immediately available which causes an NPE in the TranslogSequencer and fails the shard task. The replication gets autopaused as a result. Adding handling to check whether mapping is available.If mapping is not available, throwing an Exception so that the call can be retried.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
