### PR TITLE
Publish CCR zip to maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.rest-test'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
+apply plugin: 'opensearch.pluginzip'
 
 forbiddenApisTest.ignoreFailures = true
 
@@ -870,4 +871,27 @@ task integTestRemote(type: RestIntegTestTask) {
         setIncludePatterns("org.opensearch.replication.singleCluster.SingleClusterSanityIT")
     }
     nonInputProperties.systemProperty('tests.sanitySingleCluster', "integTestSingleCluster")
+}
+
+publishing {
+    publications {
+        pluginZip(MavenPublication) { publication ->
+            pom {
+                name = opensearchplugin.name
+                description = opensearchplugin.description
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/cross-cluster-replication"
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Publish CCR zip to maven repo
 
Depends on https://github.com/opensearch-project/cross-cluster-replication/pull/398/files

### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/384
 
###Testing done.
Verifed the zips in `build/local-staging-repo/org/opensearch/plugin/opensearch-cross-cluster-replication`
```
88665a0f606e:cross-cluster-replication ankikala$ ls build/local-staging-repo/org/opensearch/plugin/opensearch-cross-cluster-replication/2.0.0.0-SNAPSHOT/
maven-metadata.xml
maven-metadata.xml.md5
maven-metadata.xml.sha1
maven-metadata.xml.sha256
maven-metadata.xml.sha512
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.pom
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.pom.md5
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.pom.sha1
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.pom.sha256
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.pom.sha512
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.zip
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.zip.md5
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.zip.sha1
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.zip.sha256
opensearch-cross-cluster-replication-2.0.0.0-20220517.115038-1.zip.sha512
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.pom
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.pom.md5
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.pom.sha1
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.pom.sha256
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.pom.sha512
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.zip
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.zip.md5
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.zip.sha1
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.zip.sha256
opensearch-cross-cluster-replication-2.0.0.0-20220517.115758-2.zip.sha512
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.pom
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.pom.md5
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.pom.sha1
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.pom.sha256
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.pom.sha512
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.zip
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.zip.md5
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.zip.sha1
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.zip.sha256
opensearch-cross-cluster-replication-2.0.0.0-20220517.121842-3.zip.sha512
```

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
