### PR TITLE
removed jdk 14 support (#346).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
         java: 
           - 8
           - 11
-          - 14
     # Job name
     name: Build Replication plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Naveen Pajjuri <nppajjur@amazon.com>

### Description
Removed JDK 14 as suggested in https://github.com/opensearch-project/cross-cluster-replication/issues/346
 
### Issues Resolved

https://github.com/opensearch-project/cross-cluster-replication/issues/346
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
