### PR TITLE
Hardcode the aws cdk versions

### DIFF
--- a/perf_workflow/requirements.txt
+++ b/perf_workflow/requirements.txt
@@ -5,9 +5,12 @@ cerberus
 pipenv
 requests
 retry
-aws_cdk.core
-aws_cdk.aws_ec2
-aws_cdk.aws_iam
-aws_cdk.aws_logs
-aws_cdk.aws_autoscaling
+ndg-httpsclient
+pyopenssl
+pyasn1
+aws_cdk.core~=1.143.0
+aws_cdk.aws_ec2~=1.143.0
+aws_cdk.aws_iam~=1.143.0
+aws_cdk.aws_logs~=1.143.0
+aws_cdk.aws_autoscaling~=1.143.0
 git+https://git@github.com/opensearch-project/opensearch-build@main

--- a/perf_workflow/run_perf_suite/ccr_perf_test.py
+++ b/perf_workflow/run_perf_suite/ccr_perf_test.py
@@ -16,6 +16,7 @@ import string
 import requests
 from git.git_repository import GitRepository
 from requests.auth import HTTPBasicAuth
+from retry.api import retry_call
 from system.temporary_directory import TemporaryDirectory
 from system.working_directory import WorkingDirectory
 from test_workflow.perf_test.perf_multi_node_cluster import PerfMultiNodeCluster


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Changes done: 
- Hardcode the aws cdk versions due to incompatibility with newer versions. Keeping this in parity with OS Jenkins workflow([link](https://github.com/opensearch-project/opensearch-build/blob/main/vars/runPerfTestScript.groovy#L31-L33)).
```
This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
(Cloud assembly schema version mismatch: Maximum schema version supported is 17.0.0, but found 18.0.0)
```
- Added ndg-httpsclient, pyopenssl, pyasn1 to handle SSL error `SSLError: EOF occurred in violation of protocol`:  ([reference](https://stackoverflow.com/questions/33410577/python-requests-exceptions-sslerror-eof-occurred-in-violation-of-protocol)).
- Added missing import.

Sample error: 


 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
