### PR TITLE
Remove rc1 build qualifier for 2.0

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: 'opensearch-project/security'
           path: security
-          ref: 'main'
+          ref: '2.0'
       - name: Build security
         working-directory: ./security
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Remove rc1 build qualifier for 2.0
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/390
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
