### PR TITLE
_type in multi-filed mapping added instead of only _doc in 1.x

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -411,13 +411,10 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         }
     }
 
-    private suspend fun updateFollowerMapping(followerIndex: String,mappingSource: String?) {
+    private suspend fun updateFollowerMapping(followerIndex: String,mappingSource: String?,typeKey : String?) {
 
         val options = IndicesOptions.strictSingleIndexNoExpandForbidClosed()
-        if (null == mappingSource) {
-            throw MappingNotAvailableException("MappingSource is not available")
-        }
-        val putMappingRequest = PutMappingRequest().indices(followerIndex).indicesOptions(options).type("_doc")
+        val putMappingRequest = PutMappingRequest().indices(followerIndex).indicesOptions(options).type(typeKey)
             .source(mappingSource, XContentType.JSON)
         val updateMappingRequest = UpdateMetadataRequest(followerIndex, UpdateMetadataRequest.Type.MAPPING, putMappingRequest)
         client.suspendExecute(UpdateMetadataAction.INSTANCE, updateMappingRequest, injectSecurityContext = true)
@@ -562,18 +559,19 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 val options = IndicesOptions.strictSingleIndexNoExpandForbidClosed()
                 var gmr = GetMappingsRequest().indices(this.leaderIndex.name).indicesOptions(options)
                 var mappingResponse = remoteClient.suspending(remoteClient.admin().indices()::getMappings, injectSecurityContext = true)(gmr)
-                var leaderMappingSource = mappingResponse?.mappings()?.get(this.leaderIndex.name)?.get("_doc")?.source()?.toString()
+                val typeKey=  mappingResponse?.mappings()?.get(this.leaderIndex.name)?.firstOrNull()?.key
+                var leaderMappingSource = mappingResponse?.mappings()?.get(this.leaderIndex.name)?.get(typeKey)?.source()?.toString()
                 @Suppress("UNCHECKED_CAST")
-                val leaderProperties = mappingResponse?.mappings()?.get(this.leaderIndex.name)?.get("_doc")?.sourceAsMap()?.toMap()?.get("properties") as? Map<String,Any>?
+                val leaderProperties = mappingResponse?.mappings()?.get(this.leaderIndex.name)?.get(typeKey)?.sourceAsMap()?.toMap()?.get("properties") as? Map<String,Any>?
                 gmr = GetMappingsRequest().indices(this.followerIndexName).indicesOptions(options)
                 mappingResponse = client.suspending(client.admin().indices()::getMappings, injectSecurityContext = true)(gmr)
                 @Suppress("UNCHECKED_CAST")
-                val followerProperties = mappingResponse?.mappings()?.get(this.followerIndexName)?.get("_doc")?.sourceAsMap()?.toMap()?.get("properties") as? Map<String,Any>?
+                val followerProperties = mappingResponse?.mappings()?.get(this.followerIndexName)?.get(typeKey)?.sourceAsMap()?.toMap()?.get("properties") as? Map<String,Any>?
                 run updateMappingLoop@ {
                     followerProperties?.forEach { iter ->
-                        if (leaderProperties?.containsKey(iter.key) == true && leaderProperties.getValue(iter.key).toString() != (iter.value).toString()) {
+                        if (leaderProperties?.getValue(iter.key).toString() != (iter.value).toString()) {
                             log.debug("Updating Multi-field Mapping at Follower")
-                            updateFollowerMapping(this.followerIndexName, leaderMappingSource)
+                            updateFollowerMapping(this.followerIndexName, leaderMappingSource,typeKey)
                             return@updateMappingLoop
                         }
                     }

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -567,13 +567,10 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 mappingResponse = client.suspending(client.admin().indices()::getMappings, injectSecurityContext = true)(gmr)
                 @Suppress("UNCHECKED_CAST")
                 val followerProperties = mappingResponse?.mappings()?.get(this.followerIndexName)?.get(typeKey)?.sourceAsMap()?.toMap()?.get("properties") as? Map<String,Any>?
-                run updateMappingLoop@ {
-                    followerProperties?.forEach { iter ->
-                        if (leaderProperties?.getValue(iter.key).toString() != (iter.value).toString()) {
-                            log.debug("Updating Multi-field Mapping at Follower")
-                            updateFollowerMapping(this.followerIndexName, leaderMappingSource,typeKey)
-                            return@updateMappingLoop
-                        }
+                for((key,value) in followerProperties?: emptyMap()) {
+                    if (leaderProperties?.getValue(key).toString() != (value).toString()) {
+                        log.debug("Updating Multi-field Mapping at Follower")
+                        updateFollowerMapping(this.followerIndexName, leaderMappingSource, typeKey)
                     }
                 }
 


### PR DESCRIPTION
### Description
Earlier only _doc type is handled in multi-filed mapping, now made generic to handle all types in mapping as 1.x versions support types other than _doc as well 
 
### Issues Resolved
 #622 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
