### PR TITLE
Add lastExecutionTime for autofollow coroutine

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -74,6 +74,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
             try {
                 addRetryScheduler()
                 pollForIndices()
+                stat.lastExecutionTime = System.currentTimeMillis()
                 delay(replicationSettings.autofollowFetchPollDuration.millis)
             }
             catch(e: OpenSearchException) {
@@ -252,6 +253,7 @@ class AutoFollowStat: Task.Status {
     var failCounterForRun :Long=0
     var successCount: Long=0
     var failedLeaderCall :Long=0
+    var lastExecutionTime : Long=0
 
 
     constructor(name: String, pattern: String) {
@@ -266,6 +268,7 @@ class AutoFollowStat: Task.Status {
         failedIndices = inp.readSet(StreamInput::readString)
         successCount = inp.readLong()
         failedLeaderCall = inp.readLong()
+        lastExecutionTime = inp.readLong()
     }
 
     override fun writeTo(out: StreamOutput) {
@@ -275,6 +278,7 @@ class AutoFollowStat: Task.Status {
        out.writeCollection(failedIndices, StreamOutput::writeString)
        out.writeLong(successCount)
        out.writeLong(failedLeaderCall)
+       out.writeLong(lastExecutionTime)
     }
 
     override fun getWriteableName(): String {
@@ -289,6 +293,8 @@ class AutoFollowStat: Task.Status {
         builder.field("num_failed_start_replication", failCount)
         builder.field("num_failed_leader_calls", failedLeaderCall)
         builder.field("failed_indices", failedIndices)
+        builder.field("last_execution_time", lastExecutionTime)
         return builder.endObject()
     }
+
 }

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -91,6 +91,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                         .isEqualTo(true)
                 followerClient.waitForShardTaskStart(leaderIndexNameNew, waitForShardTask)
                 followerClient.waitForShardTaskStart(leaderIndexName, waitForShardTask)
+
                 var stats = followerClient.AutoFollowStats()
                 var af_stats = stats.get("autofollow_stats")!! as ArrayList<HashMap<String, Any>>
                 for (key in af_stats) {
@@ -118,8 +119,13 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                 TimeValue.timeValueSeconds(30))
             val clusterUpdateSetttingsReq = ClusterUpdateSettingsRequest().persistentSettings(settings)
             val clusterUpdateResponse = followerClient.cluster().putSettings(clusterUpdateSetttingsReq, RequestOptions.DEFAULT)
+
+            var lastExecutionTime = 0L
+            var stats = followerClient.AutoFollowStats()
+
             Assert.assertTrue(clusterUpdateResponse.isAcknowledged)
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
+
             leaderIndexNameNew = createRandomIndex(leaderClient)
             // Verify that newly created index on leader which match the pattern are also replicated.
             assertBusy({
@@ -127,7 +133,24 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                         .exists(GetIndexRequest(leaderIndexNameNew), RequestOptions.DEFAULT))
                         .isEqualTo(true)
                 followerClient.waitForShardTaskStart(leaderIndexNameNew, waitForShardTask)
+                var af_stats = stats.get("autofollow_stats")!! as ArrayList<HashMap<String, Any>>
+                for (key in af_stats) {
+                    if(key["name"] == indexPatternName) {
+                        Assertions.assertThat(key["last_execution_time"]!! as Long).isNotEqualTo(0L)
+                        lastExecutionTime = key["last_execution_time"]!! as Long
+                    }
+                }
+
             }, 30, TimeUnit.SECONDS)
+
+            assertBusy({
+            var af_stats = stats.get("autofollow_stats")!! as ArrayList<HashMap<String, Any>>
+            for (key in af_stats) {
+                if(key["name"] == indexPatternName) {
+                    Assertions.assertThat(key["last_execution_time"]!! as Long).isNotEqualTo(lastExecutionTime)
+                }
+            }
+            }, 40, TimeUnit.SECONDS)
 
 
         } finally {


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Currently if the autofollow coroutine is not getting executed for any reason, there is no mechanism to get visibility into that.
This change adds a new key `last_execution_time` in the autofollow stats which user can monitor to ensure that autofollow task is getting executed as expected.
 
### Issues Resolved
[485](https://github.com/opensearch-project/cross-cluster-replication/issues/485)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
