### PR TITLE
Include default index settings during leader setting validation

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -93,7 +93,9 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                         !leaderSettings.get(ReplicationPlugin.REPLICATED_INDEX_SETTING.key).isNullOrBlank()) {
                     throw IllegalArgumentException("Cannot Replicate a Replicated Index ${request.leaderIndex}")
                 }
-                if (!leaderSettings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.key, true)) {
+
+                // Soft deletes should be enabled for replication to work.
+                if (!leaderSettings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.key, false)) {
                     throw IllegalArgumentException("Cannot Replicate an index where the setting ${IndexSettings.INDEX_SOFT_DELETES_SETTING.key} is disabled")
                 }
 
@@ -120,6 +122,7 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
         }
     }
 
+
     private suspend fun getLeaderClusterState(leaderAlias: String, leaderIndex: String): ClusterState {
         val remoteClusterClient = client.getRemoteClusterClient(leaderAlias)
         val clusterStateRequest = remoteClusterClient.admin().cluster().prepareState()
@@ -136,8 +139,18 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
     private suspend fun getLeaderIndexSettings(leaderAlias: String, leaderIndex: String): Settings {
         val remoteClient = client.getRemoteClusterClient(leaderAlias)
         val getSettingsRequest = GetSettingsRequest().includeDefaults(true).indices(leaderIndex)
-        val settingsResponse = remoteClient.suspending(remoteClient.admin().indices()::getSettings,
-                injectSecurityContext = true)(getSettingsRequest)
-        return settingsResponse.indexToSettings.get(leaderIndex) ?: throw IndexNotFoundException("${leaderAlias}:${leaderIndex}")
+        val settingsResponse = remoteClient.suspending(
+            remoteClient.admin().indices()::getSettings,
+            injectSecurityContext = true
+        )(getSettingsRequest)
+
+        val leaderSettings = settingsResponse.indexToSettings.get(leaderIndex)
+            ?: throw IndexNotFoundException("${leaderAlias}:${leaderIndex}")
+        val leaderDefaultSettings = settingsResponse.indexToDefaultSettings.get(leaderIndex)
+            ?: throw IndexNotFoundException("${leaderAlias}:${leaderIndex}")
+
+        // Since we want user configured as well as default settings, we combine both by putting default settings
+        // and then the explicitly set ones to override the default settings.
+        return Settings.builder().put(leaderDefaultSettings).put(leaderSettings).build()
     }
 }


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
While starting replication, we perform validation on the leader settings but we aren't checking the default values right now. This change populates the settings with default value first so we always get the correct index settings.
 
### Issues Resolved
[298](https://github.com/opensearch-project/cross-cluster-replication/issues/298)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
