### PR TITLE
Handled case for _start replication with leader cluster at higher version than the follower cluster

### DIFF
--- a/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/integ/rest/StartReplicationIT.kt
@@ -358,7 +358,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
 
-        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, "source")
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).alias(Alias("leader_alias")), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
@@ -369,7 +369,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         } catch (e: ResponseException) {
             assertThat(e.response.statusLine.statusCode).isEqualTo(404)
             assertThat(e.message).contains("index_not_found_exception")
-            assertThat(e.message).contains("no such index [leader_alias]")
+            assertThat(e.message).contains("no such index [source:leader_alias]")
         }
     }
 


### PR DESCRIPTION


Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Handled case for _start replication with leader cluster at higher version than the follower cluster
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
