### PR TITLE
Using time out in cluster state observer as we are reusing the observer

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
@@ -125,7 +125,7 @@ suspend fun ClusterStateObserver.waitForNextChange(reason: String, predicate: (C
             override fun onTimeout(timeout: TimeValue?) {
                 cont.resumeWithException(OpenSearchTimeoutException("timed out waiting for $reason"))
             }
-        }, predicate)
+        }, predicate,  TimeValue(60000))
     }
 }
 


### PR DESCRIPTION
### Description
This makes `waitForNextChange` wait till time out value every time it is called. Without this change, the cluster state observer doesn't update `cso.startTimeMS` . So it waits for total `timeout` across multiple calls . For ex : 60 sec on first time and after that since `cso.startTimeMS` is not updated , the `waitForNextChange` returns immediately . This results in unnecessary CPU cycles and log flood as well. 
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/207
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
