### PR TITLE
For segrep enabled indices, use NRTReplicationEngine for replica shards

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -76,7 +76,6 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionResponse
 import org.opensearch.client.Client
 import org.opensearch.cluster.NamedDiff
-import org.opensearch.cluster.metadata.IndexMetadata.INDEX_REPLICATION_TYPE_SETTING
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.metadata.Metadata
 import org.opensearch.cluster.metadata.RepositoryMetadata
@@ -365,7 +364,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
         return if (indexSettings.settings.get(REPLICATED_INDEX_SETTING.key) != null) {
             Optional.of(EngineFactory { config ->
                 // Use NRTSegmentReplicationEngine for SEGMENT replication type indices replica shards
-                if (config.isReadOnlyReplica && indexSettings.settings.get(INDEX_REPLICATION_TYPE_SETTING.key) != null && indexSettings.settings.get(INDEX_REPLICATION_TYPE_SETTING.key).equals("SEGMENT")) {
+                if (config.isReadOnlyReplica) {
                     NRTReplicationEngine(config)
                 } else {
                     ReplicationEngine(config)

--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -364,8 +364,9 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
     override fun getEngineFactory(indexSettings: IndexSettings): Optional<EngineFactory> {
         return if (indexSettings.settings.get(REPLICATED_INDEX_SETTING.key) != null) {
             Optional.of(EngineFactory { config ->
-                if (indexSettings.settings.get(INDEX_REPLICATION_TYPE_SETTING.key).equals("SEGMENT")) {
-                    if (config.isReadOnlyReplica) NRTReplicationEngine(config) else ReplicationEngine(config)
+                // Use NRTSegmentReplicationEngine for SEGMENT replication type indices replica shards
+                if (config.isReadOnlyReplica && indexSettings.settings.get(INDEX_REPLICATION_TYPE_SETTING.key) != null && indexSettings.settings.get(INDEX_REPLICATION_TYPE_SETTING.key).equals("SEGMENT")) {
+                    NRTReplicationEngine(config)
                 } else {
                     ReplicationEngine(config)
                 }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Update EngineFactory to return NRTReplicationEngine for SegRep enabled replica shards. Today both primary & replica uses [ReplicationEngine](https://github.com/opensearch-project/cross-cluster-replication/blob/28d24507a6c641507ac44e32a353ad33eef166aa/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt#L326) (extends InternalEngine from OpenSearch) though [NRTReplicationEngine](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java#L49) is needed on replica shards for SegmentReplication to work. 

### Resolves
https://github.com/opensearch-project/OpenSearch/issues/3823

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
