### PR TITLE
Using time out in cluster state observer as we are reusing the observ…

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/Coroutines.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/Coroutines.kt
@@ -129,7 +129,7 @@ suspend fun ClusterStateObserver.waitForNextChange(reason: String, predicate: (C
             override fun onTimeout(timeout: TimeValue?) {
                 cont.resumeWithException(ElasticsearchTimeoutException("timed out waiting for $reason"))
             }
-        }, predicate)
+        }, predicate,  TimeValue(60000))
     }
 }
 


### PR DESCRIPTION
### Description
this makes `waitForNextChange` wait for time out value. Without this change, the cluster state observer doesn't update `startTimeMS` . So it waits for total `timeout` across multiple calls . For ex : 60 sec on first time and after that since `startTimeMS` is not updated , the `waitForNextChange` returns immediately . 
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/207
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
