### PR TITLE
Renewing retention lease with global-ckp + 1 , as we want operations …

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -199,7 +199,9 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
         val indexShard = followerIndexService.getShard(followerShardId.id)
 
         try {
-            retentionLeaseHelper.renewRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint, followerShardId)
+            //Retention leases preserve the operations including and starting from the retainingSequenceNumber we specify when we take the lease .
+            //hence renew retention lease with lastSyncedGlobalCheckpoint + 1
+            retentionLeaseHelper.renewRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint + 1, followerShardId)
         } catch (ex: Exception) {
             // In case of a failure, we just log it and move on. All failures scenarios are being handled below with
             // retries and backoff depending on exception.
@@ -266,9 +268,11 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                     }
                 }
 
-                //renew retention lease with global checkpoint so that any shard that picks up shard replication task has data until then.
+
+                //Retention leases preserve the operations including and starting from the retainingSequenceNumber we specify when we take the lease .
+                //hence renew retention lease with lastSyncedGlobalCheckpoint + 1 so that any shard that picks up shard replication task has data until then.
                 try {
-                    retentionLeaseHelper.renewRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint, followerShardId)
+                    retentionLeaseHelper.renewRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint + 1, followerShardId)
                     followerClusterStats.stats[followerShardId]!!.followerCheckpoint = indexShard.lastSyncedGlobalCheckpoint
                     lastLeaseRenewalMillis = System.currentTimeMillis()
                 } catch (ex: Exception) {


### PR DESCRIPTION
…from that seq number

Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>

### Description
Retention leases preserve the operations including and  starting from the `retainingSequenceNumber` we specify when we take the lease . 

Hence for follower side, once the global checkpoint moves to `x`, we should renew the lease from `x+1` as retainingSequenceNumber . 

The current code tries to take lease from `x` , which is not necessary . This can also become problematic when the earlier retention lease taken by bootstrap is `x+1` which is observed in [issue](https://github.com/opensearch-project/cross-cluster-replication/issues/205)
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/205
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
