### PR TITLE
Force security configuration init between tests to prevent transient failures in integ tests

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
@@ -118,11 +118,11 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
 
         internal fun createTestCluster(configuration: ClusterConfiguration) : TestCluster {
             return createTestCluster(configuration.clusterName, configuration.preserveSnapshots, configuration.preserveIndices,
-                configuration.preserveClusterSettings)
+                configuration.preserveClusterSettings, configuration.forceInitSecurityConfiguration)
         }
 
         internal fun createTestCluster(cluster: String, preserveSnapshots: Boolean, preserveIndices: Boolean,
-                                       preserveClusterSettings: Boolean) : TestCluster {
+                                       preserveClusterSettings: Boolean, initSecurityConfiguration: Boolean) : TestCluster {
             val systemProperties = BootstrapInfo.getSystemProperties()
             val httpHostsProp = systemProperties.get("tests.cluster.${cluster}.http_hosts") as String?
             val transportHostsProp = systemProperties.get("tests.cluster.${cluster}.transport_hosts") as String?
@@ -143,7 +143,7 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
                 isMultiNodeClusterConfiguration = false
             }
 
-            forceInitSecurityConfiguration = isSecurityPropertyEnabled && forceInitSecurityConfiguration
+            forceInitSecurityConfiguration = isSecurityPropertyEnabled && initSecurityConfiguration
 
             val httpHosts = httpHostsProp.split(',').map { HttpHost.create("$protocol://$it") }
             val transportPorts = transportHostsProp.split(',')

--- a/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
@@ -53,8 +53,8 @@ class BackwardsCompatibilityIT : MultiClusterRestTestCase() {
             val leader = "${LEADER}$suffix"
             val follower = "${FOLLOWER}$suffix"
             val clusters = HashMap<String, TestCluster>()
-            clusters.put(leader, createTestCluster(leader, true, true, true))
-            clusters.put(follower, createTestCluster(follower, true, true, true))
+            clusters.put(leader, createTestCluster(leader, true, true, true, false))
+            clusters.put(follower, createTestCluster(follower, true, true, true, false))
             testClusters = clusters
         }
 


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Force security configuration init between tests to prevent transient failures in integ tests
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
