### PR TITLE
BugFix: Fix for handling stop API after leader cluster is removed and filtering replication exception from retry

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -118,9 +118,13 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                     }
                 }
                 val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(request.indexName)
-                val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
-                val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
-                retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
+                try {
+                    val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
+                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+                    retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
+                } catch(e: Exception) {
+                    log.error("Failed to remove retention lease from the leader cluster", e)
+                }
 
                 val clusterStateUpdateResponse : AcknowledgedResponse =
                     clusterService.waitForClusterStateUpdate("stop_replication") { l -> StopReplicationTask(request, l)}

--- a/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
@@ -16,6 +16,8 @@ import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionResponse
 import org.opensearch.action.ActionType
+import org.opensearch.action.admin.cluster.health.ClusterHealthAction
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotAction
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse
 import org.opensearch.action.admin.indices.recovery.RecoveryAction
@@ -130,6 +132,10 @@ open class NoOpClient(testName :String) : NoOpNodeClient(testName) {
             var result = GetResult(ReplicationMetadataStore.REPLICATION_CONFIG_SYSTEM_INDEX, "_doc", IndexReplicationTaskTests.followerIndex, 1, 1, 1, true, by, null, null)
             var getResponse = GetResponse(result)
             listener.onResponse(getResponse as Response)
+        } else if (action == ClusterHealthAction.INSTANCE) {
+            // Store health response
+            val replicationStoreResponse = ClusterHealthResponse()
+            listener.onResponse(replicationStoreResponse as Response)
         }
     }
 }


### PR DESCRIPTION
### Description
BugFix: Fix for handling stop API after leader index is removed and filtering replication exception from retry
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
