### PR TITLE
Added cancellable coroutine with timeout for cluster update task

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -45,6 +45,7 @@ import org.opensearch.tasks.TaskId
 import org.opensearch.threadpool.Scheduler
 import org.opensearch.threadpool.ThreadPool
 import java.util.concurrent.ConcurrentSkipListSet
+import java.util.concurrent.TimeUnit
 
 class AutoFollowTask(id: Long, type: String, action: String, description: String, parentTask: TaskId,
                      headers: Map<String, String>,
@@ -91,7 +92,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
 
     private fun addRetryScheduler() {
         log.debug("Adding retry scheduler")
-        if(retryScheduler != null && !retryScheduler!!.isCancelled) {
+        if(retryScheduler != null && retryScheduler!!.getDelay(TimeUnit.NANOSECONDS) > 0L) {
             return
         }
          try {


### PR DESCRIPTION
### Description
Added cancellable coroutine with timeout for cluster update task
 - This unblocks any suspended calls when the cluster update has silently failed.
 
### Issues Resolved
N/A

### Testing
Steps:
- Induced failure on cluster update task for the initial call of autofollow
- Coroutine call is suspended for the update duration. 
- After timeout, the index moved to failed indices as part of autofollow.
- retry scheduler cleared the index from the list of failed indices.
- Replication trigger successful in the second retry.

```
[2023-04-04T18:30:12,384][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [followCluster-0] uncaught exception in thread [opensearch[followCluster-0][clusterManagerService#updateTask][T#1]]
java.lang.NullPointerException: Cannot invoke "org.opensearch.cluster.ClusterStateTaskExecutor$TaskResult.isSuccess()" because "taskResult" is null
        at org.opensearch.cluster.service.MasterService.lambda$getNonFailedTasks$7(MasterService.java:920) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]


[2023-04-04T18:32:58,879][ERROR][o.o.r.a.i.TransportReplicateIndexClusterManagerNodeAction] [followCluster-0] Failed to trigger replication for remote-index - ReplicationException[Error updating replicaiton metadata]


[2023-04-04T18:33:59,041][DEBUG][o.o.r.t.a.AutoFollowTask ] [followCluster-0][remote-cluster] Adding retry scheduler
[2023-04-04T18:33:59,046][DEBUG][o.o.r.t.a.AutoFollowTask ] [followCluster-0][remote-cluster] Checking remote-cluster under pattern name test for new indices to auto follow
[2023-04-04T18:34:28,920][DEBUG][o.o.r.t.a.AutoFollowTask ] [followCluster-0][remote-cluster] Clearing failed indices to schedule for the next retry
[2023-04-04T18:34:29,060][DEBUG][o.o.r.t.a.AutoFollowTask ] [followCluster-0][remote-cluster] Adding retry scheduler
[2023-04-04T18:34:29,061][DEBUG][o.o.r.t.a.AutoFollowTask ] [followCluster-0][remote-cluster] Checking remote-cluster under pattern name test for new indices to auto follow
[2023-04-04T18:34:29,073][INFO ][o.o.r.t.a.AutoFollowTask ] [followCluster-0][remote-cluster] Auto follow starting replication from remote-cluster:remote-index -> remote-index
```

```
curl "localhost:9201/_plugins/_replication/autofollow_stats?pretty"
{
  "num_success_start_replication" : 0,
  "num_failed_start_replication" : 0,
  "num_failed_leader_calls" : 0,
  "failed_indices" : [
    "remote-index"
  ],
  "autofollow_stats" : [
    {
      "name" : "test",
      "pattern" : "remote-index*",
      "num_success_start_replication" : 0,
      "num_failed_start_replication" : 0,
      "num_failed_leader_calls" : 0,
      "failed_indices" : [
        "remote-index"
      ],
      "last_execution_time" : 1680613409031
    }
  ]
}
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
