### PR TITLE
[Backport 2.1]  Updating filters as well during Alias update (#491)

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -518,13 +518,18 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     for (alias in toAdd) {
                         log.info("Adding alias ${alias.alias} from $followerIndexName")
                         // Copying writeIndex from leader doesn't cause any issue as writes will be blocked anyways
-                        request.addAliasAction(AliasActions.add().index(followerIndexName)
-                                .alias(alias.alias)
-                                .indexRouting(alias.indexRouting)
-                                .searchRouting(alias.searchRouting)
-                                .writeIndex(alias.writeIndex())
-                                .isHidden(alias.isHidden)
-                        )
+                        var aliasAction = AliasActions.add().index(followerIndexName)
+                            .alias(alias.alias)
+                            .indexRouting(alias.indexRouting)
+                            .searchRouting(alias.searchRouting)
+                            .writeIndex(alias.writeIndex())
+                            .isHidden(alias.isHidden)
+
+                        if (alias.filteringRequired())  {
+                            aliasAction = aliasAction.filter(alias.filter.string())
+                        }
+
+                        request.addAliasAction(aliasAction)
                     }
 
                     var toRemove = followerAliases - leaderAliases

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -65,6 +65,7 @@ import org.opensearch.index.mapper.MapperService
 import org.opensearch.repositories.fs.FsRepository
 import org.opensearch.test.OpenSearchTestCase.assertBusy
 import org.junit.Assert
+import org.opensearch.cluster.metadata.AliasMetadata
 import org.opensearch.common.xcontent.DeprecationHandler
 import org.opensearch.common.xcontent.NamedXContentRegistry
 import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
@@ -344,8 +345,10 @@ class StartReplicationIT: MultiClusterRestTestCase() {
 
         createConnectionBetweenClusters(FOLLOWER, LEADER)
 
-        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).alias(Alias("leaderAlias")), RequestOptions.DEFAULT)
-        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName)
+            .alias(Alias("leaderAlias").filter("{\"term\":{\"year\":2016}}").routing("1"))
+            , RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
                 waitForRestore = true)
@@ -361,6 +364,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                         followerClient.indices().getAlias(GetAliasesRequest().indices(followerIndexName),
                                 RequestOptions.DEFAULT).aliases[followerIndexName]
                 )
+
             }, 30L, TimeUnit.SECONDS)
         } finally {
             followerClient.stopReplication(followerIndexName)
@@ -541,7 +545,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             var indicesAliasesRequest = IndicesAliasesRequest()
             var aliasAction = IndicesAliasesRequest.AliasActions.add()
                     .index(leaderIndexName)
-                    .alias("alias1")
+                    .alias("alias1").filter("{\"term\":{\"year\":2016}}").routing("1")
             indicesAliasesRequest.addAliasAction(aliasAction)
             leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
 


### PR DESCRIPTION
Testing : Integ Test, Local
Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>

### Description
Alias filter changes aren't getting replicated to follower cluster.

On inspecting code, the [logic to replicate alias](https://github.com/opensearch-project/cross-cluster-replication/blob/main/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt#L521) is missing code to replicate filter. This results in inconsistent alias on the follower end whenever an alias filter is updated.

This change adds the logic to copy the filters as well . I have also verified that there is no other alias metadata we are missing.
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/490
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
