### PR TITLE
Handled stop replication when remote cluster is removed

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -118,9 +118,13 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                     }
                 }
                 val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(request.indexName)
-                val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
-                val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
-                retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
+                try {
+                    val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
+                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+                    retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
+                } catch(e: Exception) {
+                    log.error("Failed to remove retention lease from the leader cluster", e)
+                }
 
                 val clusterStateUpdateResponse : AcknowledgedResponse =
                     clusterService.waitForClusterStateUpdate("stop_replication") { l -> StopReplicationTask(request, l)}


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Handled stop replication when remote cluster is removed
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
