### PR TITLE
Fix for missing ShardReplicationTasks on new nodes

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -183,7 +183,8 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     ReplicationState.INIT_FOLLOW -> {
                         log.info("Starting shard tasks")
                         addIndexBlockForReplication()
-                        startShardFollowTasks(emptyMap())
+                        FollowingState(startNewOrMissingShardTasks())
+
                     }
                     ReplicationState.FOLLOWING -> {
                         if (currentTaskState is FollowingState) {
@@ -206,8 +207,8 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                             // Tasks need to be started
                             state
                         } else {
-                            state = pollShardTaskStatus((followingTaskState as FollowingState).shardReplicationTasks)
-                            followingTaskState = startMissingShardTasks((followingTaskState as FollowingState).shardReplicationTasks)
+                            state = pollShardTaskStatus()
+                            followingTaskState = FollowingState(startNewOrMissingShardTasks())
                             when (state) {
                                 is MonitoringState -> {
                                     updateMetadata()
@@ -285,24 +286,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         clusterService.addListener(this)
     }
 
-    private suspend fun startMissingShardTasks(shardTasks: Map<ShardId, PersistentTask<ShardReplicationParams>>): IndexReplicationState {
-        val persistentTasks = clusterService.state().metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
-
-        val runningShardTasks = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
-                .map { task -> task.params as ShardReplicationParams }
-                .collect(Collectors.toList())
-
-        val runningTasksForCurrentIndex = shardTasks.filter { entry -> runningShardTasks.find { task -> task.followerShardId == entry.key } != null}
-
-        val numMissingTasks = shardTasks.size - runningTasksForCurrentIndex.size
-        if (numMissingTasks > 0) {
-            log.info("Starting $numMissingTasks missing shard task(s)")
-            return startShardFollowTasks(runningTasksForCurrentIndex)
-        }
-        return FollowingState(shardTasks)
-    }
-
-    private suspend fun pollShardTaskStatus(shardTasks: Map<ShardId, PersistentTask<ShardReplicationParams>>): IndexReplicationState {
+    private suspend fun pollShardTaskStatus(): IndexReplicationState {
         val failedShardTasks = findAllReplicationFailedShardTasks(followerIndexName, clusterService.state())
         if (failedShardTasks.isNotEmpty()) {
             log.info("Failed shard tasks - ", failedShardTasks)
@@ -343,11 +327,16 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         registerCloseListeners()
         val clusterState = clusterService.state()
         val persistentTasks = clusterState.metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
-        val runningShardTasks = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
+
+        val followerShardIds = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
+            .map {  shard -> shard.value.shardId }
+            .stream().collect(Collectors.toSet())
+        val runningShardTasksForIndex = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
                 .map { task -> task.params as ShardReplicationParams }
+                .filter {taskParam -> followerShardIds.contains(taskParam.followerShardId) }
                 .collect(Collectors.toList())
 
-        if (runningShardTasks.size == 0) {
+        if (runningShardTasksForIndex.size != followerShardIds.size) {
             return InitFollowState
         }
 
@@ -691,19 +680,27 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         }
     }
 
-    private suspend fun
-            startShardFollowTasks(tasks: Map<ShardId, PersistentTask<ShardReplicationParams>>): FollowingState {
+    suspend fun startNewOrMissingShardTasks():  Map<ShardId, PersistentTask<ShardReplicationParams>> {
         assert(clusterService.state().routingTable.hasIndex(followerIndexName)) { "Can't find index $followerIndexName" }
         val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
-        val newTasks = shards.map {
+        val persistentTasks = clusterService.state().metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
+        val runningShardTasks = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
+            .map { task -> task as PersistentTask<ShardReplicationParams> }
+            .filter { task -> task.params!!.followerShardId.indexName  == followerIndexName}
+            .collect(Collectors.toMap(
+                {t: PersistentTask<ShardReplicationParams> -> t.params!!.followerShardId},
+                {t: PersistentTask<ShardReplicationParams> -> t}))
+
+        val tasks = shards.map {
             it.value.shardId
         }.associate { shardId ->
-            val task = tasks.getOrElse(shardId) {
+            val task = runningShardTasks.getOrElse(shardId) {
                 startReplicationTask(ShardReplicationParams(leaderAlias, ShardId(leaderIndex, shardId.id), shardId))
             }
             return@associate shardId to task
         }
-        return FollowingState(newTasks)
+
+        return tasks
     }
 
     private suspend fun cancelRestore() {


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
In current implementation of IndexReplicationTask, if the task gets killed and spawned up on a new node, it tries to figure out if ShardReplicationTask for all the shards are running or not. If not, it tries to create those again. This logic is broken as of now as instead of checking for `ShardReplicationTask` for current index, it check for all the `ShardReplicationTask` on the cluster. This change fixes this by filtering the tasks specific to the current index. 
 
Ideally we should be adding IT for this case but haven't as simulating the usecase would be very difficult. 

### Testing done
Simulating this code path would be tricky locally as we need to stop the ShardReplicationTasks and then immediately kill the IndexReplicationTask. 
For local testing, I've verified that the filtering logic that is added here works as expected and only filters tasks related to the current index. 

### Issues Resolved
[482](https://github.com/opensearch-project/cross-cluster-replication/issues/482)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
