### PR TITLE
Bug fix for the failed shard tasks to filter based on follower index name

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
@@ -71,7 +71,7 @@ class TransportPauseIndexReplicationAction @Inject constructor(transportService:
                 validatePauseReplicationRequest(request)
 
                 // Restoring Index can't be paused
-                val restoring = clusterService.state().custom<RestoreInProgress>(RestoreInProgress.TYPE).any { entry ->
+                val restoring = clusterService.state().custom<RestoreInProgress>(RestoreInProgress.TYPE, RestoreInProgress.EMPTY).any { entry ->
                     entry.indices().any { it == request.indexName }
                 }
 

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -302,20 +302,17 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     }
 
     private suspend fun pollShardTaskStatus(shardTasks: Map<ShardId, PersistentTask<ShardReplicationParams>>): IndexReplicationState {
-        val failedShardTasks = findAllReplicationFailedShardTasks(clusterService.state())
+        val failedShardTasks = findAllReplicationFailedShardTasks(followerIndexName, clusterService.state())
         if (failedShardTasks.isNotEmpty()) {
             log.info("Failed shard tasks - ", failedShardTasks)
             var msg = ""
             for ((shard, task) in failedShardTasks) {
                 val taskState = task.state
-                // Filter tasks related to the follower shard index and construct the error message
-                if (followerIndexName == shard.indexName) {
-                    if (taskState is org.opensearch.replication.task.shard.FailedState) {
-                        val exception: OpenSearchException? = taskState.exception
-                        msg += "[${shard} - ${exception?.javaClass?.name} - \"${exception?.message}\"], "
-                    } else {
-                        msg += "[${shard} - \"Shard task killed or cancelled.\"], "
-                    }
+                if (taskState is org.opensearch.replication.task.shard.FailedState) {
+                    val exception: OpenSearchException? = taskState.exception
+                    msg += "[${shard} - ${exception?.javaClass?.name} - \"${exception?.message}\"], "
+                } else {
+                    msg += "[${shard} - \"Shard task killed or cancelled.\"], "
                 }
             }
             return FailedState(failedShardTasks, msg)
@@ -646,13 +643,15 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         return MonitoringState
     }
 
-    private fun findAllReplicationFailedShardTasks(clusterState: ClusterState)
+    private fun findAllReplicationFailedShardTasks(followerIndexName: String, clusterState: ClusterState)
             :Map<ShardId, PersistentTask<ShardReplicationParams>> {
         val persistentTasks = clusterState.metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
 
+        // Filter tasks related to the follower shard index and construct the error message
         val failedShardTasks = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
                 .filter { task -> task.state is org.opensearch.replication.task.shard.FailedState }
                 .map { task -> task as PersistentTask<ShardReplicationParams> }
+                .filter { task -> task.params!!.followerShardId.indexName  == followerIndexName}
                 .collect(Collectors.toMap(
                         {t: PersistentTask<ShardReplicationParams> -> t.params!!.followerShardId},
                         {t: PersistentTask<ShardReplicationParams> -> t}))


### PR DESCRIPTION


Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Add missing commit: Bug fix for the failed shard tasks to filter based on follower index name
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/304
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
