### PR TITLE
Add version and snapshot param to maintain parity with default script

### DIFF
--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -18,6 +18,8 @@ function usage() {
     echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
     echo -e "-h\tPrint this message."
+    echo -e "-v OPENSEARCH_VERSION\t, no defaults"
+    echo -e "-n SNAPSHOT\t, defaults to false"
     echo "--------------------------------------------------------------------------"
 }
 
@@ -41,6 +43,12 @@ while getopts ":h:b:p:s:c:v:n:t:" arg; do
             ;;
         c)
             CREDENTIAL=$OPTARG
+            ;;
+        v)
+            # Do nothing as we're not consuming this param.
+            ;;
+        n)
+            # Do nothing as we're not consuming this param.
             ;;
         :)
             echo "-${OPTARG} requires an argument"


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Add version and snapshot param to maintain parity with default script
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/400
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
