### PR TITLE
Added coverage execution for integ tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,11 @@
  */
 
 
+import javax.management.ObjectName
+import javax.management.remote.JMXConnector
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
+import javax.management.MBeanServerInvocationHandler
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
@@ -381,6 +384,15 @@ def configureCluster(OpenSearchCluster cluster, Boolean securityEnabled) {
     cluster.waitForAllConditions()
 }
 
+interface IProxy {
+    byte[] getExecutionData(boolean reset);
+
+    void dump(boolean reset);
+
+    void reset();
+}
+
+
 int startJmxPort=7777
 int endJmxPort = startJmxPort
 integTest {
@@ -437,6 +449,22 @@ integTest {
             systemProperty "tests.cluster.${cluster.name}.security_enabled", "${-> securityEnabled.toString()}"
             systemProperty "tests.cluster.${cluster.name}.total_nodes", "${-> _numNodes.toString()}"
             configureCluster(cluster, securityEnabled)
+        }
+    }
+
+    doLast {
+        for (int port=startJmxPort; port<endJmxPort; port++) {
+            def serverUrl = "service:jmx:rmi:///jndi/rmi://127.0.0.1:" + port + "/jmxrmi"
+
+            try(def connector = JMXConnectorFactory.connect(new JMXServiceURL(serverUrl))) {
+                def proxy = MBeanServerInvocationHandler.newProxyInstance(
+                        connector.getMBeanServerConnection(), new ObjectName("org.jacoco:type=Runtime"), IProxy.class,
+                        false)
+                byte[] data = proxy.getExecutionData(false)
+                file(jacoco.destinationFile).append(data)
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to fetch coverage data " , e)
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Added coverage execution for integ tests
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/354
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
