### PR TITLE
Changes to support replication plugin on OpenSearch v2.2.0

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
+      - name: Set Up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.2.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // e.g. 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
@@ -50,7 +50,7 @@ buildscript {
 
 
         // for bwc tests
-        opensearch_previous_version = System.getProperty("bwc_older_version", "1.3.1")
+        opensearch_previous_version = System.getProperty("bwc_older_version", "2.1.0")
         plugin_previous_version = opensearch_previous_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
@@ -62,7 +62,7 @@ buildscript {
         security_no_snapshot = opensearch_build.replace("-SNAPSHOT","")
         security_plugin_path = "build/dependencies/security"
         security_plugin_download_url = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
-                '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-' + security_no_snapshot + '.zip'
+                '/5858/linux/x64/tar/builds/opensearch/plugins/opensearch-security-' + security_no_snapshot + '.zip'
 
     }
 

--- a/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
@@ -29,8 +29,8 @@ import org.opensearch.action.admin.indices.settings.put.UpdateSettingsClusterSta
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
 import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.ack.ClusterStateUpdateResponse
 import org.opensearch.cluster.ack.OpenIndexClusterStateUpdateResponse
@@ -61,7 +61,7 @@ class TransportUpdateMetadataAction @Inject constructor(
     val updateSettingsService: MetadataUpdateSettingsService,
     val indexAliasService: MetadataIndexAliasesService,
     val indexStateService: MetadataIndexStateService
-) : TransportMasterNodeAction<UpdateMetadataRequest, AcknowledgedResponse>(UpdateMetadataAction.NAME,
+) : TransportClusterManagerNodeAction<UpdateMetadataRequest, AcknowledgedResponse>(UpdateMetadataAction.NAME,
     transportService, clusterService, threadPool, actionFilters, ::UpdateMetadataRequest, indexNameExpressionResolver) {
 
     companion object {
@@ -75,7 +75,7 @@ class TransportUpdateMetadataAction @Inject constructor(
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
     }
 
-    override fun masterOperation(
+    override fun clusterManagerOperation(
         task: Task,
         request: UpdateMetadataRequest,
         state: ClusterState,
@@ -286,7 +286,7 @@ class TransportUpdateMetadataAction @Inject constructor(
         }
     }
 
-    override fun masterOperation(request: UpdateMetadataRequest?, state: ClusterState?, listener: ActionListener<AcknowledgedResponse>?) {
+    override fun clusterManagerOperation(request: UpdateMetadataRequest?, state: ClusterState?, listener: ActionListener<AcknowledgedResponse>?) {
         throw UnsupportedOperationException("The task parameter is required")
     }
 


### PR DESCRIPTION
### Description
Changes to support replication plugin on OpenSearch v2.2.0

- Updated the CI link to force on #5858 (to fetch the security plugin) and unblock the release - https://github.com/opensearch-project/cross-cluster-replication/issues/472
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/462
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
