### PR TITLE
Upgrade Snakeyml and Jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,8 @@ configurations.all {
         force 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
         force 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
         force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.12.6'
-        force 'org.yaml:snakeyaml:1.31'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+        force 'org.yaml:snakeyaml:1.32'
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
     }
 }


### PR DESCRIPTION
Signed-off-by: Sooraj Sinha <soosinha@amazon.com>

### Description
Bump Snakeyml to 1.32 and Jackson to 2.13.4 to address the CVE: https://nvd.nist.gov/vuln/detail/CVE-2022-25857
 
### Issues Resolved
#569 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
