### PR TITLE
[Backport #619 to  2.x] stopping replication before clean up of indices

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
@@ -49,7 +49,6 @@ class BasicReplicationIT : MultiClusterRestTestCase() {
         // Create an empty index on the leader and trigger replication on it
         val createIndexResponse = leader.indices().create(CreateIndexRequest(leaderIndex), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
         follower.startReplication(StartReplicationRequest("source", leaderIndex, followerIndex), waitForRestore=true)
         val source = mapOf("name" to randomAlphaOfLength(20), "age" to randomInt().toString())
         var response = leader.index(IndexRequest(leaderIndex).id("1").source(source), RequestOptions.DEFAULT)


### PR DESCRIPTION
Signed-off-by: sricharanvuppu <srivuppu@amazon.com>

### Description
stopping replication before clean up of indices
cherry picked from https://github.com/opensearch-project/cross-cluster-replication/commit/ad8e8ded88c2548a6811855929d5c71f5cea4e3e
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
