### PR TITLE
[Backport 1.x]Changed jackson databind version to 2.13.4.2 and backported to 1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript {
         plugin_previous_version = opensearch_previous_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
-        kotlin_version = System.getProperty("kotlin.version", "1.3.72")
+        kotlin_version = System.getProperty("kotlin.version", "1.6.0")
 
     }
 
@@ -59,7 +59,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC15"
-        classpath "org.jacoco:org.jacoco.agent:0.8.5"
+        classpath "org.jacoco:org.jacoco.agent:0.8.7"
     }
 }
 
@@ -75,6 +75,9 @@ allprojects {
     if (isSnapshot) {
         version += "-SNAPSHOT"
     }
+    // Have resolve the jacoco version here to work with kotlin
+    // Ref: https://github.com/jacoco/jacoco/issues/1187
+    jacoco.toolVersion = "0.8.7"
 }
 
 apply plugin: 'java'
@@ -102,7 +105,7 @@ configurations.all {
         force 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
         force 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
         force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
         force 'org.yaml:snakeyaml:1.32'
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
     }

--- a/src/main/kotlin/org/opensearch/replication/task/CrossClusterReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/CrossClusterReplicationTask.kt
@@ -21,6 +21,7 @@ import org.opensearch.replication.util.suspending
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -177,7 +178,7 @@ abstract class CrossClusterReplicationTask(id: Long, type: String, action: Strin
     protected suspend fun updateTaskState(state: PersistentTaskState) {
         client.suspending(::updatePersistentTaskState)(state)
     }
-
+    @ObsoleteCoroutinesApi
     protected abstract suspend fun execute(scope: CoroutineScope, initialState: PersistentTaskState?)
 
     protected open suspend fun cleanup() {}


### PR DESCRIPTION
Signed-off-by: Mohit Kumar <mohitamg@amazon.com>

### Description
Jackson databind version changed to 2.13.4.2 , kotlin version changed to 1.6.0 and jacoco version changed to 0.8.7
 

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
