### PR TITLE
Move number_of_shards and number_of_replicas param out of index setting

### DIFF
--- a/perf_workflow/run_perf_suite/ccr_perf_test.py
+++ b/perf_workflow/run_perf_suite/ccr_perf_test.py
@@ -182,22 +182,20 @@ class CcrPerfTest:
 
         url = "".join([followerCluster.endpoint_with_port, path])
         follower_resp = retry_call(requests.get, fkwargs={"url": url, "auth": self.CREDS, "verify": False},
-               tries=3, delay=15, backoff=2)
-        assert follower_resp.json()['status'] == "SYNCING", "Replication status is not syncing"
-        leader_checkpoint = follower_resp.json()['syncing_details']['leader_checkpoint']
-        follower_checkpoint = follower_resp.json()['syncing_details']['follower_checkpoint']
+               tries=3, delay=15, backoff=2).json()
+        assert follower_resp['status'] == "SYNCING", f"Replication status is not syncing. Response: {follower_resp}"
+        leader_checkpoint = follower_resp['syncing_details']['leader_checkpoint']
+        follower_checkpoint = follower_resp['syncing_details']['follower_checkpoint']
 
-        assert leader_checkpoint == follower_checkpoint, "Follower is not at same checkpoint as leader"
+        assert leader_checkpoint == follower_checkpoint, f"Follower is not at same checkpoint as leader. Response: {follower_resp}"
 
     def workload_options(self):
         workload_param = {
             "ingest_percentage": 100,
             "index_settings": {
-                "index": {
-                    "number_of_shards": self.test_config.get("Shards", 1),
-                    "number_of_replicas": self.test_config.get("Replica", 0),
-                    "codec": "default"
-                }
+                "number_of_shards": self.test_config.get("Shards", 1),
+                "number_of_replicas": self.test_config.get("Replica", 0),
+                "codec": "default"
             }
         }
         telemetry_options = {


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Move the `number_of_shards` and `number_of_replicas` as we observed few test runs and these aren't getting honoured.
 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
