### PR TITLE
Add Forum link in Cross-cluster replication plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ For more details on design and architecture, please refer to [RFC](docs/RFC.md) 
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
+## Getting Help
+
+If you find a bug, or have a feature request, please don't hesitate to open an issue in this repository.
+
+For more information, see the [project website](https://opensearch.org/) and [technical documentation](https://opensearch.org/docs/latest/replication-plugin/index/). If you need help and are unsure where to open an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/plugins/cross-cluster-replication/53).
+
 ## License
 
 This project is licensed under the Apache-2.0 License.


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Added a "Getting Help" section that includes a link to the main OpenSearch product page, a link that goes direction to Cross-cluster replication in documentation, and a link to the OpenSearch Forum page.
 
### Issues Resolved
This more closely corresponds to the information found in the README.md file in all of the other plugins bundled with OpenSearch.

This fixes the issue for the Cross-cluster replication plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
