### PR TITLE
Revert "Build Fix: Update Strings.toString to pass the JSON XContentT…

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationParams.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationParams.kt
@@ -20,7 +20,6 @@ import org.opensearch.common.xcontent.ObjectParser
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
-import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.Index
 import org.opensearch.persistent.PersistentTaskParams
 import java.io.IOException
@@ -81,6 +80,6 @@ class IndexReplicationParams : PersistentTaskParams {
     }
 
     override fun toString(): String {
-        return Strings.toString(XContentType.JSON, this)
+        return Strings.toString(this)
     }
 }

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationParams.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationParams.kt
@@ -20,7 +20,6 @@ import org.opensearch.common.xcontent.ObjectParser
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
-import org.opensearch.common.xcontent.XContentType
 import org.opensearch.index.shard.ShardId
 import org.opensearch.persistent.PersistentTaskParams
 import java.io.IOException
@@ -85,7 +84,7 @@ class ShardReplicationParams : PersistentTaskParams {
     }
 
     override fun toString(): String {
-        return Strings.toString(XContentType.JSON, this)
+        return Strings.toString(this)
     }
 
     class Builder {


### PR DESCRIPTION
…ype (#699)"

This reverts commit a8a31d2d9c7089465ad3f06b9491d5e53eb7185f.

### Description
This reverts commit a8a31d2d9c7089465ad3f06b9491d5e53eb7185f.
 
### Issues Resolved
Build failure in https://github.com/opensearch-project/cross-cluster-replication/pull/727
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
