### PR TITLE
Provide a custom TranslogDeletionPolicy for translog pruning based on…

### DIFF
--- a/src/main/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicy.kt
+++ b/src/main/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicy.kt
@@ -1,0 +1,61 @@
+package org.opensearch.index.translog
+
+import org.opensearch.index.IndexSettings
+import org.opensearch.index.IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING
+import org.opensearch.index.seqno.RetentionLease
+import org.opensearch.index.seqno.RetentionLeases
+import org.opensearch.replication.ReplicationPlugin
+import java.io.IOException
+import java.util.function.Supplier
+
+class ReplicationTranslogDeletionPolicy(
+    private val indexSettings: IndexSettings,
+    private val retentionLeasesSupplier: Supplier<RetentionLeases>
+) : TranslogDeletionPolicy(
+    indexSettings.translogRetentionSize.bytes,
+    indexSettings.translogRetentionAge.millis,
+    indexSettings.translogRetentionTotalFiles
+) {
+
+    /**
+     * returns the minimum translog generation that is still required by the system. Any generation below
+     * the returned value may be safely deleted
+     *
+     * @param readers current translog readers
+     * @param writer  current translog writer
+     */
+    @Synchronized
+    @Throws(IOException::class)
+    override fun minTranslogGenRequired(readers: List<TranslogReader>, writer: TranslogWriter): Long {
+        var retentionSizeInBytes: Long = indexSettings.translogRetentionSize.bytes
+        if (retentionSizeInBytes == -1L && indexSettings.settings.getAsBoolean(
+                ReplicationPlugin.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, false)) {
+            retentionSizeInBytes = INDEX_TRANSLOG_RETENTION_SIZE_SETTING.get(indexSettings.settings).bytes
+        }
+        val minBySize: Long = getMinTranslogGenBySize(readers, writer, retentionSizeInBytes)
+        val minByRetentionLeases: Long = getMinTranslogGenByRetentionLease(readers, writer)
+        val minByTranslogGenSettings = super.minTranslogGenRequired(readers, writer)
+
+        // If retention size is specified, size takes precedence.
+        return minByTranslogGenSettings.coerceAtMost(minBySize.coerceAtLeast(minByRetentionLeases))
+    }
+
+    private fun getMinTranslogGenByRetentionLease(readers: List<TranslogReader>, writer: TranslogWriter): Long {
+        var minGen: Long = writer.getGeneration();
+        val minimumRetainingSequenceNumber: Long = retentionLeasesSupplier.get()
+            .leases()
+            .stream()
+            .mapToLong(RetentionLease::retainingSequenceNumber)
+            .min()
+            .orElse(Long.MAX_VALUE);
+
+        for (i in readers.size - 1 downTo 0) {
+            val reader: TranslogReader = readers[i]
+            if(reader.checkpoint.minSeqNo <= minimumRetainingSequenceNumber &&
+                reader.checkpoint.maxSeqNo >= minimumRetainingSequenceNumber) {
+                minGen = minGen.coerceAtMost(reader.getGeneration());
+            }
+        }
+        return minGen;
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -185,8 +185,10 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
                 Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION = Setting.timeSetting ("plugins.replication.follower.retention_lease_max_failure_duration", TimeValue.timeValueHours(1), TimeValue.timeValueSeconds(1),
             TimeValue.timeValueHours(12), Setting.Property.Dynamic, Setting.Property.NodeScope)
-        val INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING: Setting<Boolean> = Setting.boolSetting("index.translog.retention_lease.pruning.enabled", false,
+        val REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING: Setting<Boolean> = Setting.boolSetting("index.plugins.replication.translog.pruning.enabled", false,
             Setting.Property.IndexScope, Setting.Property.Dynamic)
+        val REPLICATION_INDEX_TRANSLOG_RETENTION_SIZE: Setting<ByteSizeValue> = Setting.byteSizeSetting("index.plugins.replication.translog.retention_size",
+            ByteSizeValue(512, ByteSizeUnit.MB), Setting.Property.Dynamic, Setting.Property.IndexScope)
     }
 
     override fun createComponents(client: Client, clusterService: ClusterService, threadPool: ThreadPool,
@@ -343,7 +345,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
                 REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE, REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS,
                 REPLICATION_PARALLEL_READ_POLL_INTERVAL, REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,
                 REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL, REPLICATION_METADATA_SYNC_INTERVAL,
-                REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING)
+                REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING,
+                REPLICATION_INDEX_TRANSLOG_RETENTION_SIZE)
     }
 
     override fun getInternalRepositories(env: Environment, namedXContentRegistry: NamedXContentRegistry,

--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -108,9 +108,7 @@ import org.opensearch.env.NodeEnvironment
 import org.opensearch.index.IndexModule
 import org.opensearch.index.IndexSettings
 import org.opensearch.index.engine.EngineFactory
-import org.opensearch.index.seqno.RetentionLeases
 import org.opensearch.index.translog.ReplicationTranslogDeletionPolicy
-import org.opensearch.index.translog.TranslogDeletionPolicy
 import org.opensearch.index.translog.TranslogDeletionPolicyFactory
 import org.opensearch.indices.recovery.RecoverySettings
 import org.opensearch.persistent.PersistentTaskParams
@@ -146,7 +144,6 @@ import org.opensearch.threadpool.ScalingExecutorBuilder
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.watcher.ResourceWatcherService
 import java.util.Optional
-import java.util.function.BiFunction
 import java.util.function.Supplier
 
 @OpenForTesting
@@ -278,7 +275,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
         return FixedExecutorBuilder(settings, REPLICATION_EXECUTOR_NAME_LEADER, leaderThreadPoolSize, leaderThreadPoolQueueSize, REPLICATION_EXECUTOR_NAME_LEADER)
     }
 
-    fun leaderThreadPoolSize(allocatedProcessors: Int): Int {
+    private fun leaderThreadPoolSize(allocatedProcessors: Int): Int {
         return allocatedProcessors * 3 / 2 + 1
     }
 
@@ -358,7 +355,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
 
     override fun getEngineFactory(indexSettings: IndexSettings): Optional<EngineFactory> {
         return if (indexSettings.settings.get(REPLICATED_INDEX_SETTING.key) != null) {
-            Optional.of(EngineFactory { config -> org.opensearch.replication.ReplicationEngine(config) })
+            Optional.of(EngineFactory { config -> ReplicationEngine(config) })
         } else {
             Optional.empty()
         }

--- a/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchTimeoutException
-import org.opensearch.ResourceNotFoundException
 import org.opensearch.action.ActionListener
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.single.shard.TransportSingleShardAction
@@ -27,11 +26,10 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.Writeable
 import org.opensearch.common.unit.TimeValue
-import org.opensearch.index.IndexSettings
 import org.opensearch.index.shard.ShardId
 import org.opensearch.index.translog.Translog
 import org.opensearch.indices.IndicesService
-import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
+import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
 import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_EXECUTOR_NAME_LEADER
 import org.opensearch.replication.seqno.RemoteClusterStats
 import org.opensearch.replication.seqno.RemoteClusterTranslogService
@@ -148,7 +146,7 @@ class TransportGetChangesAction @Inject constructor(threadPool: ThreadPool, clus
 
     private fun isTranslogPruningByRetentionLeaseEnabled(shardId: ShardId): Boolean {
         val enabled = clusterService.state().metadata.indices.get(shardId.indexName)
-                ?.settings?.getAsBoolean(INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, false)
+                ?.settings?.getAsBoolean(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key, false)
         if(enabled != null) {
             return enabled
         }

--- a/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
@@ -31,6 +31,7 @@ import org.opensearch.index.IndexSettings
 import org.opensearch.index.shard.ShardId
 import org.opensearch.index.translog.Translog
 import org.opensearch.indices.IndicesService
+import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
 import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_EXECUTOR_NAME_LEADER
 import org.opensearch.replication.seqno.RemoteClusterStats
 import org.opensearch.replication.seqno.RemoteClusterTranslogService
@@ -147,7 +148,7 @@ class TransportGetChangesAction @Inject constructor(threadPool: ThreadPool, clus
 
     private fun isTranslogPruningByRetentionLeaseEnabled(shardId: ShardId): Boolean {
         val enabled = clusterService.state().metadata.indices.get(shardId.indexName)
-                ?.settings?.getAsBoolean(IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, false)
+                ?.settings?.getAsBoolean(INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, false)
         if(enabled != null) {
             return enabled
         }

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -50,14 +50,13 @@ import org.opensearch.common.UUIDs
 import org.opensearch.common.component.AbstractLifecycleComponent
 import org.opensearch.common.metrics.CounterMetric
 import org.opensearch.common.settings.Settings
-import org.opensearch.index.IndexSettings
 import org.opensearch.index.mapper.MapperService
 import org.opensearch.index.shard.ShardId
 import org.opensearch.index.snapshots.IndexShardSnapshotStatus
 import org.opensearch.index.store.Store
 import org.opensearch.indices.recovery.RecoverySettings
 import org.opensearch.indices.recovery.RecoveryState
-import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
+import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
 import org.opensearch.replication.util.stackTraceToString
 import org.opensearch.repositories.IndexId
 import org.opensearch.repositories.Repository
@@ -241,7 +240,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         builder.put(ReplicationPlugin.REPLICATED_INDEX_SETTING.key, replicatedIndex)
 
         // Remove translog pruning for the follower index
-        builder.remove(INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key)
+        builder.remove(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key)
 
         val indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder)
         indexMetadata.aliases.valuesIt().forEach {

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -57,6 +57,7 @@ import org.opensearch.index.snapshots.IndexShardSnapshotStatus
 import org.opensearch.index.store.Store
 import org.opensearch.indices.recovery.RecoverySettings
 import org.opensearch.indices.recovery.RecoveryState
+import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
 import org.opensearch.replication.util.stackTraceToString
 import org.opensearch.repositories.IndexId
 import org.opensearch.repositories.Repository
@@ -240,7 +241,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         builder.put(ReplicationPlugin.REPLICATED_INDEX_SETTING.key, replicatedIndex)
 
         // Remove translog pruning for the follower index
-        builder.remove(IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key)
+        builder.remove(INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key)
 
         val indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder)
         indexMetadata.aliases.valuesIt().forEach {

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -87,7 +87,7 @@ import org.opensearch.persistent.PersistentTasksCustomMetadata
 import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask
 import org.opensearch.persistent.PersistentTasksNodeService
 import org.opensearch.persistent.PersistentTasksService
-import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
+import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
 import org.opensearch.tasks.TaskId
 import org.opensearch.tasks.TaskManager
 import org.opensearch.threadpool.ThreadPool
@@ -133,7 +133,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     private var metadataPoller: Job? = null
     companion object {
         val blSettings  : Set<Setting<*>> = setOf(
-                INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING,
+                REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING,
                 IndexMetadata.INDEX_READ_ONLY_SETTING,
                 IndexMetadata.INDEX_BLOCKS_READ_SETTING,
                 IndexMetadata.INDEX_BLOCKS_WRITE_SETTING,
@@ -717,7 +717,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         // This ensures that, we don't have to search the huge translog files for the given range and ensuring that
         // the searches are optimal within a generation and skip searching the generations based on translog checkpoints
         val settingsBuilder = Settings.builder()
-                .put(INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, true)
+                .put(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key, true)
                 .put(IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.key, ByteSizeValue(32, ByteSizeUnit.MB))
         val updateSettingsRequest = remoteClient.admin().indices().prepareUpdateSettings().setSettings(settingsBuilder).setIndices(leaderIndex.name).request()
         val updateResponse = remoteClient.suspending(remoteClient.admin().indices()::updateSettings, injectSecurityContext = true)(updateSettingsRequest)

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -78,7 +78,6 @@ import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.index.Index
 import org.opensearch.index.IndexService
 import org.opensearch.index.IndexSettings
-import org.opensearch.index.IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
 import org.opensearch.index.shard.IndexShard
 import org.opensearch.index.shard.ShardId
 import org.opensearch.indices.cluster.IndicesClusterStateService
@@ -88,6 +87,7 @@ import org.opensearch.persistent.PersistentTasksCustomMetadata
 import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask
 import org.opensearch.persistent.PersistentTasksNodeService
 import org.opensearch.persistent.PersistentTasksService
+import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
 import org.opensearch.tasks.TaskId
 import org.opensearch.tasks.TaskManager
 import org.opensearch.threadpool.ThreadPool

--- a/src/test/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicyTests.kt
+++ b/src/test/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicyTests.kt
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.index.translog
+
+import org.apache.lucene.store.ByteArrayDataOutput
+import org.hamcrest.Matchers.equalTo
+import org.mockito.Mockito
+import org.opensearch.common.UUIDs
+import org.opensearch.common.bytes.BytesArray
+import org.opensearch.common.bytes.ReleasableBytesReference
+import org.opensearch.common.collect.Tuple
+import org.opensearch.common.util.BigArrays
+import org.opensearch.core.internal.io.IOUtils
+import org.opensearch.index.seqno.RetentionLease
+import org.opensearch.index.seqno.RetentionLeases
+import org.opensearch.index.shard.ShardId
+import org.opensearch.test.OpenSearchTestCase
+import java.io.IOException
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.OpenOption
+import java.nio.file.Path
+import java.util.*
+import java.util.function.Supplier
+
+
+class ReplicationTranslogDeletionPolicyTests : OpenSearchTestCase() {
+    private val TOTAL_OPS_IN_GEN = 10L
+
+    @Throws(IOException::class)
+    fun testWithRetentionLease() {
+        val now = System.currentTimeMillis()
+        val readersAndWriter: Tuple<MutableList<TranslogReader>, TranslogWriter?> = createReadersAndWriter(now)
+        val allGens: MutableList<BaseTranslogReader> = ArrayList(readersAndWriter.v1())
+        readersAndWriter.v2()?.let { allGens.add(it) }
+        val retentionLeasesSupplier: Supplier<RetentionLeases> =
+            createRetentionLeases(now, 0L, allGens.size * TOTAL_OPS_IN_GEN - 1)
+        try {
+            val minimumRetainingSequenceNumber: Long = retentionLeasesSupplier.get()
+                .leases()
+                .stream()
+                .mapToLong { obj: RetentionLease -> obj.retainingSequenceNumber() }
+                .min()
+                .orElse(Long.MAX_VALUE)
+            val selectedReader: Long = minimumRetainingSequenceNumber / TOTAL_OPS_IN_GEN
+            val selectedGen = allGens[selectedReader.toInt()].generation
+            assertThat(
+                readersAndWriter.v2()?.let {
+                    ReplicationTranslogDeletionPolicy.getMinTranslogGenByRetentionLease(
+                        readersAndWriter.v1(),
+                        it,
+                        retentionLeasesSupplier
+                    )
+                },
+                equalTo(selectedGen)
+            )
+        } finally {
+            IOUtils.close(readersAndWriter.v1())
+            IOUtils.close(readersAndWriter.v2())
+        }
+    }
+
+    @Throws(Exception::class)
+    fun testBySizeAndRetentionLease() {
+        val now = System.currentTimeMillis()
+        val readersAndWriter: Tuple<MutableList<TranslogReader>, TranslogWriter?> = createReadersAndWriter(now)
+        val allGens: MutableList<BaseTranslogReader> = ArrayList(readersAndWriter.v1())
+        readersAndWriter.v2()?.let { allGens.add(it) }
+        try {
+            val selectedReader = randomIntBetween(0, allGens.size - 1)
+            val selectedGeneration = allGens[selectedReader].generation
+            // Retaining seqno is part of lower gen
+            val size =
+                allGens.stream().skip(selectedReader.toLong()).map { obj: BaseTranslogReader -> obj.sizeInBytes() }
+                    .reduce { a: Long, b: Long -> java.lang.Long.sum(a, b) }.get()
+            var retentionLeasesSupplier: Supplier<RetentionLeases> =
+                createRetentionLeases(now, 0L, selectedGeneration * TOTAL_OPS_IN_GEN - 1)
+            assertThat(
+                readersAndWriter.v2()?.let {
+                    ReplicationTranslogDeletionPolicy.minTranslogGenRequired(
+                        readersAndWriter.v1(), it,
+                        true,
+                        size,
+                        Int.MAX_VALUE.toLong(),
+                        Int.MAX_VALUE,
+                        Int.MAX_VALUE.toLong(),
+                        retentionLeasesSupplier
+                    )
+                },
+                equalTo(selectedGeneration)
+            )
+            assertThat(
+                TranslogDeletionPolicy.getMinTranslogGenByAge(
+                    readersAndWriter.v1(),
+                    readersAndWriter.v2(),
+                    100L,
+                    System.currentTimeMillis()
+                ),
+                equalTo(readersAndWriter.v2()?.generation)
+            )
+
+            // Retention lease is part of higher gen
+            retentionLeasesSupplier = createRetentionLeases(
+                now,
+                selectedGeneration * TOTAL_OPS_IN_GEN,
+                allGens.size * TOTAL_OPS_IN_GEN + TOTAL_OPS_IN_GEN - 1
+            )
+            assertThat(
+                readersAndWriter.v2()?.let {
+                    ReplicationTranslogDeletionPolicy.minTranslogGenRequired(
+                        readersAndWriter.v1(), it,
+                        true,
+                        size,
+                        Long.MIN_VALUE,
+                        Int.MAX_VALUE,
+                        Long.MAX_VALUE,
+                        retentionLeasesSupplier
+                    )
+                },
+                equalTo(selectedGeneration)
+            )
+        } finally {
+            IOUtils.close(readersAndWriter.v1())
+            IOUtils.close(readersAndWriter.v2())
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun createRetentionLeases(now: Long, lowestSeqNo: Long, highestSeqNo: Long): Supplier<RetentionLeases> {
+        val leases = LinkedList<RetentionLease>()
+        val numberOfLeases = randomIntBetween(1, 5)
+        for (i in 0 until numberOfLeases) {
+            val seqNo = randomLongBetween(lowestSeqNo, highestSeqNo)
+            leases.add(RetentionLease("test_$i", seqNo, now - (numberOfLeases - i) * 1000, "test"))
+        }
+        return Supplier { RetentionLeases(1L, 1L, leases) }
+    }
+
+    @Throws(IOException::class)
+    private fun createReadersAndWriter(now: Long): Tuple<MutableList<TranslogReader>, TranslogWriter?> {
+        val tempDir: Path = createTempDir()
+        Files.createFile(tempDir.resolve(Translog.CHECKPOINT_FILE_NAME))
+        var writer: TranslogWriter? = null
+        val readers: MutableList<TranslogReader> = ArrayList()
+        val numberOfReaders = randomIntBetween(0, 10)
+        val translogUUID = UUIDs.randomBase64UUID(random())
+        for (gen in 1..numberOfReaders + 1) {
+            if (writer != null) {
+                val reader = Mockito.spy(writer.closeIntoReader())
+                Mockito.doReturn(writer.lastModifiedTime).`when`(reader).lastModifiedTime
+                readers.add(reader)
+            }
+            writer = TranslogWriter.create(
+                ShardId("index", "uuid", 0),
+                translogUUID,
+                gen.toLong(),
+                tempDir.resolve(Translog.getFilename(gen.toLong())),
+                { path: Path, options: Array<OpenOption> ->
+                    FileChannel.open(
+                        path,
+                        *options
+                    )
+                },
+                TranslogConfig.DEFAULT_BUFFER_SIZE,
+                1L,
+                1L,
+                { 1L },
+                { 1L },
+                randomNonNegativeLong(),
+                TragicExceptionHolder(),
+                { },
+                BigArrays.NON_RECYCLING_INSTANCE
+            )
+            writer = Mockito.spy(writer)
+            Mockito.doReturn(now - (numberOfReaders - gen + 1) * 1000).`when`(writer).lastModifiedTime
+            val bytes = ByteArray(4)
+            val out = ByteArrayDataOutput(bytes)
+            val startSeqNo: Long = (gen - 1) * TOTAL_OPS_IN_GEN
+            val endSeqNo: Long = startSeqNo + TOTAL_OPS_IN_GEN - 1
+            for (ops in endSeqNo downTo startSeqNo) {
+                out.reset(bytes)
+                out.writeInt(ops.toInt())
+                writer.add(ReleasableBytesReference.wrap(BytesArray(bytes)), ops)
+            }
+        }
+        return Tuple(readers, writer)
+    }
+}

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -66,6 +66,7 @@ import org.opensearch.index.mapper.MapperService
 import org.opensearch.repositories.fs.FsRepository
 import org.opensearch.test.OpenSearchTestCase.assertBusy
 import org.junit.Assert
+import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
 import org.opensearch.replication.followerStats
 import org.opensearch.replication.leaderStats
 import org.opensearch.replication.task.index.IndexReplicationExecutor.Companion.log
@@ -385,14 +386,14 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 assertThat(followerClient.indices()
                         .getSettings(GetSettingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
                         .getSetting(followerIndexName,
-                                IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key)
+                                INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key)
                         .isNullOrEmpty())
             }
 
             assertThat(leaderClient.indices()
                     .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
                     .getSetting(leaderIndexName,
-                            IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key) == "true")
+                            INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key) == "true")
 
         } finally {
             followerClient.stopReplication(followerIndexName)
@@ -413,7 +414,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             val leaderSettings = leaderClient.indices()
                     .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
             assertThat(leaderSettings.getSetting(leaderIndexName,
-                            IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key) == "true")
+                            INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key) == "true")
             assertThat(leaderSettings.getSetting(leaderIndexName,
                             IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.key) == "32mb")
 
@@ -440,7 +441,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             }
             // Turn-off the settings and index doc
             val settingsBuilder = Settings.builder()
-                    .put(IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, false)
+                    .put(INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, false)
             val settingsUpdateResponse = leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName)
                     .settings(settingsBuilder.build()), RequestOptions.DEFAULT)
             Assert.assertEquals(settingsUpdateResponse.isAcknowledged, true)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -30,7 +30,6 @@ import org.apache.http.HttpStatus
 import org.apache.http.entity.ContentType
 import org.apache.http.nio.entity.NStringEntity
 import org.apache.http.util.EntityUtils
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.opensearch.OpenSearchStatusException
@@ -66,11 +65,9 @@ import org.opensearch.index.mapper.MapperService
 import org.opensearch.repositories.fs.FsRepository
 import org.opensearch.test.OpenSearchTestCase.assertBusy
 import org.junit.Assert
-import org.opensearch.replication.ReplicationPlugin.Companion.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING
+import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
 import org.opensearch.replication.followerStats
 import org.opensearch.replication.leaderStats
-import org.opensearch.replication.task.index.IndexReplicationExecutor.Companion.log
-import java.lang.Thread.sleep
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
@@ -386,14 +383,14 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 assertThat(followerClient.indices()
                         .getSettings(GetSettingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
                         .getSetting(followerIndexName,
-                                INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key)
+                                REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key)
                         .isNullOrEmpty())
             }
 
             assertThat(leaderClient.indices()
                     .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
                     .getSetting(leaderIndexName,
-                            INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key) == "true")
+                            REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key) == "true")
 
         } finally {
             followerClient.stopReplication(followerIndexName)
@@ -414,7 +411,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             val leaderSettings = leaderClient.indices()
                     .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
             assertThat(leaderSettings.getSetting(leaderIndexName,
-                            INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key) == "true")
+                            REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key) == "true")
             assertThat(leaderSettings.getSetting(leaderIndexName,
                             IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.key) == "32mb")
 
@@ -441,7 +438,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             }
             // Turn-off the settings and index doc
             val settingsBuilder = Settings.builder()
-                    .put(INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.key, false)
+                    .put(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key, false)
             val settingsUpdateResponse = leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName)
                     .settings(settingsBuilder.build()), RequestOptions.DEFAULT)
             Assert.assertEquals(settingsUpdateResponse.isAcknowledged, true)


### PR DESCRIPTION
… retention leases.

Signed-off-by: Rabi Panda <pandarab@amazon.com>

### Description
This commit overrides the new getCustomTranslogDeletionPolicyFactory method of the EnginePlugin to provide a custom TranslogDeletionPolicy. The extension is added as part of OpenSearch 1.2 (https://github.com/opensearch-project/OpenSearch/pull/1404).  This PR uses the work originally done by @mch2 in a draft PR #145 

As part of https://github.com/opensearch-project/OpenSearch/issues/1100, the changes for translog pruning based on retention leases were added to the OpenSearch core which have been deprecated and being removed in https://github.com/opensearch-project/OpenSearch/pull/1416.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
