### PR TITLE
Enhanced autofollow to trigger concurrent replication jobs based on setting

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -191,6 +191,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             ByteSizeValue(512, ByteSizeUnit.MB), Setting.Property.Dynamic, Setting.Property.IndexScope)
         val REPLICATION_FOLLOWER_BLOCK_START: Setting<Boolean> = Setting.boolSetting("plugins.replication.follower.block.start", false,
                 Setting.Property.Dynamic, Setting.Property.NodeScope)
+        val REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size", 3, 1, 10,
+            Setting.Property.Dynamic, Setting.Property.NodeScope)
     }
 
     override fun createComponents(client: Client, clusterService: ClusterService, threadPool: ThreadPool,
@@ -348,7 +350,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
                 REPLICATION_PARALLEL_READ_POLL_INTERVAL, REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,
                 REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL, REPLICATION_METADATA_SYNC_INTERVAL,
                 REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING,
-                REPLICATION_INDEX_TRANSLOG_RETENTION_SIZE, REPLICATION_FOLLOWER_BLOCK_START)
+                REPLICATION_INDEX_TRANSLOG_RETENTION_SIZE, REPLICATION_FOLLOWER_BLOCK_START, REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE)
     }
 
     override fun getInternalRepositories(env: Environment, namedXContentRegistry: NamedXContentRegistry,

--- a/src/main/kotlin/org/opensearch/replication/ReplicationSettings.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationSettings.kt
@@ -31,6 +31,7 @@ open class ReplicationSettings(clusterService: ClusterService) {
     @Volatile var metadataSyncInterval = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL)
     @Volatile var leaseRenewalMaxFailureDuration: TimeValue = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION)
     @Volatile var followerBlockStart: Boolean = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START)
+    @Volatile var autofollowConcurrentJobsTriggerSize: Int = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE)
 
     init {
         listenForUpdates(clusterService.clusterSettings)
@@ -47,5 +48,6 @@ open class ReplicationSettings(clusterService: ClusterService) {
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL) { autofollowRetryPollDuration = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL) { metadataSyncInterval = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START) { followerBlockStart = it }
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE) { autofollowConcurrentJobsTriggerSize = it }
     }
 }

--- a/src/main/kotlin/org/opensearch/replication/action/status/ShardInfoResponse.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/status/ShardInfoResponse.kt
@@ -11,7 +11,6 @@
 
 package org.opensearch.replication.action.status
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.action.support.broadcast.BroadcastResponse
 import org.opensearch.action.support.broadcast.BroadcastShardResponse
 import org.opensearch.common.ParseField
@@ -28,6 +27,11 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     val status: String
     lateinit var replayDetails: ReplayDetails
     lateinit var restoreDetails: RestoreDetails
+
+    companion object {
+        const val BOOTSTRAPPING = "BOOTSTRAPPING"
+        const val SYNCING = "SYNCING"
+    }
 
     constructor(si: StreamInput) : super(si) {
         this.status = si.readString()

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -380,3 +380,19 @@ fun RestHighLevelClient.updateReplicationStartBlockSetting(enabled: Boolean) {
     val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
     assertThat(response.isAcknowledged).isTrue()
 }
+
+fun RestHighLevelClient.updateAutoFollowConcurrentStartReplicationJobSetting(concurrentJobs: Int?) {
+    val settings = if(concurrentJobs != null) {
+        Settings.builder()
+            .put("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size", concurrentJobs)
+            .build()
+    } else {
+        Settings.builder()
+            .putNull("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size")
+            .build()
+    }
+    val updateSettingsRequest = ClusterUpdateSettingsRequest()
+    updateSettingsRequest.persistentSettings(settings)
+    val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
+    assertThat(response.isAcknowledged).isTrue()
+}

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -546,13 +546,16 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
             getSettingsRequest.indices(followerIndexName)
             // Leader setting is copied
-            Assert.assertEquals(
+            assertBusy({
+                Assert.assertEquals(
                     "2",
                     followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-            )
-            assertEqualAliases()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                )
+                assertEqualAliases()
+            }, 30L, TimeUnit.SECONDS)
+
 
             // Case 2 :  Blocklisted  setting are not copied
             Assert.assertNull(followerClient.indices()
@@ -580,28 +583,30 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
 
             // Case 3 : Updated Settings take higher priority.  Blocklisted  settins shouldn't matter for that
-            Assert.assertEquals(
+            assertBusy({
+                Assert.assertEquals(
                     "3",
                     followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-            )
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                )
 
-            Assert.assertEquals(
+                Assert.assertEquals(
                     "10s",
                     followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName]["index.search.idle.after"]
-            )
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName]["index.search.idle.after"]
+                )
 
-            Assert.assertEquals(
+                Assert.assertEquals(
                     "none",
                     followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
-            )
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
+                )
 
-            assertEqualAliases()
+                assertEqualAliases()
+            }, 30L, TimeUnit.SECONDS)
 
             //Clear the settings
             settings = Settings.builder()


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Enhanced autofollow to trigger concurrent replication jobs based on setting
 - Addressed integ test issue in `StartReplicationIT`
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/307
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
