### PR TITLE
Add workflow to run knn-index tests

### DIFF
--- a/.github/workflows/knn-index.yml
+++ b/.github/workflows/knn-index.yml
@@ -1,0 +1,72 @@
+name: Knn tests
+# This workflow is triggered on pull requests to main branch
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - '*'
+
+jobs:
+  req:
+    # Job name
+    name: Knn plugin check
+    runs-on: ubuntu-latest
+    outputs:
+      isKnnPluginAvailable: ${{ steps.knn-plugin-availability-check.outputs.isKnnPluginAvailable }}
+    steps:
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - id: knn-plugin-availability-check
+        name: "Knn plugin check"
+        run: |
+          opensearch_version=$(grep "System.getProperty(\"opensearch.version\", \"" build.gradle | grep '\([0-9]\|[.]\)\{5\}' -o)
+          opensearch_version=$opensearch_version".0-SNAPSHOT"
+          # we publish build artifacts to the below url 
+          plugin_url="https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-knn/"$opensearch_version"/"
+          st=$(curl -s -o /dev/null -w "%{http_code}" $plugin_url)
+          if [ "$st" = "200" ]; then
+            echo "isKnnPluginAvailable=True" >> $GITHUB_OUTPUT
+            cat $GITHUB_OUTPUT
+          else
+            echo "isKnnPluginAvailable=False" >> $GITHUB_OUTPUT
+            cat $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: req
+    if: ${{ 'True' == needs.req.outputs.isKnnPluginAvailable }}
+    # Job name
+    name: Build and Run Knn tests
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Build and run Replication tests
+        run: |
+          ./gradlew clean release -Dbuild.snapshot=true -PnumNodes=1  -Dtests.class=org.opensearch.replication.BasicReplicationIT   -Dtests.method="test knn index replication"  -Pknn=true 
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: logs
+          path: |
+            build/testclusters/integTest-*/logs/*
+            build/testclusters/leaderCluster-*/logs/*
+            build/testclusters/followCluster-*/logs/*
+      - name: Create Artifact Path
+        run: |
+          mkdir -p cross-cluster-replication-artifacts
+          cp ./build/distributions/*.zip cross-cluster-replication-artifacts
+      - name: Uploads coverage
+        with:
+          fetch-depth: 2
+        uses: codecov/codecov-action@v1.2.1


### PR DESCRIPTION
added new workflow to run knn-index
Signed-off-by: Monu Singh <msnghgw@amazon.com>

### Description
Cross cluster replication now supports Knn index.
To test that each commit passes for knn-index, we are introducing a separate workflow to run cross cluster repication on knn-index.

A need for separate workflow arised as we do not want to add knn-plugin as a dependency as this may lead to failures if knn plugin is not available. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
