### PR TITLE
BugFix: Fix for handling stop API after leader cluster is removed and filtering replication exception from retry

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -118,9 +118,13 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                     }
                 }
                 val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(request.indexName)
-                val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
-                val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
-                retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
+                try {
+                    val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
+                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+                    retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
+                } catch(e: Exception) {
+                    log.error("Failed to remove retention lease from the leader cluster", e)
+                }
 
                 val clusterStateUpdateResponse : AcknowledgedResponse =
                     clusterService.waitForClusterStateUpdate("stop_replication") { l -> StopReplicationTask(request, l)}

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -87,6 +87,7 @@ import org.opensearch.persistent.PersistentTasksCustomMetadata
 import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask
 import org.opensearch.persistent.PersistentTasksNodeService
 import org.opensearch.persistent.PersistentTasksService
+import org.opensearch.replication.ReplicationException
 import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
 import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.TaskId
@@ -190,7 +191,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                             shouldCallEvalMonitoring = false
                             MonitoringState
                         } else {
-                            throw org.opensearch.replication.ReplicationException("Wrong state type: ${currentTaskState::class}")
+                            throw ReplicationException("Wrong state type: ${currentTaskState::class}")
                         }
                     }
                     ReplicationState.MONITORING -> {
@@ -235,8 +236,10 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     currentTaskState = updateState(newState)
                 }
                 if (isCompleted) break
-            }
-            catch(e: OpenSearchException) {
+            } catch(e: ReplicationException) {
+                log.error("Exiting index replication task", e)
+                throw e
+            } catch(e: OpenSearchException) {
                 val status = e.status().status
                 // Index replication task shouldn't exit before shard replication tasks
                 // As long as shard replication tasks doesn't encounter any errors, Index task
@@ -627,7 +630,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 defaultContext = true
             )
             if (!pauseReplicationResponse.isAcknowledged) {
-                throw org.opensearch.replication.ReplicationException(
+                throw ReplicationException(
                     "Failed to gracefully pause replication after one or more shard tasks failed. " +
                             "Replication tasks may need to be paused manually."
                 )
@@ -755,7 +758,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         val response = client.suspending(client.admin().cluster()::restoreSnapshot, defaultContext = true)(restoreRequest)
         if (response.restoreInfo != null) {
             if (response.restoreInfo.failedShards() != 0) {
-                throw org.opensearch.replication.ReplicationException("Restore failed: $response")
+                throw ReplicationException("Restore failed: $response")
             }
             return FollowingState(emptyMap())
         }


### PR DESCRIPTION
### Description
BugFix: Fix for handling stop API after leader index is removed and filtering replication exception from retry
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
