### PR TITLE
Enhanced status API validations to check for index name

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/status/ShardInfoRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/status/ShardInfoRequest.kt
@@ -39,7 +39,11 @@ class ShardInfoRequest : BroadcastRequest<ShardInfoRequest> , ToXContentObject {
     }
 
     override fun validate(): ActionRequestValidationException? {
-        return null
+        var validationException = ActionRequestValidationException()
+        if(indexName.isEmpty()) {
+            validationException.addValidationError("Index name must be specified to obtain replication status")
+        }
+        return if(validationException.validationErrors().isEmpty()) return null else validationException
     }
 
     override fun indices(): Array<String> {

--- a/src/main/kotlin/org/opensearch/replication/rest/ReplicationStatusHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/ReplicationStatusHandler.kt
@@ -39,7 +39,7 @@ class ReplicationStatusHandler : BaseRestHandler() {
 
     @Throws(IOException::class)
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
-        val index = request.param("index")
+        val index = request.param("index", "")
         var isVerbose = (request.paramAsBoolean("verbose", false))
         val indexReplicationStatusRequest = ShardInfoRequest(index,isVerbose)
         return RestChannelConsumer {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ReplicationStatusIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ReplicationStatusIT.kt
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.integ.rest
+
+import org.assertj.core.api.Assertions
+import org.junit.Assert
+import org.opensearch.client.RequestOptions
+import org.opensearch.client.ResponseException
+import org.opensearch.client.indices.CreateIndexRequest
+import org.opensearch.replication.MultiClusterAnnotations
+import org.opensearch.replication.MultiClusterRestTestCase
+import org.opensearch.replication.startReplication
+import org.opensearch.replication.stopReplication
+import org.opensearch.replication.StartReplicationRequest
+import org.opensearch.replication.replicationStatus
+import org.opensearch.replication.`validate status syncing response`
+import java.util.concurrent.TimeUnit
+
+@MultiClusterAnnotations.ClusterConfigurations(
+    MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER),
+    MultiClusterAnnotations.ClusterConfiguration(clusterName = FOLLOWER)
+)
+class ReplicationStatusIT: MultiClusterRestTestCase() {
+
+    fun `test replication status with valid params`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        val indexName = "test-status-valid-param"
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(indexName), RequestOptions.DEFAULT)
+        Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", indexName, indexName), waitForRestore = true)
+            assertBusy({
+                var statusResp = followerClient.replicationStatus(indexName)
+                `validate status syncing response`(statusResp)
+            }, 30, TimeUnit.SECONDS)
+        } finally {
+            followerClient.stopReplication(indexName)
+        }
+    }
+
+    fun `test replication status without valid params`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        try {
+            followerClient.replicationStatus("")
+            Assert.fail("Status API shouldn't succeed in this case")
+        } catch (e: ResponseException) {
+            Assert.assertEquals(e.response.statusLine.statusCode, 400)
+            Assert.assertTrue(e.message != null)
+            Assert.assertTrue(e.message!!.contains("Index name must be specified to obtain replication status"))
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Enhanced status API validations to check for index name
```
GET _plugins/_replication//_status?pretty" 

{
  "error" : {
    "root_cause" : [
      {
        "type" : "action_request_validation_exception",
        "reason" : "Validation Failed: 1: Index name should be specified to obtain replication status;"
      }
    ],
    "type" : "action_request_validation_exception",
    "reason" : "Validation Failed: 1: Index name should be specified to obtain replication status;"
  },
  "status" : 400
}
```


### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/314


 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
