### PR TITLE
Handled batch requests for replication metadata update under cluster state

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/metadata/state/UpdateReplicationMetadataTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/metadata/state/UpdateReplicationMetadataTests.kt
@@ -1,0 +1,75 @@
+package org.opensearch.replication.metadata.state
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import org.junit.Assert
+import org.opensearch.cluster.ClusterState
+import org.opensearch.replication.action.replicationstatedetails.UpdateReplicationStateDetailsRequest
+import org.opensearch.replication.metadata.ReplicationOverallState
+import org.opensearch.replication.metadata.UpdateReplicationStateDetailsTaskExecutor
+import org.opensearch.test.ClusterServiceUtils
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.TestThreadPool
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class UpdateReplicationMetadataTests : OpenSearchTestCase() {
+
+    var threadPool = TestThreadPool("ReplicationPluginTest")
+    var clusterService  = ClusterServiceUtils.createClusterService(threadPool)
+
+    fun `test single task update`() {
+        val currentState: ClusterState = clusterService.state()
+        // single task
+        val tasks = arrayListOf(UpdateReplicationStateDetailsRequest("test-index",
+                hashMapOf("REPLICATION_LAST_KNOWN_OVERALL_STATE" to "RUNNING"), UpdateReplicationStateDetailsRequest.UpdateType.ADD))
+        val tasksResult = UpdateReplicationStateDetailsTaskExecutor.INSTANCE.execute(currentState, tasks)
+
+        val updatedReplicationDetails = tasksResult.resultingState?.metadata
+                ?.custom<ReplicationStateMetadata>(ReplicationStateMetadata.NAME)?.replicationDetails
+
+        Assert.assertNotNull(updatedReplicationDetails)
+        Assert.assertNotNull(updatedReplicationDetails?.get("test-index"))
+        val replicationStateParams = updatedReplicationDetails?.get("test-index")
+
+        Assert.assertEquals(ReplicationOverallState.RUNNING.name, replicationStateParams?.get(REPLICATION_LAST_KNOWN_OVERALL_STATE))
+    }
+
+    fun `test multiple tasks to add replication metadata`() {
+        val currentState: ClusterState = clusterService.state()
+        // multiple tasks
+        val tasks = arrayListOf(UpdateReplicationStateDetailsRequest("test-index-1",
+                hashMapOf("REPLICATION_LAST_KNOWN_OVERALL_STATE" to "RUNNING"), UpdateReplicationStateDetailsRequest.UpdateType.ADD),
+                UpdateReplicationStateDetailsRequest("test-index-2",
+                        hashMapOf("REPLICATION_LAST_KNOWN_OVERALL_STATE" to "RUNNING"), UpdateReplicationStateDetailsRequest.UpdateType.ADD))
+        val tasksResult = UpdateReplicationStateDetailsTaskExecutor.INSTANCE.execute(currentState, tasks)
+
+        val updatedReplicationDetails = tasksResult.resultingState?.metadata
+                ?.custom<ReplicationStateMetadata>(ReplicationStateMetadata.NAME)?.replicationDetails
+
+        Assert.assertNotNull(updatedReplicationDetails)
+        Assert.assertNotNull(updatedReplicationDetails?.get("test-index-1"))
+        var replicationStateParams = updatedReplicationDetails?.get("test-index-1")
+        Assert.assertEquals(ReplicationOverallState.RUNNING.name, replicationStateParams?.get(REPLICATION_LAST_KNOWN_OVERALL_STATE))
+        Assert.assertNotNull(updatedReplicationDetails?.get("test-index-2"))
+        replicationStateParams = updatedReplicationDetails?.get("test-index-2")
+        Assert.assertEquals(ReplicationOverallState.RUNNING.name, replicationStateParams?.get(REPLICATION_LAST_KNOWN_OVERALL_STATE))
+    }
+
+    fun `test multiple tasks to add and delete replication metadata`() {
+        val currentState: ClusterState = clusterService.state()
+        // multiple tasks
+        val tasks = arrayListOf(UpdateReplicationStateDetailsRequest("test-index-1",
+                hashMapOf("REPLICATION_LAST_KNOWN_OVERALL_STATE" to "RUNNING"), UpdateReplicationStateDetailsRequest.UpdateType.ADD),
+                UpdateReplicationStateDetailsRequest("test-index-2",
+                        hashMapOf("REPLICATION_LAST_KNOWN_OVERALL_STATE" to "RUNNING"), UpdateReplicationStateDetailsRequest.UpdateType.REMOVE))
+        val tasksResult = UpdateReplicationStateDetailsTaskExecutor.INSTANCE.execute(currentState, tasks)
+
+        val updatedReplicationDetails = tasksResult.resultingState?.metadata
+                ?.custom<ReplicationStateMetadata>(ReplicationStateMetadata.NAME)?.replicationDetails
+
+        Assert.assertNotNull(updatedReplicationDetails)
+        Assert.assertNotNull(updatedReplicationDetails?.get("test-index-1"))
+        var replicationStateParams = updatedReplicationDetails?.get("test-index-1")
+        Assert.assertEquals(ReplicationOverallState.RUNNING.name, replicationStateParams?.get(REPLICATION_LAST_KNOWN_OVERALL_STATE))
+        Assert.assertNull(updatedReplicationDetails?.get("test-index-2"))
+    }
+}


### PR DESCRIPTION
### Description
Handled batch requests for replication metadata update under cluster state.
- Replication metadata tracks current replication state(running/pause/resume/stopped) for a particular index under the cluster state. During simultaneous state transitions of various replication jobs under the cluster, multiple requests are triggered to the clustermanager node. As these are updating the replication metadata, requests are batched at the clustermanager and are executed together. Previously, these batched requests are not handled properly and state updates were applied for only one task. This PR accounts for all the batched tasks to compute the overall replication metadata to update the cluster state. 
 
### Issues Resolved
N/A

### Testing
- Forced state update to pick two tasks and verified that the metadata update happens under the cluster state.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
