### PR TITLE
Add custom build.sh to publish the plugin zip

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ ! -z "$QUALIFIER" ]] && VERSION=$VERSION-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+mkdir -p $OUTPUT/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins
+
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Add custom build.sh to publish the plugin zip
 
### Issues Resolved
[384](https://github.com/opensearch-project/cross-cluster-replication/issues/384)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

```
88665a0f606e:cross-cluster-replication ankikala$ ./scripts/build.sh -v 2.1.0 -s true
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ VERSION=2.1.0
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ SNAPSHOT=true
+ getopts :h:v:q:s:o:p:a: arg
+ '[' -z 2.1.0 ']'
+ [[ ! -z '' ]]
+ [[ true == \t\r\u\e ]]
+ VERSION=2.1.0-SNAPSHOT
+ '[' -z '' ']'
+ OUTPUT=artifacts
+ mkdir -p artifacts
+ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=2.1.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.4.2/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build 
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.4.2
  OS Info               : Mac OS X 10.16 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-14.0.2.jdk/Contents/Home
  Random Testing Seed   : 197AD061B54BDAD4
  In FIPS 140 mode      : false
=======================================

> Task :compileKotlin
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt: (260, 16): Type List<ExecutorBuilder<out ExecutorBuilder.ExecutorSettings>> is inaccessible in this context due to: public/*package*/ abstract class ExecutorSettings defined in org.opensearch.threadpool.ExecutorBuilder
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/autofollow/AutoFollowClusterManagerNodeRequest.kt: (16, 45): 'MasterNodeRequest<Request : MasterNodeRequest<Request!>!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/autofollow/AutoFollowClusterManagerNodeRequest.kt: (23, 44): 'MasterNodeRequest<Request : MasterNodeRequest<Request!>!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt: (34, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt: (52, 9): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt: (54, 96): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportUpdateAutoFollowPatternAction.kt: (42, 103): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt: (72, 9): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexClusterManagerNodeRequest.kt: (16, 45): 'MasterNodeRequest<Request : MasterNodeRequest<Request!>!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexClusterManagerNodeRequest.kt: (24, 9): 'MasterNodeRequest<Request : MasterNodeRequest<Request!>!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt: (54, 23): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt: (34, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt: (65, 9): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt: (67, 27): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/block/TransportUpddateIndexBlockAction.kt: (26, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/block/TransportUpddateIndexBlockAction.kt: (47, 9): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/index/block/TransportUpddateIndexBlockAction.kt: (49, 65): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt: (29, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt: (53, 5): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt: (55, 61): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/TransportUpdateReplicationStateDetails.kt: (25, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/TransportUpdateReplicationStateDetails.kt: (42, 9): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/TransportUpdateReplicationStateDetails.kt: (44, 27): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/TransportUpdateReplicationStateDetails.kt: (56, 25): Unchecked cast: UpdateReplicationStateDetailsTaskExecutor to ClusterStateTaskExecutor<AcknowledgedRequest<UpdateReplicationStateDetailsRequest>>
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt: (43, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt: (70, 5): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt: (72, 61): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stats/NodeStatsRequest.kt: (14, 44): 'BaseNodeRequest' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stats/NodeStatsRequest.kt: (19, 26): 'BaseNodeRequest' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stats/TransportAutoFollowStatsAction.kt: (34, 147): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stats/TransportFollowerStatsAction.kt: (39, 75): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stats/TransportLeaderStatsAction.kt: (41, 73): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/status/TransportReplicationStatusAction.kt: (39, 27): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt: (44, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt: (75, 5): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt: (77, 61): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/update/TransportUpdateIndexReplicationAction.kt: (28, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/update/TransportUpdateIndexReplicationAction.kt: (51, 5): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/action/update/TransportUpdateIndexReplicationAction.kt: (53, 61): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt: (33, 45): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt: (64, 5): 'TransportMasterNodeAction<Request : MasterNodeRequest<Request!>!, Response : ActionResponse!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt: (109, 92): 'masterNodeTimeout(): TimeValue!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt: (129, 53): 'masterNodeTimeout(): TimeValue!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt: (189, 74): 'masterNodeTimeout(): TimeValue!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt: (214, 40): 'masterNodeTimeout(): TimeValue!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt: (253, 84): 'masterNodeTimeout(): TimeValue!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterMultiChunkTransfer.kt: (53, 99): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt: (86, 147): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt: (45, 31): 'masterNodeTimeout(TimeValue!): UpdateSettingsRequest!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt: (45, 109): 'masterNodeTimeout(): TimeValue!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterTranslogService.kt: (41, 35): 'getHistoryOperationsFromTranslogFile(String!, Long, Long): Translog.Snapshot!' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/task/CrossClusterReplicationTask.kt: (97, 17): This declaration is experimental and its usage should be marked with '@kotlinx.coroutines.ObsoleteCoroutinesApi' or '@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)'
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt: (71, 26): This declaration overrides experimental member of supertype 'CrossClusterReplicationTask' and should be annotated with '@kotlinx.coroutines.ObsoleteCoroutinesApi'
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt: (163, 33): This declaration overrides experimental member of supertype 'CrossClusterReplicationTask' and should be annotated with '@kotlinx.coroutines.ObsoleteCoroutinesApi'
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt: (305, 45): Parameter 'shardTasks' is never used
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt: (654, 37): Unchecked cast: PersistentTasksCustomMetadata.PersistentTask<*>! to PersistentTasksCustomMetadata.PersistentTask<ShardReplicationParams>
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt: (23, 45): 'MasterNodeRequest<Request : MasterNodeRequest<Request!>!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt: (254, 18): 'MasterNodeRequest<Request : MasterNodeRequest<Request!>!>' is deprecated. Deprecated in Java
w: /Volumes/ws/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt: (51, 18): 'toLowerCase(Locale): String' is deprecated. Use lowercase() instead.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1m 7s
11 actionable tasks: 11 executed
++ find . -path '*build/distributions/*.zip'
+ zipPath=./build/distributions/opensearch-cross-cluster-replication-2.1.0.0-SNAPSHOT.zip
++ dirname ./build/distributions/opensearch-cross-cluster-replication-2.1.0.0-SNAPSHOT.zip
+ distributions=./build/distributions
+ echo 'COPY ./build/distributions/*.zip'
COPY ./build/distributions/*.zip
+ mkdir -p artifacts/plugins
+ cp ./build/distributions/opensearch-cross-cluster-replication-2.1.0.0-SNAPSHOT.zip ./artifacts/plugins
+ ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=2.1.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.4.2
  OS Info               : Mac OS X 10.16 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-14.0.2.jdk/Contents/Home
  Random Testing Seed   : 62FE807254C2DCAC
  In FIPS 140 mode      : false
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
10 actionable tasks: 3 executed, 7 up-to-date
+ mkdir -p artifacts/maven/org/opensearch
+ cp -r ./build/local-staging-repo/org/opensearch/. artifacts/maven/org/opensearch
```
