### PR TITLE
Modified security github workflow to run based on plugin availability in central repo

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -9,7 +9,35 @@ on:
       - '*'
 
 jobs:
+  req:
+    # Job name
+    name: Security plugin check
+    runs-on: ubuntu-latest
+    outputs:
+      isSecurityPluginAvailable: ${{ steps.security-plugin-availability-check.outputs.isSecurityPluginAvailable }}
+    steps:
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - id: security-plugin-availability-check
+        name: "Security plugin check"
+        run: |
+          opensearch_version=$(grep "System.getProperty(\"opensearch.version\", \"" build.gradle | grep '\([0-9]\|[.]\)\{5\}' -o)
+          opensearch_version=$opensearch_version".0-SNAPSHOT"
+          # we publish build artifacts to the below url 
+          plugin_url="https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-security/"$opensearch_version"/"
+          st=$(curl -s -o /dev/null -w "%{http_code}" $plugin_url)
+          if [ "$st" = "200" ]; then
+            echo "isSecurityPluginAvailable=True" >> $GITHUB_OUTPUT
+            cat $GITHUB_OUTPUT
+          else
+            echo "isSecurityPluginAvailable=False" >> $GITHUB_OUTPUT
+            cat $GITHUB_OUTPUT
+          fi
+
   build:
+    needs: req
+    if: ${{ 'True' == needs.req.outputs.isSecurityPluginAvailable }}
     # Job name
     name: Build and Run Security tests
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,10 @@ buildscript {
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.6.0")
 
-        security_plugin_version = opensearch_build.replace("-SNAPSHOT","")
+        security_plugin_version = opensearch_build
+        if (!isSnapshot) {
+            security_plugin_version = opensearch_build.replace("-SNAPSHOT","")
+        }
     }
 
     repositories {


### PR DESCRIPTION
### Description
Modified security github workflow to run based on plugin availability on central repo.
- In case the security plugin is not present, the test workflow will be skipped. 
- Corrected the security plugin version bug in `build.gradle` in case of snapshot build
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/725
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
