### PR TITLE
Derive security context information when security plugin fails to populate user info

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/util/SecurityContext.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/util/SecurityContext.kt
@@ -58,7 +58,14 @@ class SecurityContext {
                 UpdateAutoFollowPatternAction.NAME)
 
         fun fromSecurityThreadContext(threadContext: ThreadContext): User? {
-            val userInfo = threadContext.getTransient<String?>(ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT)
+            var userInfo = threadContext.getTransient<String?>(ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT)
+            val userObj = threadContext.getTransient<Any?>(OPENDISTRO_SECURITY_USER)
+            if(userInfo == null && userObj != null) {
+                // Case: When admin certs are used, security plugin skips populating the user info in thread context.
+                // If userObj(obj) is present and userInfo(String) is not populated, assuming admin role for the user and
+                // only passed role(use_roles) in the request is stored after checks (as admin should have access to all roles)
+                userInfo = "adminDN|"
+            }
             return User.parse(userInfo)
         }
 

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/util/SecurityContextTests.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/util/SecurityContextTests.kt
@@ -1,0 +1,40 @@
+package com.amazon.elasticsearch.replication.util
+
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.util.concurrent.ThreadContext
+import org.elasticsearch.test.ESTestCase
+import org.junit.Assert
+import org.junit.Before
+
+class SecurityContextTests: ESTestCase() {
+
+    companion object {
+        var threadContext: ThreadContext? = null
+    }
+
+    @Before
+    fun setupContext() {
+        threadContext = ThreadContext(Settings.EMPTY)
+    }
+
+    fun `test security context from ThreadContext with user Info`() {
+        threadContext!!.putTransient("_opendistro_security_user_info", "admin||all_access")
+        val expectedUser = User("admin", emptyList<String>(), listOf("all_access"), emptyList<String>())
+        val returnedUser = SecurityContext.fromSecurityThreadContext(threadContext!!)
+        Assert.assertEquals(expectedUser, returnedUser)
+    }
+
+    fun `test security context from ThreadContext with user Info not present and user obj present`() {
+        threadContext!!.putTransient("_opendistro_security_user_info", null)
+        threadContext!!.putTransient("_opendistro_security_user", "")
+        val expectedUser = User("adminDN", emptyList<String>(), emptyList<String>(), emptyList<String>())
+        val returnedUser = SecurityContext.fromSecurityThreadContext(threadContext!!)
+        Assert.assertEquals(expectedUser, returnedUser)
+    }
+
+    fun `test security context from ThreadContext with user Info and user obj not present`() {
+        val returnedUser = SecurityContext.fromSecurityThreadContext(threadContext!!)
+        Assert.assertNull(returnedUser)
+    }
+}


### PR DESCRIPTION
### Description
Derive security context information when security plugin fails to populate user info
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/203
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
