### PR TITLE
Backport UpdateAutoFollowPatternIT changes to 2.x

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -197,6 +197,8 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             }, 30, TimeUnit.SECONDS)
             // Verify that existing index matching the pattern are replicated.
             assertBusy ({
+                followerClient.waitForShardTaskStart(leaderIndexName)
+                followerClient.waitForShardTaskStart(leaderIndexName2)
                 Assertions.assertThat(followerClient.indices()
                         .exists(GetIndexRequest(leaderIndexName2), RequestOptions.DEFAULT))
                         .isEqualTo(true)
@@ -208,12 +210,10 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                     assert(key["num_success_start_replication"]!! as Int == 1)
                 }
                 assertTrue(af_stats.size == 2)
-            }, 30, TimeUnit.SECONDS)
+            }, 60, TimeUnit.SECONDS)
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName2)
-            followerClient.waitForShardTaskStart(leaderIndexName)
-            followerClient.waitForShardTaskStart(leaderIndexName2)
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Monu Singh <msnghgw@amazon.com>
(cherry picked from commit f9746e54d030828a1ea0721456fe10dd094010cb)

### Description
UpdateAutoFollowPatternIT test "test auto follow stats" was waiting for 30 seconds to poll for shard replication task to start. This was causing intermittent failure as shard replication task may take more time to start.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
