### PR TITLE
[Backport 2.x]Adding Index Settings validation before starting replication (#461)

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
@@ -31,6 +31,27 @@ object ValidationUtil {
 
     private val log = LogManager.getLogger(ValidationUtil::class.java)
 
+    fun validateIndexSettings(
+        environment: Environment,
+        followerIndex: String,
+        leaderSettings: Settings,
+        overriddenSettings: Settings,
+        metadataCreateIndexService: MetadataCreateIndexService
+    ) {
+        val settingsList = arrayOf(leaderSettings, overriddenSettings)
+        val desiredSettingsBuilder = Settings.builder()
+        // Desired settings are taking leader Settings and then overriding them with desired settings
+        for (settings in settingsList) {
+            for (key in settings.keySet()) {
+                desiredSettingsBuilder.copy(key, settings);
+            }
+        }
+        val desiredSettings = desiredSettingsBuilder.build()
+
+        metadataCreateIndexService.validateIndexSettings(followerIndex,desiredSettings, false)
+        validateAnalyzerSettings(environment, leaderSettings, overriddenSettings)
+    }
+
     fun validateAnalyzerSettings(environment: Environment, leaderSettings: Settings, overriddenSettings: Settings) {
         val analyserSettings = leaderSettings.filter { k: String? -> k!!.matches(Regex("index.analysis.*path")) }
         for (analyserSetting in analyserSettings.keySet()) {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -1168,6 +1168,26 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         }
     }
 
+    fun `test start replication invalid settings`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        val settings = Settings.builder()
+            .put("index.data_path", "/random-path/invalid-setting")
+            .build()
+
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, settings = settings))
+        } catch (e: ResponseException) {
+            Assert.assertEquals(400, e.response.statusLine.statusCode)
+            Assert.assertTrue(e.message!!.contains("Validation Failed: 1: custom path [/random-path/invalid-setting] is not a sub-path of path.shared_data"))
+        }
+    }
+
     fun `test that replication is not started when all primary shards are not in active state`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)


### PR DESCRIPTION
* Adding Index Settings validation before starting replication

Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>

* Retrieving default index settings before starting replication

Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>
(cherry picked from commit 93b43f4504b3be58a4083b4da29c79729940a1d4)

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
