### PR TITLE
Added configurable parameter to use 50% of heap memory for CCR perfor…

### DIFF
--- a/perf_workflow/requirements.txt
+++ b/perf_workflow/requirements.txt
@@ -6,6 +6,7 @@ pipenv
 requests
 retry
 ndg-httpsclient
+psutil
 pyopenssl
 pyasn1
 aws_cdk.core~=1.143.0

--- a/perf_workflow/run_perf_suite/ccr_perf_test.py
+++ b/perf_workflow/run_perf_suite/ccr_perf_test.py
@@ -52,6 +52,7 @@ class CcrPerfTest:
         self.execution_id = None
         self.test_succeeded = False
         self.failure_reason = None
+        self.use_50_percent_heap = test_config["use_50_percent_heap"]
 
     def get_infra_repo_url(self):
         if "GITHUB_TOKEN" in os.environ:
@@ -79,6 +80,7 @@ class CcrPerfTest:
                         self.security,
                         self.test_config.get("DataNodes", 1),
                         self.test_config.get("MasterNodes", 0),
+                        use_50_percent_heap = self.use_50_percent_heap
                     )
                     # TODO: Add support for configurable instance type. Default is m5.2xlarge
                     with self.create_cluster(

--- a/perf_workflow/run_perf_suite/test_suite.yaml
+++ b/perf_workflow/run_perf_suite/test_suite.yaml
@@ -4,18 +4,21 @@
   Workload: eventdata
   DataNodes: 1
   MasterNodes: 0
+  use_50_percent_heap: "enable"
 - Number: 2
   Description: "single_node_multiple_shard"
   Shards: 10
   Workload: so
   DataNodes: 1
   MasterNodes: 0
+  use_50_percent_heap: "enable"
 - Number: 3
   Description: "multi_node_without_replica"
   Shards: 4
   Workload: nyc_taxis
   DataNodes: 4
   MasterNodes: 3
+  use_50_percent_heap: "enable"
 - Number: 4
   Description: "multi_node_with_replica"
   Shards: 4
@@ -23,3 +26,4 @@
   Workload: nyc_taxis
   DataNodes: 4
   MasterNodes: 3
+  use_50_percent_heap: "enable"


### PR DESCRIPTION
Signed-off-by: Mohit Kumar <mohitamg@amazon.com>

### Description
Currently, the CC perf test uses 1GB of heap memory irrespective of node heap size for cluster nodes participating in the test.
These changes that have been made include a variable and if its value is true then use 50% of total heap memory for CC perf test.
Added a optional boolean type parameter to let clusters participating in the cross cluster performance test to use 50% of heap memory for system processes but for the CCR repo in general kept it "enable"
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-infra/issues/170
 
### Check List
- [] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
