### PR TITLE
Revert "Removed jackson-databind dependency from build-gradle that now comes from core"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ configurations.all {
         force 'org.apache.httpcomponents.core5:httpcore5-h2:5.1.4'
         force 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
         force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
         force 'org.yaml:snakeyaml:1.32'
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
         force 'net.java.dev.jna:jna:5.12.1'


### PR DESCRIPTION

This reverts commit b08b58e67a9963c9f19ebf310a5b1776786b9401.

### Description
Jackson is no longer in core, so reverting changes made for https://github.com/opensearch-project/cross-cluster-replication/issues/665
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
