### PR TITLE
[Backport #619 to 2.2] stopReplication API removed from integ test cases 

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
@@ -11,6 +11,7 @@
 
 package org.opensearch.replication
 
+import com.nhaarman.mockitokotlin2.stub
 import org.opensearch.replication.MultiClusterAnnotations.ClusterConfiguration
 import org.opensearch.replication.MultiClusterAnnotations.ClusterConfigurations
 import org.opensearch.replication.MultiClusterAnnotations.getAnnotationsFromClass
@@ -56,6 +57,7 @@ import org.junit.After
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
+import org.opensearch.index.mapper.ObjectMapper
 import java.nio.file.Files
 import java.security.KeyManagementException
 import java.security.KeyStore
@@ -419,8 +421,32 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
             testCluster.lowLevelClient.performRequest(request)
         }
     }
-
+    private fun stopAllReplicationJobs(testCluster: TestCluster) {
+        val indicesResponse = testCluster.lowLevelClient.performRequest((Request("GET","/_cat/indices/*,-.*?format=json&pretty")))
+        val indicesResponseEntity = EntityUtils.toString(indicesResponse.entity)
+        var parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, indicesResponseEntity)
+        parser.list().forEach{ item->
+            val str = item.toString()
+            val map = str.subSequence(1,str.length-1).split(",").associate {
+                val (key, value) = it.trim().split("=")
+                key to value
+            }
+            val ind = map.get("index")
+            try {
+                val stopRequest = Request("POST","/_plugins/_replication/" + ind.toString() + "/_stop")
+                stopRequest.setJsonEntity("{}")
+                stopRequest.setOptions(RequestOptions.DEFAULT)
+                val response=testCluster.lowLevelClient.performRequest(stopRequest)
+            }
+            catch (e:ResponseException){
+                if(e.response.statusLine.statusCode!=400) {
+                    throw e
+                }
+            }
+        }
+    }
     protected fun wipeIndicesFromCluster(testCluster: TestCluster) {
+        stopAllReplicationJobs(testCluster)
         try {
             val deleteRequest = Request("DELETE", "*,-.*") // All except system indices
             val response = testCluster.lowLevelClient.performRequest(deleteRequest)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteFollowerIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteFollowerIT.kt
@@ -36,44 +36,35 @@ class ClusterRerouteFollowerIT : MultiClusterRestTestCase() {
     fun `test replication works after rerouting a shard from one node to another in follower cluster`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-        try {
-            changeTemplate(LEADER)
-            createConnectionBetweenClusters(FOLLOWER, LEADER)
-            val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
-            Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
-            insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
-
-            //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
-            assertBusy ({
-                try {
-                    Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 1")
-                } catch (ex: Exception) {
-                    Assert.fail("Exception while querying follower cluster. Failing to retry again")
-                }
-            }, 1, TimeUnit.MINUTES)
-
-            val nodes = getNodesInCluster(FOLLOWER)
-
-            val primaryNode = getPrimaryNodeForShard(FOLLOWER,followerIndexName, "0")
-            val unassignedNode = nodes.filter{!it.equals(primaryNode)}.stream().findFirst().get()
-            rerouteShard(FOLLOWER, "0", followerIndexName, primaryNode, unassignedNode)
-
-            assertBusy ({
-                Assertions.assertThat(getPrimaryNodeForShard(FOLLOWER,followerIndexName, "0")).isEqualTo(unassignedNode)
-            }, 1, TimeUnit.MINUTES)
-            logger.info("rereouted shard is " + getPrimaryNodeForShard(FOLLOWER,followerIndexName, "0"))
-            insertDocToIndex(LEADER, "2", "dummy data 2",leaderIndexName)
-
-            assertBusy ({
-                try {
-                    Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 2")
-                } catch (ex: Exception) {
-                    Assert.fail("Exception while querying follower cluster. Failing to retry again")
-                }
-            }, 1, TimeUnit.MINUTES)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        changeTemplate(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+        insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
+        //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
+        assertBusy ({
+            try {
+                Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 1")
+            } catch (ex: Exception) {
+                Assert.fail("Exception while querying follower cluster. Failing to retry again")
+            }
+        }, 1, TimeUnit.MINUTES)
+        val nodes = getNodesInCluster(FOLLOWER)
+        val primaryNode = getPrimaryNodeForShard(FOLLOWER,followerIndexName, "0")
+        val unassignedNode = nodes.filter{!it.equals(primaryNode)}.stream().findFirst().get()
+        rerouteShard(FOLLOWER, "0", followerIndexName, primaryNode, unassignedNode)
+        assertBusy ({
+            Assertions.assertThat(getPrimaryNodeForShard(FOLLOWER,followerIndexName, "0")).isEqualTo(unassignedNode)
+        }, 1, TimeUnit.MINUTES)
+        logger.info("rereouted shard is " + getPrimaryNodeForShard(FOLLOWER,followerIndexName, "0"))
+        insertDocToIndex(LEADER, "2", "dummy data 2",leaderIndexName)
+        assertBusy ({
+            try {
+                Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 2")
+            } catch (ex: Exception) {
+                Assert.fail("Exception while querying follower cluster. Failing to retry again")
+            }
+        }, 1, TimeUnit.MINUTES)
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteLeaderIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteLeaderIT.kt
@@ -36,43 +36,34 @@ class ClusterRerouteLeaderIT : MultiClusterRestTestCase() {
     fun `test replication works after rerouting a shard from one node to another in leader cluster`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-        try {
-            changeTemplate(LEADER)
-            createConnectionBetweenClusters(FOLLOWER, LEADER)
-            val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
-            Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
-            insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
-
-            //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
-            assertBusy ({
-                try {
-                    Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 1")
-                } catch (ex: Exception) {
-                    Assert.fail("Exception while querying follower cluster. Failing to retry again")
-                }
-            }, 1, TimeUnit.MINUTES)
-
-            val nodes = getNodesInCluster(LEADER)
-            val primaryNode = getPrimaryNodeForShard(LEADER,leaderIndexName, "0")
-            val unassignedNode = nodes.filter{!it.equals(primaryNode)}.stream().findFirst().get()
-            rerouteShard(LEADER, "0", leaderIndexName, primaryNode, unassignedNode)
-
-            assertBusy ({
-                Assertions.assertThat(getPrimaryNodeForShard(LEADER,leaderIndexName, "0")).isEqualTo(unassignedNode)
-            }, 1, TimeUnit.MINUTES)
-
-            insertDocToIndex(LEADER, "2", "dummy data 2",leaderIndexName)
-
-            assertBusy ({
-                try {
-                    Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 2")
-                } catch (ex: Exception) {
-                    Assert.fail("Exception while querying follower cluster. Failing to retry again")
-                }
-            }, 1, TimeUnit.MINUTES)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        changeTemplate(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+        insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
+        //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
+        assertBusy ({
+            try {
+                Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 1")
+            } catch (ex: Exception) {
+                Assert.fail("Exception while querying follower cluster. Failing to retry again")
+            }
+        }, 1, TimeUnit.MINUTES)
+        val nodes = getNodesInCluster(LEADER)
+        val primaryNode = getPrimaryNodeForShard(LEADER,leaderIndexName, "0")
+        val unassignedNode = nodes.filter{!it.equals(primaryNode)}.stream().findFirst().get()
+        rerouteShard(LEADER, "0", leaderIndexName, primaryNode, unassignedNode)
+        assertBusy ({
+            Assertions.assertThat(getPrimaryNodeForShard(LEADER,leaderIndexName, "0")).isEqualTo(unassignedNode)
+        }, 1, TimeUnit.MINUTES)
+        insertDocToIndex(LEADER, "2", "dummy data 2",leaderIndexName)
+        assertBusy ({
+            try {
+                Assertions.assertThat(docs(FOLLOWER, followerIndexName)).contains("dummy data 2")
+            } catch (ex: Exception) {
+                Assert.fail("Exception while querying follower cluster. Failing to retry again")
+            }
+        }, 1, TimeUnit.MINUTES)
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ReplicationStatusIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ReplicationStatusIT.kt
@@ -38,15 +38,11 @@ class ReplicationStatusIT: MultiClusterRestTestCase() {
         createConnectionBetweenClusters(FOLLOWER, LEADER)
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(indexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", indexName, indexName), waitForRestore = true)
-            assertBusy({
-                var statusResp = followerClient.replicationStatus(indexName)
-                `validate status syncing response`(statusResp)
-            }, 30, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(indexName)
-        }
+        followerClient.startReplication(StartReplicationRequest("source", indexName, indexName), waitForRestore = true)
+        assertBusy({
+            var statusResp = followerClient.replicationStatus(indexName)
+            `validate status syncing response`(statusResp)
+        }, 30, TimeUnit.SECONDS)
     }
 
     fun `test replication status without valid params`() {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ResumeReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ResumeReplicationIT.kt
@@ -59,26 +59,19 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
     fun `test pause and resume replication in following state and empty index`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-
-            /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
-            and verify the same
-             */
-            followerClient.pauseReplication(followerIndexName)
-            var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate paused status response`(statusResp)
-            statusResp = followerClient.replicationStatus(followerIndexName,false)
-            `validate aggregated paused status response`(statusResp)
-            followerClient.resumeReplication(followerIndexName)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
+        and verify the same
+         */
+        followerClient.pauseReplication(followerIndexName)
+        var statusResp = followerClient.replicationStatus(followerIndexName)
+        `validate paused status response`(statusResp)
+        statusResp = followerClient.replicationStatus(followerIndexName,false)
+        `validate aggregated paused status response`(statusResp)
+        followerClient.resumeReplication(followerIndexName)
     }
 
 
@@ -86,127 +79,88 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-
-            assertThatThrownBy {
-                var statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate status syncing response`(statusResp)
-                statusResp = followerClient.replicationStatus(followerIndexName,false)
-                `validate status syncing aggregated response`(statusResp)
-                followerClient.resumeReplication(followerIndexName)
-                statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate not paused status response`(statusResp)
-                statusResp = followerClient.replicationStatus(followerIndexName,false)
-                `validate not paused status aggregated response`(statusResp)
-            }.isInstanceOf(ResponseException::class.java)
-                    .hasMessageContaining("Replication on Index ${followerIndexName} is already running")
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        assertThatThrownBy {
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate status syncing response`(statusResp)
+            statusResp = followerClient.replicationStatus(followerIndexName,false)
+            `validate status syncing aggregated response`(statusResp)
+            followerClient.resumeReplication(followerIndexName)
+            statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate not paused status response`(statusResp)
+            statusResp = followerClient.replicationStatus(followerIndexName,false)
+            `validate not paused status aggregated response`(statusResp)
+        }.isInstanceOf(ResponseException::class.java)
+                .hasMessageContaining("Replication on Index ${followerIndexName} is already running")
     }
 
     fun `test resume without retention lease`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         var createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-
-
-            followerClient.pauseReplication(followerIndexName)
-
-            // If we delete the existing index and recreate the index with same name, retention leases should be lost
-            val deleteIndexResponse = leaderClient.indices().delete(DeleteIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
-            assertThat(deleteIndexResponse.isAcknowledged).isTrue()
-            createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
-            assertThat(createIndexResponse.isAcknowledged).isTrue()
-
-            assertThatThrownBy {
-                followerClient.resumeReplication(followerIndexName)
-            }.isInstanceOf(ResponseException::class.java)
-                    .hasMessageContaining("Retention lease doesn't exist. Replication can't be resumed for $followerIndexName")
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        followerClient.pauseReplication(followerIndexName)
+        // If we delete the existing index and recreate the index with same name, retention leases should be lost
+        val deleteIndexResponse = leaderClient.indices().delete(DeleteIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(deleteIndexResponse.isAcknowledged).isTrue()
+        createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        assertThatThrownBy {
+            followerClient.resumeReplication(followerIndexName)
+        }.isInstanceOf(ResponseException::class.java)
+                .hasMessageContaining("Retention lease doesn't exist. Replication can't be resumed for $followerIndexName")
     }
 
     fun `test pause and resume replication amid leader index close and open`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
 
-            /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
-            and verify the same
-             */
-            followerClient.pauseReplication(followerIndexName)
-
-            leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
-            leaderClient.indices().open(OpenIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
-
-            followerClient.resumeReplication(followerIndexName)
-
-            //Update mapping post resume assert
-            val sourceMap : MutableMap<String, String> = HashMap()
-            sourceMap["x"] = "y"
-            val indexResponse = leaderClient.index(IndexRequest(leaderIndexName).id("2").source(sourceMap), RequestOptions.DEFAULT)
-            assertThat(indexResponse.result).isIn(DocWriteResponse.Result.CREATED, DocWriteResponse.Result.UPDATED)
-            assertBusy ({
-                Assert.assertEquals(
-                        leaderClient.indices().getMapping(GetMappingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
-                                .mappings()[leaderIndexName],
-                        followerClient.indices().getMapping(GetMappingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
-                                .mappings()[followerIndexName]
-                )
-            }, 60, TimeUnit.SECONDS)
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
+        and verify the same
+         */
+        followerClient.pauseReplication(followerIndexName)
+        leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
+        leaderClient.indices().open(OpenIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
+        followerClient.resumeReplication(followerIndexName)
+        //Update mapping post resume assert
+        val sourceMap : MutableMap<String, String> = HashMap()
+        sourceMap["x"] = "y"
+        val indexResponse = leaderClient.index(IndexRequest(leaderIndexName).id("2").source(sourceMap), RequestOptions.DEFAULT)
+        assertThat(indexResponse.result).isIn(DocWriteResponse.Result.CREATED, DocWriteResponse.Result.UPDATED)
+        assertBusy ({
+            Assert.assertEquals(
+                    leaderClient.indices().getMapping(GetMappingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
+                            .mappings()[leaderIndexName],
+                    followerClient.indices().getMapping(GetMappingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
+                            .mappings()[followerIndexName]
+            )
+        }, 60, TimeUnit.SECONDS)
     }
 
     fun `test pause and resume replication amid index close`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-
-            /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
-            and verify the same
-             */
-            followerClient.pauseReplication(followerIndexName)
-
-            leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
-
-            assertThatThrownBy {
-                followerClient.resumeReplication(followerIndexName)
-            }.isInstanceOf(ResponseException::class.java)
-                    .hasMessageContaining("closed")
-        } finally {
-            try {
-                followerClient.stopReplication(followerIndexName)
-            } catch (e: Exception) {
-                // DO nothing
-            }
-        }
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
+        and verify the same
+         */
+        followerClient.pauseReplication(followerIndexName)
+        leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
+        assertThatThrownBy {
+            followerClient.resumeReplication(followerIndexName)
+        }.isInstanceOf(ResponseException::class.java)
+                .hasMessageContaining("closed")
     }
 
     fun `test that replication fails to resume when custom analyser is not present in follower`() {
@@ -217,35 +171,26 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         try {
             Files.copy(synonyms, synonymPath)
-
             val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
             assertThat(createIndexResponse.isAcknowledged).isTrue()
-
             createConnectionBetweenClusters(FOLLOWER, LEADER)
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
             followerClient.pauseReplication(followerIndexName)
             leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
             val settings: Settings = Settings.builder().loadFromStream(synonymsJson, javaClass.getResourceAsStream(synonymsJson), false)
                 .build()
-
             try {
                 leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
             } catch (e: Exception) {
                 assumeNoException("Ignored test as analyzer setting could not be added", e)
             }
             leaderClient.indices().open(OpenIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
-
             assertThatThrownBy {
                 followerClient.resumeReplication(followerIndexName)
             }.isInstanceOf(ResponseException::class.java).hasMessageContaining("resource_not_found_exception")
         } finally {
             if (Files.exists(synonymPath)) {
                 Files.delete(synonymPath)
-            }
-            try {
-                followerClient.stopReplication(followerIndexName)
-            } catch (e: Exception) {
-                // DO nothing
             }
         }
     }
@@ -261,26 +206,21 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         try {
             Files.copy(synonyms, synonymPath)
-
             val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
             assertThat(createIndexResponse.isAcknowledged).isTrue()
-
             createConnectionBetweenClusters(FOLLOWER, LEADER)
-
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
             followerClient.pauseReplication(followerIndexName)
             leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
             Files.copy(synonyms, followerSynonymPath)
             val settings: Settings = Settings.builder().loadFromStream(synonymsJson, javaClass.getResourceAsStream(synonymsJson), false)
                 .build()
-
             try {
                 leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
             } catch (e: Exception) {
                 assumeNoException("Ignored test as analyzer setting could not be added", e)
             }
             leaderClient.indices().open(OpenIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
-
             followerClient.resumeReplication(followerIndexName)
             var statusResp = followerClient.replicationStatus(followerIndexName)
             `validate status syncing response`(statusResp)
@@ -290,11 +230,6 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
             }
             if (Files.exists(followerSynonymPath)) {
                 Files.delete(followerSynonymPath)
-            }
-            try {
-                followerClient.stopReplication(followerIndexName)
-            } catch (e: Exception) {
-                // DO nothing
             }
         }
     }
@@ -312,7 +247,6 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
         try {
             Files.copy(synonyms, synonymPath)
             Files.copy(synonyms, followerSynonymPath)
-
             var settings: Settings = Settings.builder().loadFromStream(synonymsJson, javaClass.getResourceAsStream(synonymsJson), false)
                 .build()
             try {
@@ -321,7 +255,6 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
             } catch (e: Exception) {
                 assumeNoException("Ignored test as analyzer setting could not be added", e)
             }
-
             createConnectionBetweenClusters(FOLLOWER, LEADER)
             val overriddenSettings: Settings = Settings.builder()
                 .put("index.analysis.filter.my_filter.synonyms_path", followerSynonymFilename)
@@ -329,7 +262,6 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, overriddenSettings), waitForRestore = true)
             followerClient.pauseReplication(followerIndexName)
             leaderClient.indices().close(CloseIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
-
             Files.copy(synonyms, newSynonymPath)
             settings = Settings.builder()
                 .put("index.analysis.filter.my_filter.synonyms_path", "synonyms_new.txt")
@@ -340,7 +272,6 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
                 assumeNoException("Ignored test as analyzer setting could not be added", e)
             }
             leaderClient.indices().open(OpenIndexRequest(leaderIndexName), RequestOptions.DEFAULT);
-
             followerClient.resumeReplication(followerIndexName)
             var statusResp = followerClient.replicationStatus(followerIndexName)
             `validate status syncing response`(statusResp)
@@ -354,12 +285,6 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
             if (Files.exists(newSynonymPath)) {
                 Files.delete(newSynonymPath)
             }
-            try {
-                followerClient.stopReplication(followerIndexName)
-            } catch (e: Exception) {
-                // DO nothing
-            }
         }
     }
-
 }

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityBase.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityBase.kt
@@ -243,7 +243,6 @@ abstract class SecurityBase : MultiClusterRestTestCase()   {
         private fun createRoleWithPermissions(indexPattern: String, role: String) {
             val followerClient = testClusters.get(FOLLOWER)
             val persistentConnectionRequest = Request("PUT", "_plugins/_security/api/roles/"+role)
-
             val entityAsString = """
             {
                 "cluster_permissions": [
@@ -278,7 +277,6 @@ abstract class SecurityBase : MultiClusterRestTestCase()   {
             val entityAsString = """
                 {"users": ["$user"]}
             """.trimMargin()
-
             persistentConnectionRequest.entity = NStringEntity(entityAsString, ContentType.APPLICATION_JSON)
             val persistentConnectionResponse = followerClient!!.lowLevelClient.performRequest(persistentConnectionRequest)
             assertTrue(HttpStatus.SC_CREATED.toLong() == persistentConnectionResponse.statusLine.statusCode.toLong() ||
@@ -307,7 +305,6 @@ abstract class SecurityBase : MultiClusterRestTestCase()   {
                 "password":"$password"
             }
             """.trimMargin()
-
             persistentConnectionRequest.entity = NStringEntity(entityAsString, ContentType.APPLICATION_JSON)
             val persistentConnectionResponse = followerClient!!.lowLevelClient.performRequest(persistentConnectionRequest)
             assertTrue(HttpStatus.SC_CREATED.toLong() == persistentConnectionResponse.statusLine.statusCode.toLong() ||

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -56,17 +56,14 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
-            followerClient.startReplication(startReplicationRequest,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
-            assertBusy {
-                Assertions.assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-            }
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+
+        followerClient.startReplication(startReplicationRequest,
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+        assertBusy {
+            Assertions.assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
     }
 
@@ -116,26 +113,23 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
-            var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")
-            followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                    requestOptions = requestOptions)
 
-            /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
-            and verify the same
-             */
-            followerClient.pauseReplication(followerIndexName,
-                    requestOptions = requestOptions)
+        var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
+        var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")
+        followerClient.startReplication(startReplicationRequest, waitForRestore = true,
+                requestOptions = requestOptions)
 
-            // Validate paused replication using Status Api
-            assertBusy {
-                `validate aggregated paused status response`(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = requestOptions))
-            }
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        /* At this point, the follower cluster should be in FOLLOWING state. Next, we pause replication
+        and verify the same
+         */
+        followerClient.pauseReplication(followerIndexName,
+                requestOptions = requestOptions)
+
+        // Validate paused replication using Status Api
+        assertBusy {
+            `validate aggregated paused status response`(followerClient.replicationStatus(followerIndexName,
+                    requestOptions = requestOptions))
         }
     }
 
@@ -147,22 +141,18 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
-            followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+        var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
-            Assertions.assertThatThrownBy {
-                followerClient.pauseReplication(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
-            }.isInstanceOf(ResponseException::class.java)
-            .hasMessageContaining("403 Forbidden")
+        followerClient.startReplication(startReplicationRequest, waitForRestore = true,
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
 
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        Assertions.assertThatThrownBy {
+            followerClient.pauseReplication(followerIndexName,
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+        }.isInstanceOf(ResponseException::class.java)
+        .hasMessageContaining("403 Forbidden")
     }
 
     fun `test for FOLLOWER that STATUS Api works for user with valid permissions`() {
@@ -173,19 +163,16 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
-            followerClient.startReplication(startReplicationRequest,  waitForRestore = true,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+        var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
-            assertBusy {
-                `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
-            }
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(startReplicationRequest,  waitForRestore = true,
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+
+        assertBusy {
+            `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
         }
     }
 
@@ -197,21 +184,18 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
-                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
-            followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+        var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
-            Assertions.assertThatThrownBy {
-                followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
-            }.isInstanceOf(ResponseException::class.java)
-            .hasMessageContaining("403 Forbidden")
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(startReplicationRequest, waitForRestore = true,
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+
+        Assertions.assertThatThrownBy {
+            followerClient.replicationStatus(followerIndexName,
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+        }.isInstanceOf(ResponseException::class.java)
+        .hasMessageContaining("403 Forbidden")
     }
 
     fun `test for FOLLOWER that UPDATE settings works for user with valid permissions`() {
@@ -229,89 +213,76 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
+            useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+        assertBusy {
+            Assertions.assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
+        }
+        val getSettingsRequest = GetSettingsRequest()
+        getSettingsRequest.indices(followerIndexName)
+        Assert.assertEquals(
+                "1",
+                followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+        )
+
+        settings = Settings.builder()
+                .put("index.shard.check_on_startup", "checksum")
+                .build()
+        followerClient.updateReplication(followerIndexName, settings,
                 requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
-            assertBusy {
-                Assertions.assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-            val getSettingsRequest = GetSettingsRequest()
-            getSettingsRequest.indices(followerIndexName)
+
+        // Wait for the settings to get updated at follower cluster.
+        assertBusy ({
             Assert.assertEquals(
-                    "1",
+                    "checksum",
                     followerClient.indices()
                             .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                            .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
             )
-
-            settings = Settings.builder()
-                    .put("index.shard.check_on_startup", "checksum")
-                    .build()
-            followerClient.updateReplication(followerIndexName, settings,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
-
-            // Wait for the settings to get updated at follower cluster.
-            assertBusy ({
-                Assert.assertEquals(
-                        "checksum",
-                        followerClient.indices()
-                                .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
-                )
-            }, 30L, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        }, 30L, TimeUnit.SECONDS)
     }
 
     fun `test for FOLLOWER that UPDATE settings is forbidden for user with invalid permissions`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         val followerIndexName = "follower-index1-settings-invalid-perm"
-
         setMetadataSyncDelay()
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         var settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
                 .build()
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
-                    useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
-            assertBusy {
-                Assertions.assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-            val getSettingsRequest = GetSettingsRequest()
-            getSettingsRequest.indices(followerIndexName)
-            Assert.assertEquals(
-                    "1",
-                    followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-            )
-
-            settings = Settings.builder()
-                    .put("index.shard.check_on_startup", "checksum")
-                    .build()
-
-            Assertions.assertThatThrownBy {
-                followerClient.updateReplication(followerIndexName, settings,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
-            }.isInstanceOf(ResponseException::class.java)
-            .hasMessageContaining("403 Forbidden")
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
+                useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+        assertBusy {
+            Assertions.assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
         }
+        val getSettingsRequest = GetSettingsRequest()
+        getSettingsRequest.indices(followerIndexName)
+        Assert.assertEquals(
+                "1",
+                followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+        )
+        settings = Settings.builder()
+                .put("index.shard.check_on_startup", "checksum")
+                .build()
+        Assertions.assertThatThrownBy {
+            followerClient.updateReplication(followerIndexName, settings,
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+        }.isInstanceOf(ResponseException::class.java)
+        .hasMessageContaining("403 Forbidden")
     }
 
     fun `test for FOLLOWER that AutoFollow works for user with valid permissions`() {
@@ -324,12 +295,10 @@ class SecurityCustomRolesIT: SecurityBase()  {
         val leaderIndexName = createRandomIndex(indexPrefix, leaderClient)
         var leaderIndexNameNew = ""
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"),
                     requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
-
             // Verify that existing index matching the pattern are replicated.
             assertBusy ({
                 Assertions.assertThat(followerClient.indices()
@@ -337,7 +306,6 @@ class SecurityCustomRolesIT: SecurityBase()  {
                         .isEqualTo(true)
             }, 30, TimeUnit.SECONDS)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
-
             leaderIndexNameNew = createRandomIndex(indexPrefix, leaderClient)
             // Verify that newly created index on leader which match the pattern are also replicated.
             assertBusy ({
@@ -347,8 +315,6 @@ class SecurityCustomRolesIT: SecurityBase()  {
             }, 60, TimeUnit.SECONDS)
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            followerClient.stopReplication(leaderIndexName, false)
-            followerClient.stopReplication(leaderIndexNameNew)
         }
     }
 
@@ -358,7 +324,6 @@ class SecurityCustomRolesIT: SecurityBase()  {
         val indexPattern = "follower-index1*"
         val indexPatternName = "test_pattern"
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         Assertions.assertThatThrownBy {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"),
@@ -388,16 +353,13 @@ class SecurityCustomRolesIT: SecurityBase()  {
         val leaderClient = getClientForCluster(LEADER)
         val followerIndexName = "follower-index1"
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
-
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
-
             insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
             //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
             assertBusy ({
@@ -407,7 +369,6 @@ class SecurityCustomRolesIT: SecurityBase()  {
                     Assert.fail("Exception while querying follower cluster. Failing to retry again")
                 }
             }, 1, TimeUnit.MINUTES)
-
             assertBusy {
                 `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
                         requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
@@ -422,7 +383,6 @@ class SecurityCustomRolesIT: SecurityBase()  {
             }, 100, TimeUnit.SECONDS)
         } finally {
             updateRole(followerIndexName,"followerRoleValidPerms", true)
-            followerClient.stopReplication(followerIndexName)
         }
     }
 

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
@@ -42,13 +42,10 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         val leaderClient = getClientForCluster(LEADER)
         val followerIndexName = "follower-index1"
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
-
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleNoPerms",followerClusterRole = "followerRoleValidPerms"))
-
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
                 requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser6","password")) }
                 .isInstanceOf(ResponseException::class.java)
@@ -61,16 +58,13 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         val leaderClient = getClientForCluster(LEADER)
         val followerIndexName = "follower-index1"
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
-
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
-
             insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
             //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
             assertBusy ({
@@ -80,23 +74,18 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
                     Assert.fail("Exception while querying follower cluster. Failing to retry again")
                 }
             }, 1, TimeUnit.MINUTES)
-
             assertBusy {
                 `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
                         requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
             }
-
             updateRole(followerIndexName,"leaderRoleValidPerms", false)
             insertDocToIndex(LEADER, "2", "dummy data 2",leaderIndexName)
-
             assertBusy ({
                 validatePausedState(followerClient.replicationStatus(followerIndexName,
                         requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
             }, 100, TimeUnit.SECONDS)
-
         } finally {
             updateRole(followerIndexName,"leaderRoleValidPerms", true)
-            followerClient.stopReplication(followerIndexName)
         }
     }
 
@@ -105,17 +94,14 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         val leaderClient = getClientForCluster(LEADER)
         val followerIndexName = "follower-index1"
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         try {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
-
             updateFileChunkPermissions("","leaderRoleValidPerms", false)
             followerClient.startReplication(startReplicationRequest,
                     requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
-
             assertBusy ({
                 validateFailedState(followerClient.replicationStatus(followerIndexName,
                         requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
@@ -125,7 +111,6 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
             Assert.assertNull(ex)
         } finally {
             updateFileChunkPermissions("","leaderRoleValidPerms", true)
-            followerClient.stopReplication(followerIndexName)
         }
     }
 

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -73,6 +73,7 @@ import org.opensearch.replication.followerStats
 import org.opensearch.replication.leaderStats
 import org.opensearch.replication.updateReplicationStartBlockSetting
 import java.nio.file.Files
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 
@@ -96,52 +97,39 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test start replication in following state and empty index`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-            }
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
     }
 
     fun `test start replication with settings`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
         val settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3)
                 .build()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, settings = settings), waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-            }
-
-            val getSettingsRequest = GetSettingsRequest()
-            getSettingsRequest.indices(followerIndexName)
-            getSettingsRequest.includeDefaults(true)
-            assertBusy ({
-                Assert.assertEquals(
-                        "3",
-                        followerClient.indices()
-                                .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-                )
-            }, 15, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, settings = settings), waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
+        val getSettingsRequest = GetSettingsRequest()
+        getSettingsRequest.indices(followerIndexName)
+        getSettingsRequest.includeDefaults(true)
+        assertBusy ({
+            Assert.assertEquals(
+                    "3",
+                    followerClient.indices()
+                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+            )
+        }, 15, TimeUnit.SECONDS)
     }
 
 
@@ -151,22 +139,18 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         createConnectionBetweenClusters(FOLLOWER, LEADER)
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-            assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-            leaderClient.lowLevelClient.performRequest(Request("POST", "/" + leaderIndexName + "/_close"))
-            assertBusy ({
-                try {
-                    assertThat(followerClient.replicationStatus(followerIndexName)).containsKey("status")
-                    var statusResp = followerClient.replicationStatus(followerIndexName)
-                    `validate paused status on closed index`(statusResp)
-                } catch (e : Exception) {
-                    Assert.fail()
-                }
-            },30, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
+        leaderClient.lowLevelClient.performRequest(Request("POST", "/" + leaderIndexName + "/_close"))
+        assertBusy ({
+            try {
+                assertThat(followerClient.replicationStatus(followerIndexName)).containsKey("status")
+                var statusResp = followerClient.replicationStatus(followerIndexName)
+                `validate paused status on closed index`(statusResp)
+            } catch (e : Exception) {
+                Assert.fail()
+            }
+        },30, TimeUnit.SECONDS)
     }
 
 
@@ -176,52 +160,38 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         createConnectionBetweenClusters(FOLLOWER, LEADER)
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-            followerClient.pauseReplication(followerIndexName)
-            leaderClient.lowLevelClient.performRequest(Request("POST", "/" + leaderIndexName + "/_close"))
-            leaderClient.lowLevelClient.performRequest(Request("POST", "/" + leaderIndexName + "/_open"))
-            followerClient.resumeReplication(followerIndexName)
-            var statusResp = followerClient.replicationStatus(followerIndexName)
-            `validate not paused status response`(statusResp)
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        followerClient.pauseReplication(followerIndexName)
+        leaderClient.lowLevelClient.performRequest(Request("POST", "/" + leaderIndexName + "/_close"))
+        leaderClient.lowLevelClient.performRequest(Request("POST", "/" + leaderIndexName + "/_open"))
+        followerClient.resumeReplication(followerIndexName)
+        var statusResp = followerClient.replicationStatus(followerIndexName)
+        `validate not paused status response`(statusResp)
     }
 
     fun `test start replication fails when replication has already been started for the same index`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
-        try {
-            val createIndexResponse =
-                leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
-            assertThat(createIndexResponse.isAcknowledged).isTrue()
-            followerClient.startReplication(
-                StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true
-            )
-            assertThatThrownBy {
-                followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
-            }.isInstanceOf(ResponseException::class.java).hasMessageContaining(
-                "Cant use same index again for replication." +
-                        " Delete the index:$followerIndexName"
-            )
-        }
-        finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        val createIndexResponse =
+            leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        followerClient.startReplication(
+            StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true
+        )
+        assertThatThrownBy {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+        }.isInstanceOf(ResponseException::class.java).hasMessageContaining(
+            "Cant use same index again for replication." +
+                    " Delete the index:$followerIndexName"
+        )
     }
 
     fun `test start replication fails when remote cluster alias does not exist`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
         assertThatThrownBy {
@@ -233,9 +203,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test start replication fails when index does not exist`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
         assertThatThrownBy {
@@ -247,9 +215,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test start replication fails when the follower cluster is write blocked or metadata blocked`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
         addClusterMetadataBlock(FOLLOWER, "true")
@@ -264,122 +230,99 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test that follower index has same mapping as leader index`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-            Assert.assertEquals(
-                    leaderClient.indices().getMapping(GetMappingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
-                            .mappings()[leaderIndexName],
-                    followerClient.indices().getMapping(GetMappingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
-                            .mappings()[followerIndexName]
-            )
-            // test that new mapping created on leader is also propagated to follower
-            val putMappingRequest = PutMappingRequest(leaderIndexName)
-            putMappingRequest.source("{\"properties\":{\"name\":{\"type\":\"keyword\"}}}", XContentType.JSON)
-            leaderClient.indices().putMapping(putMappingRequest, RequestOptions.DEFAULT)
-            val sourceMap = mapOf("name" to randomAlphaOfLength(5))
-            leaderClient.index(IndexRequest(leaderIndexName).id("1").source(sourceMap), RequestOptions.DEFAULT)
-            val leaderMappings = leaderClient.indices().getMapping(GetMappingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
-                .mappings()[leaderIndexName]
-            assertBusy({
-                Assert.assertEquals(
-                    leaderMappings,
-                    followerClient.indices().getMapping(GetMappingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
-                        .mappings()[followerIndexName]
-                )
-            }, 30L, TimeUnit.SECONDS)
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName), waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
         }
+        Assert.assertEquals(
+                leaderClient.indices().getMapping(GetMappingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
+                        .mappings()[leaderIndexName],
+                followerClient.indices().getMapping(GetMappingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
+                        .mappings()[followerIndexName]
+        )
+        // test that new mapping created on leader is also propagated to follower
+        val putMappingRequest = PutMappingRequest(leaderIndexName)
+        putMappingRequest.source("{\"properties\":{\"name\":{\"type\":\"keyword\"}}}", XContentType.JSON)
+        leaderClient.indices().putMapping(putMappingRequest, RequestOptions.DEFAULT)
+        val sourceMap = mapOf("name" to randomAlphaOfLength(5))
+        leaderClient.index(IndexRequest(leaderIndexName).id("1").source(sourceMap), RequestOptions.DEFAULT)
+        val leaderMappings = leaderClient.indices().getMapping(GetMappingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
+            .mappings()[leaderIndexName]
+        assertBusy({
+            Assert.assertEquals(
+                leaderMappings,
+                followerClient.indices().getMapping(GetMappingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
+                    .mappings()[followerIndexName]
+            )
+        }, 30L, TimeUnit.SECONDS)
     }
 
     fun `test that index settings are getting replicated`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                 .build()
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-            val getSettingsRequest = GetSettingsRequest()
-            getSettingsRequest.indices(followerIndexName)
-            getSettingsRequest.names(IndexMetadata.SETTING_NUMBER_OF_REPLICAS)
-            assertBusy({
-                Assert.assertEquals(
-                    "0",
-                    followerClient.indices()
-                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-                )
-            }, 30L, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
         }
+        val getSettingsRequest = GetSettingsRequest()
+        getSettingsRequest.indices(followerIndexName)
+        getSettingsRequest.names(IndexMetadata.SETTING_NUMBER_OF_REPLICAS)
+        assertBusy({
+            Assert.assertEquals(
+                "0",
+                followerClient.indices()
+                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+            )
+        }, 30L, TimeUnit.SECONDS)
     }
 
     fun `test that aliases settings are getting replicated`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName)
             .alias(Alias("leaderAlias").filter("{\"term\":{\"year\":2016}}").routing("1"))
             , RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-            assertBusy({
-                Assert.assertEquals(
-                        leaderClient.indices().getAlias(GetAliasesRequest().indices(leaderIndexName),
-                                RequestOptions.DEFAULT).aliases[leaderIndexName],
-                        followerClient.indices().getAlias(GetAliasesRequest().indices(followerIndexName),
-                                RequestOptions.DEFAULT).aliases[followerIndexName]
-                )
-
-            }, 30L, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
         }
+        assertBusy({
+            Assert.assertEquals(
+                    leaderClient.indices().getAlias(GetAliasesRequest().indices(leaderIndexName),
+                            RequestOptions.DEFAULT).aliases[leaderIndexName],
+                    followerClient.indices().getAlias(GetAliasesRequest().indices(followerIndexName),
+                            RequestOptions.DEFAULT).aliases[followerIndexName]
+            )
+
+        }, 30L, TimeUnit.SECONDS)
     }
 
     fun `test that replication cannot be started on leader alias directly`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER, "source")
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).alias(Alias("leader_alias")), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
         try {
             followerClient.startReplication(StartReplicationRequest("source", "leader_alias", followerIndexName))
             fail("Expected startReplication to fail")
@@ -393,89 +336,67 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test that translog settings are set on leader and not on follower`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-                assertThat(followerClient.indices()
-                        .getSettings(GetSettingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
-                        .getSetting(followerIndexName,
-                                REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key)
-                        .isNullOrEmpty())
-            }
-
-            assertThat(leaderClient.indices()
-                    .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
-                    .getSetting(leaderIndexName,
-                            REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key) == "true")
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
+            assertThat(followerClient.indices()
+                    .getSettings(GetSettingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
+                    .getSetting(followerIndexName,
+                            REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key)
+                    .isNullOrEmpty())
         }
+        assertThat(leaderClient.indices()
+                .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
+                .getSetting(leaderIndexName,
+                        REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key) == "true")
     }
 
     fun `test that translog settings are set on leader`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-
-            val leaderSettings = leaderClient.indices()
-                    .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
-            assertThat(leaderSettings.getSetting(leaderIndexName,
-                            REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key) == "true")
-            assertThat(leaderSettings.getSetting(leaderIndexName,
-                            IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.key) == "32mb")
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        val leaderSettings = leaderClient.indices()
+                .getSettings(GetSettingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(leaderSettings.getSetting(leaderIndexName,
+                        REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key) == "true")
+        assertThat(leaderSettings.getSetting(leaderIndexName,
+                        IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.key) == "32mb")
     }
 
     fun `test that replication continues after removing translog settings based on retention lease`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                    waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-            // Turn-off the settings and index doc
-            val settingsBuilder = Settings.builder()
-                    .put(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key, false)
-            val settingsUpdateResponse = leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName)
-                    .settings(settingsBuilder.build()), RequestOptions.DEFAULT)
-            Assert.assertEquals(settingsUpdateResponse.isAcknowledged, true)
-            val sourceMap = mapOf("name" to randomAlphaOfLength(5))
-            leaderClient.index(IndexRequest(leaderIndexName).id("2").source(sourceMap), RequestOptions.DEFAULT)
-            assertBusy({
-                followerClient.get(GetRequest(followerIndexName).id("2"), RequestOptions.DEFAULT).isExists
-            }, 30L, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+                waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
         }
+        // Turn-off the settings and index doc
+        val settingsBuilder = Settings.builder()
+                .put(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key, false)
+        val settingsUpdateResponse = leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName)
+                .settings(settingsBuilder.build()), RequestOptions.DEFAULT)
+        Assert.assertEquals(settingsUpdateResponse.isAcknowledged, true)
+        val sourceMap = mapOf("name" to randomAlphaOfLength(5))
+        leaderClient.index(IndexRequest(leaderIndexName).id("2").source(sourceMap), RequestOptions.DEFAULT)
+        assertBusy({
+            followerClient.get(GetRequest(followerIndexName).id("2"), RequestOptions.DEFAULT).isExists
+        }, 30L, TimeUnit.SECONDS)
     }
 
     private fun addClusterMetadataBlock(clusterName: String, blockValue: String) {
@@ -500,203 +421,163 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test that dynamic index settings and alias are getting replicated `() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         setMetadataSyncDelay()
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         var settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                 .build()
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-
-            settings = Settings.builder()
-                    .build()
-
-            followerClient.updateReplication( followerIndexName, settings)
-
-            val getSettingsRequest = GetSettingsRequest()
-            getSettingsRequest.indices(followerIndexName)
-            getSettingsRequest.includeDefaults(true)
-            Assert.assertEquals(
-                    "0",
-                    followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-            )
-
-            settings = Settings.builder()
-                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
-                    .put("routing.allocation.enable", "none")
-                    .build()
-
-            leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
-
-            var indicesAliasesRequest = IndicesAliasesRequest()
-            var aliasAction = IndicesAliasesRequest.AliasActions.add()
-                    .index(leaderIndexName)
-                    .alias("alias1").filter("{\"term\":{\"year\":2016}}").routing("1")
-            indicesAliasesRequest.addAliasAction(aliasAction)
-            leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
-
-            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
-            getSettingsRequest.indices(followerIndexName)
-            // Leader setting is copied
-            assertBusy({
-                Assert.assertEquals(
-                    "2",
-                    followerClient.indices()
-                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-                )
-                assertEqualAliases()
-            }, 30L, TimeUnit.SECONDS)
-
-
-            // Case 2 :  Blocklisted  setting are not copied
-            Assert.assertNull(followerClient.indices()
-                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName].get("index.routing.allocation.enable"))
-
-            //Alias test case 2: Update existing alias
-            aliasAction = IndicesAliasesRequest.AliasActions.add()
-                    .index(leaderIndexName)
-                    .routing("2")
-                    .alias("alias1")
-                    .writeIndex(true)
-                    .isHidden(false)
-            indicesAliasesRequest.addAliasAction(aliasAction)
-            leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
-
-            //Use Update API
-            settings = Settings.builder()
-                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3)
-                    .put("index.routing.allocation.enable", "none")
-                    .put("index.search.idle.after", "10s")
-                    .build()
-
-            followerClient.updateReplication( followerIndexName, settings)
-            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
-
-            // Case 3 : Updated Settings take higher priority.  Blocklisted  settins shouldn't matter for that
-            assertBusy({
-                Assert.assertEquals(
-                    "3",
-                    followerClient.indices()
-                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-                )
-
-                Assert.assertEquals(
-                    "10s",
-                    followerClient.indices()
-                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName]["index.search.idle.after"]
-                )
-
-                Assert.assertEquals(
-                    "none",
-                    followerClient.indices()
-                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
-                )
-
-                assertEqualAliases()
-            }, 30L, TimeUnit.SECONDS)
-
-            //Clear the settings
-            settings = Settings.builder()
-                    .build()
-            followerClient.updateReplication( followerIndexName, settings)
-
-            //Alias test case 3: Delete one alias and add another alias
-            aliasAction = IndicesAliasesRequest.AliasActions.remove()
-                    .index(leaderIndexName)
-                    .alias("alias1")
-            indicesAliasesRequest.addAliasAction(aliasAction
-            )
-            leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
-            var aliasAction2 = IndicesAliasesRequest.AliasActions.add()
-                    .index(leaderIndexName)
-                    .routing("12")
-                    .alias("alias2")
-                    .indexRouting("indexRouting")
-            indicesAliasesRequest.addAliasAction(aliasAction2)
-
-            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
-
-            assertBusy({
-                Assert.assertEquals(
-                    null,
-                    followerClient.indices()
-                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName]["index.search.idle.after"]
-                )
-                assertEqualAliases()
-            }, 30L, TimeUnit.SECONDS)
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
         }
-
+        settings = Settings.builder()
+                .build()
+        followerClient.updateReplication( followerIndexName, settings)
+        val getSettingsRequest = GetSettingsRequest()
+        getSettingsRequest.indices(followerIndexName)
+        getSettingsRequest.includeDefaults(true)
+        Assert.assertEquals(
+                "0",
+                followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+        )
+        settings = Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
+                .put("routing.allocation.enable", "none")
+                .build()
+        leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
+        var indicesAliasesRequest = IndicesAliasesRequest()
+        var aliasAction = IndicesAliasesRequest.AliasActions.add()
+                .index(leaderIndexName)
+                .alias("alias1").filter("{\"term\":{\"year\":2016}}").routing("1")
+        indicesAliasesRequest.addAliasAction(aliasAction)
+        leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
+        TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+        getSettingsRequest.indices(followerIndexName)
+        // Leader setting is copied
+        assertBusy({
+            Assert.assertEquals(
+                "2",
+                followerClient.indices()
+                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+            )
+            assertEqualAliases()
+        }, 30L, TimeUnit.SECONDS)
+        // Case 2 :  Blocklisted  setting are not copied
+        Assert.assertNull(followerClient.indices()
+                .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                .indexToSettings[followerIndexName].get("index.routing.allocation.enable"))
+        //Alias test case 2: Update existing alias
+        aliasAction = IndicesAliasesRequest.AliasActions.add()
+                .index(leaderIndexName)
+                .routing("2")
+                .alias("alias1")
+                .writeIndex(true)
+                .isHidden(false)
+        indicesAliasesRequest.addAliasAction(aliasAction)
+        leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
+        //Use Update API
+        settings = Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3)
+                .put("index.routing.allocation.enable", "none")
+                .put("index.search.idle.after", "10s")
+                .build()
+        followerClient.updateReplication( followerIndexName, settings)
+        TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+        // Case 3 : Updated Settings take higher priority.  Blocklisted  settins shouldn't matter for that
+        assertBusy({
+            Assert.assertEquals(
+                "3",
+                followerClient.indices()
+                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+            )
+            Assert.assertEquals(
+                "10s",
+                followerClient.indices()
+                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                    .indexToSettings[followerIndexName]["index.search.idle.after"]
+            )
+            Assert.assertEquals(
+                "none",
+                followerClient.indices()
+                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                    .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
+            )
+            assertEqualAliases()
+        }, 30L, TimeUnit.SECONDS)
+        //Clear the settings
+        settings = Settings.builder()
+                .build()
+        followerClient.updateReplication( followerIndexName, settings)
+        //Alias test case 3: Delete one alias and add another alias
+        aliasAction = IndicesAliasesRequest.AliasActions.remove()
+                .index(leaderIndexName)
+                .alias("alias1")
+        indicesAliasesRequest.addAliasAction(aliasAction
+        )
+        leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
+        var aliasAction2 = IndicesAliasesRequest.AliasActions.add()
+                .index(leaderIndexName)
+                .routing("12")
+                .alias("alias2")
+                .indexRouting("indexRouting")
+        indicesAliasesRequest.addAliasAction(aliasAction2)
+        TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+        assertBusy({
+            Assert.assertEquals(
+                null,
+                followerClient.indices()
+                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                    .indexToSettings[followerIndexName]["index.search.idle.after"]
+            )
+            assertEqualAliases()
+        }, 30L, TimeUnit.SECONDS)
     }
 
     fun `test that static index settings are getting replicated `() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         setMetadataSyncDelay()
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         var settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
                 .build()
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }
-            val getSettingsRequest = GetSettingsRequest()
-            getSettingsRequest.indices(followerIndexName)
-            Assert.assertEquals(
-                    "1",
-                    followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-            )
-
-            settings = Settings.builder()
-                    .put("index.shard.check_on_startup", "checksum")
-                    .build()
-            followerClient.updateReplication(followerIndexName, settings)
-
-            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
-            Assert.assertEquals(
-                    "checksum",
-                    followerClient.indices()
-                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
-            )
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
         }
+        val getSettingsRequest = GetSettingsRequest()
+        getSettingsRequest.indices(followerIndexName)
+        Assert.assertEquals(
+                "1",
+                followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+        )
+        settings = Settings.builder()
+                .put("index.shard.check_on_startup", "checksum")
+                .build()
+        followerClient.updateReplication(followerIndexName, settings)
+        TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+        Assert.assertEquals(
+                "checksum",
+                followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
+        )
     }
 
     fun `test that replication fails to start when custom analyser is not present in follower`() {
@@ -709,7 +590,6 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             val settings: Settings = Settings.builder().loadFromStream(synonymsJson, javaClass.getResourceAsStream(synonymsJson), false)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
                 .build()
-
             val leaderClient = getClientForCluster(LEADER)
             val followerClient = getClientForCluster(FOLLOWER)
             try {
@@ -719,9 +599,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             } catch (e: Exception) {
                 assumeNoException("Ignored test as analyzer setting could not be added", e)
             }
-
             createConnectionBetweenClusters(FOLLOWER, LEADER)
-
             assertThatThrownBy {
                 followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
             }.isInstanceOf(ResponseException::class.java).hasMessageContaining("resource_not_found_exception")
@@ -741,11 +619,9 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         try {
             Files.copy(synonyms, leaderSynonymPath)
             Files.copy(synonyms, followerSynonymPath)
-
             val settings: Settings = Settings.builder().loadFromStream(synonymsJson, javaClass.getResourceAsStream(synonymsJson), false)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
                 .build()
-
             val leaderClient = getClientForCluster(LEADER)
             val followerClient = getClientForCluster(FOLLOWER)
             try {
@@ -755,17 +631,11 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             } catch (e: Exception) {
                 assumeNoException("Ignored test as analyzer setting could not be added", e)
             }
-
             createConnectionBetweenClusters(FOLLOWER, LEADER)
-
-            try {
-                followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                    waitForRestore = true)
-                assertBusy {
-                    assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-                }
-            } finally {
-                followerClient.stopReplication(followerIndexName)
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+                waitForRestore = true)
+            assertBusy {
+                assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
             }
         } finally {
             if (Files.exists(leaderSynonymPath)) {
@@ -787,11 +657,9 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         try {
             Files.copy(synonyms, leaderSynonymPath)
             Files.copy(synonyms, followerSynonymPath)
-
             val settings: Settings = Settings.builder().loadFromStream(synonymsJson, javaClass.getResourceAsStream(synonymsJson), false)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
                 .build()
-
             val leaderClient = getClientForCluster(LEADER)
             val followerClient = getClientForCluster(FOLLOWER)
             try {
@@ -801,20 +669,14 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             } catch (e: Exception) {
                 assumeNoException("Ignored test as analyzer setting could not be added", e)
             }
-
             createConnectionBetweenClusters(FOLLOWER, LEADER)
-
-            try {
-                val overriddenSettings: Settings = Settings.builder()
-                    .put("index.analysis.filter.my_filter.synonyms_path", synonymFollowerFilename)
-                    .build()
-                followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, overriddenSettings),
-                    waitForRestore = true)
-                assertBusy {
-                    assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-                }
-            } finally {
-                followerClient.stopReplication(followerIndexName)
+            val overriddenSettings: Settings = Settings.builder()
+                .put("index.analysis.filter.my_filter.synonyms_path", synonymFollowerFilename)
+                .build()
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, overriddenSettings),
+                waitForRestore = true)
+            assertBusy {
+                assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
             }
         } finally {
             if (Files.exists(leaderSynonymPath)) {
@@ -829,73 +691,58 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test that follower index cannot be deleted after starting replication`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-            }
-            // Need to wait till index blocks appear into state
-            assertBusy {
-                val clusterBlocksResponse = followerClient.lowLevelClient.performRequest(Request("GET", "/_cluster/state/blocks"))
-                val clusterResponseString = EntityUtils.toString(clusterBlocksResponse.entity)
-                assertThat(clusterResponseString.contains("cross-cluster-replication"))
-                    .withFailMessage("Cant find replication block afer starting replication")
-                    .isTrue()
-            }
-            // Delete index
-            assertThatThrownBy {
-                followerClient.indices().delete(DeleteIndexRequest(followerIndexName), RequestOptions.DEFAULT)
-            }.isInstanceOf(OpenSearchStatusException::class.java).hasMessageContaining("cluster_block_exception")
-            // Close index
-            assertThatThrownBy {
-                followerClient.indices().close(CloseIndexRequest(followerIndexName), RequestOptions.DEFAULT)
-            }.isInstanceOf(OpenSearchStatusException::class.java).hasMessageContaining("cluster_block_exception")
-            // Index document
-            assertThatThrownBy {
-                val sourceMap = mapOf("name" to randomAlphaOfLength(5))
-                followerClient.index(IndexRequest(followerIndexName).id("1").source(sourceMap), RequestOptions.DEFAULT)
-            }.isInstanceOf(OpenSearchStatusException::class.java).hasMessageContaining("cluster_block_exception")
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
+        // Need to wait till index blocks appear into state
+        assertBusy {
+            val clusterBlocksResponse = followerClient.lowLevelClient.performRequest(Request("GET", "/_cluster/state/blocks"))
+            val clusterResponseString = EntityUtils.toString(clusterBlocksResponse.entity)
+            assertThat(clusterResponseString.contains("cross-cluster-replication"))
+                .withFailMessage("Cant find replication block afer starting replication")
+                .isTrue()
+        }
+        // Delete index
+        assertThatThrownBy {
+            followerClient.indices().delete(DeleteIndexRequest(followerIndexName), RequestOptions.DEFAULT)
+        }.isInstanceOf(OpenSearchStatusException::class.java).hasMessageContaining("cluster_block_exception")
+        // Close index
+        assertThatThrownBy {
+            followerClient.indices().close(CloseIndexRequest(followerIndexName), RequestOptions.DEFAULT)
+        }.isInstanceOf(OpenSearchStatusException::class.java).hasMessageContaining("cluster_block_exception")
+        // Index document
+        assertThatThrownBy {
+            val sourceMap = mapOf("name" to randomAlphaOfLength(5))
+            followerClient.index(IndexRequest(followerIndexName).id("1").source(sourceMap), RequestOptions.DEFAULT)
+        }.isInstanceOf(OpenSearchStatusException::class.java).hasMessageContaining("cluster_block_exception")
     }
 
     fun `test that replication gets paused if the leader index is deleted`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                waitForRestore = true)
-            assertBusy {
-                assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
-            }
-            assertBusy {
-                var statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate status syncing response`(statusResp)
-            }
-            val deleteIndexResponse = leaderClient.indices().delete(DeleteIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
-            assertThat(deleteIndexResponse.isAcknowledged).isTrue()
-
-            assertBusy({
-                var statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate paused status response due to leader index deleted`(statusResp)
-            }, 15, TimeUnit.SECONDS)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true)
+        assertBusy {
+            assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
+        assertBusy {
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate status syncing response`(statusResp)
+        }
+        val deleteIndexResponse = leaderClient.indices().delete(DeleteIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(deleteIndexResponse.isAcknowledged).isTrue()
+        assertBusy({
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate paused status response due to leader index deleted`(statusResp)
+        }, 15, TimeUnit.SECONDS)
     }
 
     fun `test forcemerge on leader during replication bootstrap`() {
@@ -907,7 +754,6 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings),
             RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
@@ -917,28 +763,22 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             assertThat(leaderClient.indices()
                 .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT))
         }
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                TimeValue.timeValueSeconds(10),
-                false)
-            //Given the size of index, the replication should be in RESTORING phase at this point
-            leaderClient.indices().forcemerge(ForceMergeRequest(leaderIndexName), RequestOptions.DEFAULT)
-
-            assertBusy {
-                var statusResp = followerClient.replicationStatus(followerIndexName)
-                `validate status syncing response`(statusResp)
-            }
-            TimeUnit.SECONDS.sleep(30)
-
-            assertBusy ({
-                Assert.assertEquals(leaderClient.count(CountRequest(leaderIndexName), RequestOptions.DEFAULT).toString(),
-                    followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).toString())
-                },
-                30, TimeUnit.SECONDS
-            )
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            TimeValue.timeValueSeconds(10),
+            false)
+        //Given the size of index, the replication should be in RESTORING phase at this point
+        leaderClient.indices().forcemerge(ForceMergeRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertBusy {
+            var statusResp = followerClient.replicationStatus(followerIndexName)
+            `validate status syncing response`(statusResp)
         }
+        TimeUnit.SECONDS.sleep(30)
+        assertBusy ({
+            Assert.assertEquals(leaderClient.count(CountRequest(leaderIndexName), RequestOptions.DEFAULT).toString(),
+                followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).toString())
+            },
+            30, TimeUnit.SECONDS
+        )
     }
 
     fun `test that snapshot on leader does not affect replication during bootstrap`() {
@@ -950,15 +790,11 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val repoPath = PathUtils.get(buildDir, repoPath)
-
         val putRepositoryRequest = PutRepositoryRequest("my-repo")
             .type(FsRepository.TYPE)
             .settings("{\"location\": \"$repoPath\"}", XContentType.JSON)
-
         leaderClient.snapshot().createRepository(putRepositoryRequest, RequestOptions.DEFAULT)
-
         val createIndexResponse = leaderClient.indices().create(
             CreateIndexRequest(leaderIndexName).settings(settings),
             RequestOptions.DEFAULT
@@ -972,152 +808,122 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                     .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
             )
         }
-        try {
-            followerClient.startReplication(
-                StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                TimeValue.timeValueSeconds(10),
-                false
-            )
-            //Given the size of index, the replication should be in RESTORING phase at this point
-            leaderClient.snapshot().create(CreateSnapshotRequest("my-repo", "snapshot_1").indices(leaderIndexName), RequestOptions.DEFAULT)
-
-            assertBusy({
-                    var statusResp = followerClient.replicationStatus(followerIndexName)
-                    `validate status syncing response`(statusResp)
-                }, 30, TimeUnit.SECONDS
-            )
-            assertBusy({
-                Assert.assertEquals(
-                    leaderClient.count(CountRequest(leaderIndexName), RequestOptions.DEFAULT).toString(),
-                    followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).toString()
-                )},
-                30, TimeUnit.SECONDS
-            )
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
+        followerClient.startReplication(
+            StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            TimeValue.timeValueSeconds(10),
+            false
+        )
+        //Given the size of index, the replication should be in RESTORING phase at this point
+        leaderClient.snapshot().create(CreateSnapshotRequest("my-repo", "snapshot_1").indices(leaderIndexName), RequestOptions.DEFAULT)
+        assertBusy({
+                var statusResp = followerClient.replicationStatus(followerIndexName)
+                `validate status syncing response`(statusResp)
+            }, 30, TimeUnit.SECONDS
+        )
+        assertBusy({
+            Assert.assertEquals(
+                leaderClient.count(CountRequest(leaderIndexName), RequestOptions.DEFAULT).toString(),
+                followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).toString()
+            )},
+            30, TimeUnit.SECONDS
+        )
     }
 
     fun `test leader stats`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
                 .build()
-
         val createIndexResponse = leaderClient.indices().create(
                 CreateIndexRequest(leaderIndexName).settings(settings),
                 RequestOptions.DEFAULT
         )
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
-        try {
-            followerClient.startReplication(
-                    StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                    TimeValue.timeValueSeconds(10),
-                    true
-            )
-
-            val docCount = 50
-
-            for (i in 1..docCount) {
-                val sourceMap = mapOf("name" to randomAlphaOfLength(5))
-                leaderClient.index(IndexRequest(leaderIndexName).id(i.toString()).source(sourceMap), RequestOptions.DEFAULT)
-            }
-
-            // Have to wait until the new operations are available to read at the leader cluster
-            assertBusy({
-                val stats = leaderClient.leaderStats()
-                assertThat(stats.size).isEqualTo(9)
-                assertThat(stats.getValue("num_replicated_indices").toString()).isEqualTo("1")
-                assertThat(stats.getValue("operations_read").toString()).isEqualTo(docCount.toString())
-                assertThat(stats.getValue("operations_read_lucene").toString()).isEqualTo("0")
-                assertThat(stats.getValue("operations_read_translog").toString()).isEqualTo(docCount.toString())
-                assertThat(stats.containsKey("index_stats"))
-            }, 60L, TimeUnit.SECONDS)
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(
+                StartReplicationRequest("source", leaderIndexName, followerIndexName),
+                TimeValue.timeValueSeconds(10),
+                true
+        )
+        val docCount = 50
+        for (i in 1..docCount) {
+            val sourceMap = mapOf("name" to randomAlphaOfLength(5))
+            leaderClient.index(IndexRequest(leaderIndexName).id(i.toString()).source(sourceMap), RequestOptions.DEFAULT)
         }
+        // Have to wait until the new operations are available to read at the leader cluster
+        assertBusy({
+            val stats = leaderClient.leaderStats()
+            assertThat(stats.size).isEqualTo(9)
+            assertThat(stats.getValue("num_replicated_indices").toString()).isEqualTo("1")
+            assertThat(stats.getValue("operations_read").toString()).isEqualTo(docCount.toString())
+            assertThat(stats.getValue("operations_read_lucene").toString()).isEqualTo("0")
+            assertThat(stats.getValue("operations_read_translog").toString()).isEqualTo(docCount.toString())
+            assertThat(stats.containsKey("index_stats"))
+        }, 60L, TimeUnit.SECONDS)
     }
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/176")
     fun `test follower stats`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
-        val followerIndex2 = "follower_index_2"
-        val followerIndex3 = "follower_index_3"
-
+        val leaderIndexName2 = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)+"leader"
+        val followerIndexName2 = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)+"follower"
+        val leaderIndexName3 = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)+"leader"
+        val followerIndexName3 = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)+"follower"
+//        val followerIndex2 = "follower_index_2"
+//        val followerIndex3 = "follower_index_3"
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(
                 CreateIndexRequest(leaderIndexName),
                 RequestOptions.DEFAULT
         )
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
-        try {
-            followerClient.startReplication(
-                    StartReplicationRequest("source", leaderIndexName, followerIndexName),
-                    TimeValue.timeValueSeconds(10),
-                    true
-            )
-            followerClient.startReplication(
-                    StartReplicationRequest("source", leaderIndexName, followerIndex2),
-                    TimeValue.timeValueSeconds(10),
-                    true
-            )
-            followerClient.startReplication(
-                    StartReplicationRequest("source", leaderIndexName, followerIndex3),
-                    TimeValue.timeValueSeconds(10),
-                    true
-            )
-            val docCount = 50
-            for (i in 1..docCount) {
-                val sourceMap = mapOf("name" to randomAlphaOfLength(5))
-                leaderClient.index(IndexRequest(leaderIndexName).id(i.toString()).source(sourceMap), RequestOptions.DEFAULT)
-            }
-
-            followerClient.pauseReplication(followerIndex2)
-            followerClient.stopReplication(followerIndex3)
-
-
-            val stats = followerClient.followerStats()
-            assertThat(stats.getValue("num_syncing_indices").toString()).isEqualTo("1")
-            assertThat(stats.getValue("num_paused_indices").toString()).isEqualTo("1")
-            assertThat(stats.getValue("num_failed_indices").toString()).isEqualTo("0")
-            assertThat(stats.getValue("num_shard_tasks").toString()).isEqualTo("1")
-            assertThat(stats.getValue("operations_written").toString()).isEqualTo("50")
-            assertThat(stats.getValue("operations_read").toString()).isEqualTo("50")
-            assertThat(stats.getValue("failed_read_requests").toString()).isEqualTo("0")
-            assertThat(stats.getValue("failed_write_requests").toString()).isEqualTo("0")
-            assertThat(stats.containsKey("index_stats"))
-            assertThat(stats.size).isEqualTo(16)
-
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-            followerClient.stopReplication(followerIndex2)
+        followerClient.startReplication(
+                StartReplicationRequest("source", leaderIndexName, followerIndexName),
+                TimeValue.timeValueSeconds(10),
+                true
+        )
+        followerClient.startReplication(
+                StartReplicationRequest("source", leaderIndexName2, followerIndexName2),
+                TimeValue.timeValueSeconds(10),
+                true
+        )
+        followerClient.startReplication(
+                StartReplicationRequest("source", leaderIndexName3, followerIndexName3),
+                TimeValue.timeValueSeconds(10),
+                true
+        )
+        val docCount = 50
+        for (i in 1..docCount) {
+            val sourceMap = mapOf("name" to randomAlphaOfLength(5))
+            leaderClient.index(IndexRequest(leaderIndexName).id(i.toString()).source(sourceMap), RequestOptions.DEFAULT)
         }
+        followerClient.pauseReplication(followerIndexName2)
+        val stats = followerClient.followerStats()
+        assertThat(stats.getValue("num_syncing_indices").toString()).isEqualTo("1")
+        assertThat(stats.getValue("num_paused_indices").toString()).isEqualTo("1")
+        assertThat(stats.getValue("num_failed_indices").toString()).isEqualTo("0")
+        assertThat(stats.getValue("num_shard_tasks").toString()).isEqualTo("1")
+        assertThat(stats.getValue("operations_written").toString()).isEqualTo("50")
+        assertThat(stats.getValue("operations_read").toString()).isEqualTo("50")
+        assertThat(stats.getValue("failed_read_requests").toString()).isEqualTo("0")
+        assertThat(stats.getValue("failed_write_requests").toString()).isEqualTo("0")
+        assertThat(stats.getValue("follower_checkpoint").toString()).isEqualTo((docCount-1).toString())
+        assertThat(stats.containsKey("index_stats"))
+        assertThat(stats.size).isEqualTo(16)
     }
 
     fun `test that replication cannot be started on invalid indexName`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).alias(Alias("leaderAlias")), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
         assertValidationFailure(followerClient, "leaderIndex", followerIndexName,
             "Value leaderIndex must be lowercase")
         assertValidationFailure(followerClient, "leaderindex", "followerIndex",
             "Value followerIndex must be lowercase")
-
         assertValidationFailure(followerClient, "test*", followerIndexName,
             "Value test* must not contain the following characters")
         assertValidationFailure(followerClient, "test#", followerIndexName,
@@ -1128,10 +934,8 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             "Value . must not be '.' or '..'")
         assertValidationFailure(followerClient, "..", followerIndexName,
             "Value .. must not be '.' or '..'")
-
         assertValidationFailure(followerClient, "_leader", followerIndexName,
             "Value _leader must not start with '_' or '-' or '+'")
-
         assertValidationFailure(followerClient, "-leader", followerIndexName,
             "Value -leader must not start with '_' or '-' or '+'")
         assertValidationFailure(followerClient, "+leader", followerIndexName,
@@ -1145,45 +949,33 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test that replication is not started when start block is set`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
         val createIndexResponse = leaderClient.indices().create(
                 CreateIndexRequest(leaderIndexName),
                 RequestOptions.DEFAULT
         )
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-
         // Setting to add replication start block
         followerClient.updateReplicationStartBlockSetting(true)
-
         assertThatThrownBy { followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
                 waitForRestore = true) }
                 .isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("[FORBIDDEN] Replication START block is set")
-
         // Remove replication start block and start replication
         followerClient.updateReplicationStartBlockSetting(false)
-
-        try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
                     waitForRestore = true)
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
     }
 
     fun `test start replication invalid settings`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
         val settings = Settings.builder()
             .put("index.data_path", "/random-path/invalid-setting")
             .build()
-
         try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, settings = settings))
         } catch (e: ResponseException) {
@@ -1195,7 +987,6 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test that replication is not started when all primary shards are not in active state`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
         // Exclude leader cluster nodes to stop assignment for the new shards
         excludeAllClusterNodes(LEADER)
@@ -1211,13 +1002,11 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         assertBusy {
             assertThat(leaderClient.indices().exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
-
         // start repilcation should fail as the shards are not active on the leader cluster
         assertThatThrownBy { followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
                 waitForRestore = true) }
                 .isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("Primary shards in the Index[source:${leaderIndexName}] are not active")
-
     }
 
     private fun excludeAllClusterNodes(clusterName: String) {
@@ -1262,10 +1051,8 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         var getAliasesRequest = GetAliasesRequest().indices(followerIndexName)
         var aliasRespone = followerClient.indices().getAlias(getAliasesRequest, RequestOptions.DEFAULT)
         var followerAliases = aliasRespone.aliases.get(followerIndexName)
-
         aliasRespone = leaderClient.indices().getAlias(GetAliasesRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
         var leaderAliases = aliasRespone.aliases.get(leaderIndexName)
-
         Assert.assertEquals(followerAliases, leaderAliases)
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -68,21 +68,17 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val leaderIndexName = createRandomIndex(leaderClient)
         var leaderIndexNameNew = ""
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
-
             // Verify that existing index matching the pattern are replicated.
             assertBusy ({
                 Assertions.assertThat(followerClient.indices()
                         .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT))
                         .isEqualTo(true)
             }, 30, TimeUnit.SECONDS)
-
             assertBusy ({
                 Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
             }, 10, TimeUnit.SECONDS)
-
             leaderIndexNameNew = createRandomIndex(leaderClient)
             // Verify that newly created index on leader which match the pattern are also replicated.
             assertBusy ({
@@ -102,8 +98,6 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             }, 60, TimeUnit.SECONDS)
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            followerClient.stopReplication(leaderIndexName, false)
-            followerClient.stopReplication(leaderIndexNameNew)
         }
     }
 
@@ -112,20 +106,16 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val leaderClient = getClientForCluster(LEADER)
         var leaderIndexNameNew = ""
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         try {
             // Set poll duration to 30sec from 60sec (default)
             val settings = Settings.builder().put(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL.key,
                 TimeValue.timeValueSeconds(30))
             val clusterUpdateSetttingsReq = ClusterUpdateSettingsRequest().persistentSettings(settings)
             val clusterUpdateResponse = followerClient.cluster().putSettings(clusterUpdateSetttingsReq, RequestOptions.DEFAULT)
-
             var lastExecutionTime = 0L
             var stats = followerClient.AutoFollowStats()
-
             Assert.assertTrue(clusterUpdateResponse.isAcknowledged)
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
-
             leaderIndexNameNew = createRandomIndex(leaderClient)
             // Verify that newly created index on leader which match the pattern are also replicated.
             assertBusy({
@@ -140,9 +130,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                         lastExecutionTime = key["last_execution_time"]!! as Long
                     }
                 }
-
             }, 30, TimeUnit.SECONDS)
-
             assertBusy({
             var af_stats = stats.get("autofollow_stats")!! as ArrayList<HashMap<String, Any>>
             for (key in af_stats) {
@@ -151,11 +139,8 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                 }
             }
             }, 40, TimeUnit.SECONDS)
-
-
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            followerClient.stopReplication(leaderIndexNameNew)
         }
     }
 
@@ -165,14 +150,11 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val leaderClient = getClientForCluster(LEADER)
         val leaderIndexName = createRandomIndex(leaderClient)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         try {
             val settings = Settings.builder()
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3)
                     .build()
-
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern, settings)
-
             // Verify that existing index matching the pattern are replicated.
             assertBusy ({
                 Assertions.assertThat(followerClient.indices()
@@ -180,8 +162,6 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                         .isEqualTo(true)
             }, 30, TimeUnit.SECONDS)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
-
-
             val getSettingsRequest = GetSettingsRequest()
             getSettingsRequest.indices(leaderIndexName)
             getSettingsRequest.includeDefaults(true)
@@ -196,7 +176,6 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             }, 15, TimeUnit.SECONDS)
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            followerClient.stopReplication(leaderIndexName)
         }
     }
     
@@ -204,27 +183,22 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val indexPatternName2 = "test_pattern2"
         val indexPattern2 = "lead_index*"
         val leaderIndexName2 = "lead_index1"
-
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         val leaderIndexName = createRandomIndex(leaderClient)
         leaderClient.indices().create(CreateIndexRequest(leaderIndexName2), RequestOptions.DEFAULT)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName2, indexPattern2)
-
             assertBusy ({
                 Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(2)
             }, 30, TimeUnit.SECONDS)
-
             // Verify that existing index matching the pattern are replicated.
             assertBusy ({
                 Assertions.assertThat(followerClient.indices()
                         .exists(GetIndexRequest(leaderIndexName2), RequestOptions.DEFAULT))
                         .isEqualTo(true)
-
                 var stats = followerClient.AutoFollowStats()
                 Assertions.assertThat(stats.size).isEqualTo(5)
                 assert(stats["num_success_start_replication"]!! as Int == 2)
@@ -238,9 +212,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName2)
             followerClient.waitForShardTaskStart(leaderIndexName)
-            followerClient.stopReplication(leaderIndexName)
             followerClient.waitForShardTaskStart(leaderIndexName2)
-            followerClient.stopReplication(leaderIndexName2)
         }
     }
 
@@ -249,35 +221,26 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val leaderClient = getClientForCluster(LEADER)
         val leaderIndexName = createRandomIndex(leaderClient)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
+        followerClient.startReplication(StartReplicationRequest(connectionAlias, leaderIndexName, leaderIndexName),
+                TimeValue.timeValueSeconds(10),true, waitForRestore = true)
+        assertBusy({
+            Assertions.assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
+        }, 30, TimeUnit.SECONDS)
+        // Assert that there is no auto follow task & one index replication task
+        Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(0)
+        Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
         try {
-            followerClient.startReplication(StartReplicationRequest(connectionAlias, leaderIndexName, leaderIndexName),
-                    TimeValue.timeValueSeconds(10),true, waitForRestore = true)
-
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
             assertBusy({
-                Assertions.assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
-            }, 30, TimeUnit.SECONDS)
-
-            // Assert that there is no auto follow task & one index replication task
-            Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(0)
-            Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
-
-            try {
-                followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
-
-                assertBusy({
-                    // Assert that there is still only one index replication task
-                    Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
-                    Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
-                    followerClient.waitForShardTaskStart(leaderIndexName, waitForShardTask)
-                },30, TimeUnit.SECONDS)
-            } finally {
-                followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            }
+                // Assert that there is still only one index replication task
+                Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+                Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
+                followerClient.waitForShardTaskStart(leaderIndexName, waitForShardTask)
+            },30, TimeUnit.SECONDS)
         } finally {
-            followerClient.stopReplication(leaderIndexName)
+            followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
         }
     }
 
@@ -293,7 +256,6 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
     fun `test auto follow should fail on pattern name validation failure`() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         assertPatternNameValidation(followerClient, "testPattern",
             "Value testPattern must be lowercase")
         assertPatternNameValidation(followerClient, "testPattern*",
@@ -306,10 +268,8 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             "Value . must not be '.' or '..'")
         assertPatternNameValidation(followerClient, "..",
             "Value .. must not be '.' or '..'")
-
         assertPatternNameValidation(followerClient, "_leader",
             "Value _leader must not start with '_' or '-' or '+'")
-
         assertPatternNameValidation(followerClient, "-leader",
             "Value -leader must not start with '_' or '-' or '+'")
         assertPatternNameValidation(followerClient, "+leader",
@@ -332,9 +292,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         val leaderIndexName = createRandomIndex(leaderClient)
-
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
 
@@ -344,52 +302,42 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                         .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT))
                         .isEqualTo(true)
             }
-
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
             Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
             followerClient.waitForShardTaskStart(leaderIndexName, waitForShardTask)
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
         }
-
         // Verify that auto follow tasks is stopped but the shard replication task remains.
         assertBusy ({
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(0)
         }, 30, TimeUnit.SECONDS)
-
         Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
-        followerClient.stopReplication(leaderIndexName)
     }
 
     fun `test autofollow task with start replication block`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         val leaderIndexName = createRandomIndex(leaderClient)
         try {
-
             // Add replication start block
             followerClient.updateReplicationStartBlockSetting(true)
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
             sleep(30000) // Default poll for auto follow in worst case
-
             // verify both index replication tasks and autofollow tasks
             // Replication shouldn't have been started - 0 tasks
             // Autofollow task should still be up - 1 task
             Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(0)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
-
             // Remove replication start block
             followerClient.updateReplicationStartBlockSetting(false)
             sleep(45000) // poll for auto follow in worst case
-
             // Index should be replicated and autofollow task should be present
             Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            followerClient.stopReplication(leaderIndexName)
         }
     }
 
@@ -397,38 +345,29 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         // create two leader indices and test autofollow to trigger to trigger jobs based on setting
         val leaderIndexName1 = createRandomIndex(leaderClient)
         val leaderIndexName2 = createRandomIndex(leaderClient)
-
         followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(2)
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
-
             // Verify that existing index matching the pattern are replicated.
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(leaderIndexName1), RequestOptions.DEFAULT))
                     .isEqualTo(true)
             }
-
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(leaderIndexName2), RequestOptions.DEFAULT))
                     .isEqualTo(true)
             }
-
             sleep(30000) // Default poll for auto follow in worst case
-
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
-
         } finally {
             // Reset default autofollow setting
             followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(null)
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            followerClient.stopReplication(leaderIndexName1)
-            followerClient.stopReplication(leaderIndexName2)
         }
     }
 
@@ -436,37 +375,28 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-
         // create two leader indices and test autofollow to trigger to trigger jobs based on setting
         val leaderIndexName1 = createRandomIndex(leaderClient)
         val leaderIndexName2 = createRandomIndex(leaderClient)
-
         followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(1)
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
-
             // Verify that existing index matching the pattern are replicated.
             assertBusy {
                 // check that the index replication task is created for only index
                 Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
             }
-
             sleep(30000) // Default poll for auto follow in worst case
-
             assertBusy {
                 // check that the index replication task is created for only index
                 Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(2)
             }
-
             sleep(30000) // Default poll for auto follow in worst case
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
-
         } finally {
             // Reset default autofollow setting
             followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(null)
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
-            followerClient.stopReplication(leaderIndexName1)
-            followerClient.stopReplication(leaderIndexName2)
         }
     }
 

--- a/src/test/kotlin/org/opensearch/replication/task/TaskCancellationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/TaskCancellationIT.kt
@@ -45,68 +45,52 @@ class TaskCancellationIT : MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         val primaryShards = 3
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(
                 CreateIndexRequest(leaderIndexName).settings(Settings.builder().put("index.number_of_shards", primaryShards).build()),
                 RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
-            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
-            // Wait for Shard tasks to come up.
-            var tasks = Collections.emptyList<String>()
-            assertBusy {
-                tasks = followerClient.getShardReplicationTasks(followerIndexName)
-                Assert.assertEquals(tasks.size, primaryShards)
-            }
-
-            // Cancel one shard task
-            val cancelTasksRequest = CancelTasksRequest.Builder().withTaskId(TaskId(tasks[0])).
-                withWaitForCompletion(true).build()
-            followerClient.tasks().cancel(cancelTasksRequest, RequestOptions.DEFAULT)
-
-            // Verify that replication is continuing and the shards tasks are up and running
-            assertBusy {
-                Assert.assertEquals(followerClient.getShardReplicationTasks(followerIndexName).size, primaryShards)
-                assertThat(followerClient.getIndexReplicationTask(followerIndexName).isNotBlank()).isTrue()
-                `validate status due shard task cancellation`(followerClient.replicationStatus(followerIndexName))
-            }
-        } finally {
-            followerClient.stopReplication(followerIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+        // Wait for Shard tasks to come up.
+        var tasks = Collections.emptyList<String>()
+        assertBusy {
+            tasks = followerClient.getShardReplicationTasks(followerIndexName)
+            Assert.assertEquals(tasks.size, primaryShards)
+        }
+        // Cancel one shard task
+        val cancelTasksRequest = CancelTasksRequest.Builder().withTaskId(TaskId(tasks[0])).
+            withWaitForCompletion(true).build()
+        followerClient.tasks().cancel(cancelTasksRequest, RequestOptions.DEFAULT)
+        // Verify that replication is continuing and the shards tasks are up and running
+        assertBusy {
+            Assert.assertEquals(followerClient.getShardReplicationTasks(followerIndexName).size, primaryShards)
+            assertThat(followerClient.getIndexReplicationTask(followerIndexName).isNotBlank()).isTrue()
+            `validate status due shard task cancellation`(followerClient.replicationStatus(followerIndexName))
         }
     }
 
     fun `test user triggering cancel on an index task`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-
         createConnectionBetweenClusters(FOLLOWER, LEADER)
-
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        try {
             followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
             // Wait for Shard tasks to come up.
             assertBusy {
                 assertThat(followerClient.getShardReplicationTasks(followerIndexName).isEmpty()).isEqualTo(false)
             }
-
             // Cancel the index replication task
             var task = followerClient.getIndexReplicationTask(followerIndexName)
             assertThat(task.isNullOrBlank()).isFalse()
             val cancelTasksRequest = CancelTasksRequest.Builder().withTaskId(TaskId(task)).
             withWaitForCompletion(true).build()
             followerClient.tasks().cancel(cancelTasksRequest, RequestOptions.DEFAULT)
-
             // Verify that replication has paused.
             assertBusy {
                 assertThat(followerClient.getShardReplicationTasks(followerIndexName).isEmpty()).isTrue()
                 assertThat(followerClient.getIndexReplicationTask(followerIndexName).isNullOrBlank()).isTrue()
                 `validate status due index task cancellation`(followerClient.replicationStatus(followerIndexName))
             }
-        } finally {
-            followerClient.stopReplication(followerIndexName)
-        }
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/task/shard/TransportReplayChangesActionIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/shard/TransportReplayChangesActionIT.kt
@@ -36,60 +36,48 @@ class TransportReplayChangesActionIT  : MultiClusterRestTestCase() {
         // Create a leader/follower index
         val leaderIndex = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndex = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
-
-        try {
-            val doc1 = mapOf("name" to randomAlphaOfLength(20))
-            // Create Leader Index
-            val response = leader.index(IndexRequest(leaderIndex).id("1").source(doc1), RequestOptions.DEFAULT)
-            Assertions.assertThat(response.result)
-                .withFailMessage("Failed to create leader data").isEqualTo(DocWriteResponse.Result.CREATED)
-
-            // Setup Mapping on leader
-            var putMappingRequest = PutMappingRequest(leaderIndex)
-            putMappingRequest.source(
-                "{\"dynamic\":\"strict\",\"properties\":{\"name\":{\"type\":\"text\"}}}",
-                XContentType.JSON
-            )
-            leader.indices().putMapping(putMappingRequest, RequestOptions.DEFAULT)
-
-            // Start replication
-            follower.startReplication(
-                StartReplicationRequest("source", leaderIndex, followerIndex),
-                waitForRestore = true
-            )
-            assertBusy {
-                val getResponse = follower.get(GetRequest(followerIndex, "1"), RequestOptions.DEFAULT)
-                Assertions.assertThat(getResponse.isExists).isTrue()
-                Assertions.assertThat(getResponse.sourceAsMap).isEqualTo(doc1)
-            }
-
-            // Add a new field in mapping.
-            putMappingRequest = PutMappingRequest(leaderIndex)
-            putMappingRequest.source(
-                "{\"dynamic\":\"strict\",\"properties\":{\"name\":{\"type\":\"text\"},\"place\":{\"type\":\"text\"}}}",
-                XContentType.JSON
-            )
-            leader.indices().putMapping(putMappingRequest, RequestOptions.DEFAULT)
-
-            // Ingest a doc on the leader
-            val doc2 = mapOf("name" to randomAlphaOfLength(5), "place" to randomAlphaOfLength(5))
-            leader.index(IndexRequest(leaderIndex).id("2").source(doc2), RequestOptions.DEFAULT)
-
-            // Verify that replication is working as expected.
-            assertBusy ({
-                Assert.assertEquals(leader.count(CountRequest(leaderIndex), RequestOptions.DEFAULT).toString(),
-                    follower.count(CountRequest(followerIndex), RequestOptions.DEFAULT).toString())
-                `validate status syncing response`(follower.replicationStatus(followerIndex))
-                val getResponse = follower.get(GetRequest(followerIndex, "2"), RequestOptions.DEFAULT)
-                Assertions.assertThat(getResponse.isExists).isTrue()
-                Assertions.assertThat(getResponse.sourceAsMap).isEqualTo(doc2)
-            },
-                30, TimeUnit.SECONDS
-            )
-
-        } finally {
-            follower.stopReplication(followerIndex)
+        val doc1 = mapOf("name" to randomAlphaOfLength(20))
+        // Create Leader Index
+        val response = leader.index(IndexRequest(leaderIndex).id("1").source(doc1), RequestOptions.DEFAULT)
+        Assertions.assertThat(response.result)
+            .withFailMessage("Failed to create leader data").isEqualTo(DocWriteResponse.Result.CREATED)
+        // Setup Mapping on leader
+        var putMappingRequest = PutMappingRequest(leaderIndex)
+        putMappingRequest.source(
+            "{\"dynamic\":\"strict\",\"properties\":{\"name\":{\"type\":\"text\"}}}",
+            XContentType.JSON
+        )
+        leader.indices().putMapping(putMappingRequest, RequestOptions.DEFAULT)
+        // Start replication
+        follower.startReplication(
+            StartReplicationRequest("source", leaderIndex, followerIndex),
+            waitForRestore = true
+        )
+        assertBusy {
+            val getResponse = follower.get(GetRequest(followerIndex, "1"), RequestOptions.DEFAULT)
+            Assertions.assertThat(getResponse.isExists).isTrue()
+            Assertions.assertThat(getResponse.sourceAsMap).isEqualTo(doc1)
         }
-
+        // Add a new field in mapping.
+        putMappingRequest = PutMappingRequest(leaderIndex)
+        putMappingRequest.source(
+            "{\"dynamic\":\"strict\",\"properties\":{\"name\":{\"type\":\"text\"},\"place\":{\"type\":\"text\"}}}",
+            XContentType.JSON
+        )
+        leader.indices().putMapping(putMappingRequest, RequestOptions.DEFAULT)
+        // Ingest a doc on the leader
+        val doc2 = mapOf("name" to randomAlphaOfLength(5), "place" to randomAlphaOfLength(5))
+        leader.index(IndexRequest(leaderIndex).id("2").source(doc2), RequestOptions.DEFAULT)
+        // Verify that replication is working as expected.
+        assertBusy ({
+            Assert.assertEquals(leader.count(CountRequest(leaderIndex), RequestOptions.DEFAULT).toString(),
+                follower.count(CountRequest(followerIndex), RequestOptions.DEFAULT).toString())
+            `validate status syncing response`(follower.replicationStatus(followerIndex))
+            val getResponse = follower.get(GetRequest(followerIndex, "2"), RequestOptions.DEFAULT)
+            Assertions.assertThat(getResponse.isExists).isTrue()
+            Assertions.assertThat(getResponse.sourceAsMap).isEqualTo(doc2)
+        },
+            30, TimeUnit.SECONDS
+        )
     }
 }


### PR DESCRIPTION
### Description
 stopReplication API removed from integ test cases and stopAllReplicationJobs API added in MultiClusterRestTestCase 
### Issues Resolved
#412 


Signed-off-by: sricharanvuppu <srivuppu@amazon.com>

Signed-off-by: sricharanvuppu <srivuppu@amazon.com>
(cherry picked from commit ad8e8ded88c2548a6811855929d5c71f5cea4e3e)

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
