### PR TITLE
added groupId to pluginzip publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -889,6 +889,7 @@ publishing {
             pom {
                 name = opensearchplugin.name
                 description = opensearchplugin.description
+                group = "org.opensearch.plugin"
                 licenses {
                     license {
                         name = "The Apache License, Version 2.0"


### PR DESCRIPTION
Signed-off-by: sricharanvuppu <srivuppu@amazon.com>

### Description
Added `groupId` as `org.opensearch.plugin` in `pluginZip` publication
 
### Issues Resolved
#534 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
