### PR TITLE
Adding a proxy mode connection setup for CCR

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesService.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesService.kt
@@ -25,12 +25,11 @@ class RemoteClusterRepositoriesService(private val repositoriesService: Supplier
     }
 
     private fun listenForUpdates(clusterSettings: ClusterSettings) {
-        // TODO: Proxy support from ES 7.7. Needs additional handling based on those settings
-        clusterSettings.addAffixUpdateConsumer(REMOTE_CLUSTER_SEEDS, this::updateRepositoryDetails) { _, _ -> Unit }
-        clusterSettings.addAffixUpdateConsumer(PROXY_ADDRESS, this::updateRepositoryDetails) { _, _ -> Unit }
+        clusterSettings.addAffixUpdateConsumer(REMOTE_CLUSTER_SEEDS, this::updateRepositoryDetailsForSeeds) { _, _ -> Unit }
+        clusterSettings.addAffixUpdateConsumer(PROXY_ADDRESS, this::updateRepositoryDetailsForProxy) { _, _ -> Unit }
     }
 
-    private fun updateRepositoryDetails(alias: String, seeds: List<String>?) {
+    private fun updateRepositoryDetailsForSeeds(alias: String, seeds: List<String>?) {
         if(seeds.isNullOrEmpty()) {
             repositoriesService.get().unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + alias)
             return
@@ -39,7 +38,7 @@ class RemoteClusterRepositoriesService(private val repositoriesService: Supplier
         repositoriesService.get().registerInternalRepository(REMOTE_REPOSITORY_PREFIX + alias, REMOTE_REPOSITORY_TYPE)
     }
 
-    private fun updateRepositoryDetails(alias: String, proxyIp: String?) {
+    private fun updateRepositoryDetailsForProxy(alias: String, proxyIp: String?) {
         if(proxyIp.isNullOrEmpty()) {
             repositoriesService.get().unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + alias)
             return

--- a/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
@@ -1,6 +1,6 @@
 package org.opensearch.replication.repository
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import com.nhaarman.mockitokotlin2.times
 import org.mockito.Mockito
 import org.opensearch.Version
 import org.opensearch.cluster.node.DiscoveryNode
@@ -13,7 +13,6 @@ import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.threadpool.TestThreadPool
 import java.util.function.Supplier
 
-@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
     var threadPool = TestThreadPool("ReplicationPluginTest")
 
@@ -29,7 +28,24 @@ class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
         val repositoriesService = Mockito.mock(RepositoriesService::class.java)
         RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
         clusterSetting.applySettings(Settings.builder().putList("cluster.remote.con-alias.seeds", "127.0.0.1:9300", "127.0.0.2:9300").build())
-        Mockito.verify(repositoriesService).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+        Mockito.verify(repositoriesService, times(1)).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+    }
+
+    fun `test removal of seed_nodes`() {
+        var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        val discoveryNode = DiscoveryNode(
+            "node",
+            buildNewFakeTransportAddress(), emptyMap(),
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            Version.CURRENT
+        )
+        var clusterService  = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSetting)
+        val repositoriesService = Mockito.mock(RepositoriesService::class.java)
+        RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
+        clusterSetting.applySettings(Settings.builder().putList("cluster.remote.con-alias.seeds", "127.0.0.1:9300", "127.0.0.2:9300").build())
+        Mockito.verify(repositoriesService, times(1)).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+        clusterSetting.applySettings(Settings.builder().putNull("cluster.remote.con-alias.seeds").build())
+        Mockito.verify(repositoriesService, times(1)).unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias")
     }
 
     fun `test changes in proxy_id for proxy-setup`() {
@@ -43,7 +59,26 @@ class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
         var clusterService  = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSetting)
         val repositoriesService = Mockito.mock(RepositoriesService::class.java)
         RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
+        // trying remove con-alias once
         clusterSetting.applySettings(Settings.builder().put("cluster.remote.con-alias.mode", "proxy").put("cluster.remote.con-alias.proxy_address", "127.0.0.1:100").build())
-        Mockito.verify(repositoriesService).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+        Mockito.verify(repositoriesService, times(1)).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+    }
+
+    fun `test removal of proxy_id for proxy-setup`() {
+        var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        val discoveryNode = DiscoveryNode(
+            "node",
+            buildNewFakeTransportAddress(), emptyMap(),
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            Version.CURRENT
+        )
+        var clusterService  = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSetting)
+        val repositoriesService = Mockito.mock(RepositoriesService::class.java)
+        RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
+        clusterSetting.applySettings(Settings.builder().put("cluster.remote.con-alias.mode", "proxy").put("cluster.remote.con-alias.proxy_address", "127.0.0.1:100").build())
+        Mockito.verify(repositoriesService, times(1)).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+        clusterSetting.applySettings(Settings.builder().putNull("cluster.remote.con-alias.mode").build())
+        clusterSetting.applySettings(Settings.builder().putNull("cluster.remote.con-alias.proxy_address").build())
+        Mockito.verify(repositoriesService, times(1)).unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias")
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
@@ -1,6 +1,5 @@
 package org.opensearch.replication.repository
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
 import com.nhaarman.mockitokotlin2.times
 import org.mockito.Mockito
 import org.opensearch.Version
@@ -14,12 +13,11 @@ import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.threadpool.TestThreadPool
 import java.util.function.Supplier
 
-@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
-    var threadPool = TestThreadPool("ReplicationPluginTest")
 
     fun `test changes in seed_nodes`() {
         var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        var threadPool = TestThreadPool("ReplicationPluginTest")
         val discoveryNode = DiscoveryNode(
                 "node",
                 buildNewFakeTransportAddress(), emptyMap(),
@@ -31,10 +29,12 @@ class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
         RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
         clusterSetting.applySettings(Settings.builder().putList("cluster.remote.con-alias.seeds", "127.0.0.1:9300", "127.0.0.2:9300").build())
         Mockito.verify(repositoriesService, times(1)).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+        threadPool.shutdown()
     }
 
     fun `test removal of seed_nodes`() {
         var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        var threadPool = TestThreadPool("ReplicationPluginTest")
         val discoveryNode = DiscoveryNode(
             "node",
             buildNewFakeTransportAddress(), emptyMap(),
@@ -48,10 +48,12 @@ class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
         Mockito.verify(repositoriesService, times(1)).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
         clusterSetting.applySettings(Settings.builder().putNull("cluster.remote.con-alias.seeds").build())
         Mockito.verify(repositoriesService, times(1)).unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias")
+        threadPool.shutdown()
     }
 
     fun `test changes in proxy_id for proxy-setup`() {
         var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        var threadPool = TestThreadPool("ReplicationPluginTest")
         val discoveryNode = DiscoveryNode(
                 "node",
                 buildNewFakeTransportAddress(), emptyMap(),
@@ -61,13 +63,14 @@ class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
         var clusterService  = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSetting)
         val repositoriesService = Mockito.mock(RepositoriesService::class.java)
         RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
-        // trying remove con-alias once
         clusterSetting.applySettings(Settings.builder().put("cluster.remote.con-alias.mode", "proxy").put("cluster.remote.con-alias.proxy_address", "127.0.0.1:100").build())
         Mockito.verify(repositoriesService, times(1)).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+        threadPool.shutdown()
     }
 
     fun `test removal of proxy_id for proxy-setup`() {
         var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        var threadPool = TestThreadPool("ReplicationPluginTest")
         val discoveryNode = DiscoveryNode(
             "node",
             buildNewFakeTransportAddress(), emptyMap(),
@@ -82,5 +85,6 @@ class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
         clusterSetting.applySettings(Settings.builder().putNull("cluster.remote.con-alias.mode").build())
         clusterSetting.applySettings(Settings.builder().putNull("cluster.remote.con-alias.proxy_address").build())
         Mockito.verify(repositoriesService, times(1)).unregisterInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias")
+        threadPool.shutdown()
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
@@ -1,0 +1,49 @@
+package org.opensearch.replication.repository
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import org.mockito.Mockito
+import org.opensearch.Version
+import org.opensearch.cluster.node.DiscoveryNode
+import org.opensearch.cluster.node.DiscoveryNodeRole
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.repositories.RepositoriesService
+import org.opensearch.test.ClusterServiceUtils
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.TestThreadPool
+import java.util.function.Supplier
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
+    var threadPool = TestThreadPool("ReplicationPluginTest")
+
+    fun `test changes in seed_nodes`() {
+        var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        val discoveryNode = DiscoveryNode(
+                "node",
+                buildNewFakeTransportAddress(), emptyMap(),
+                DiscoveryNodeRole.BUILT_IN_ROLES,
+                Version.CURRENT
+        )
+        var clusterService  = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSetting)
+        val repositoriesService = Mockito.mock(RepositoriesService::class.java)
+        RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
+        clusterSetting.applySettings(Settings.builder().putList("cluster.remote.con-alias.seeds", "127.0.0.1:9300", "127.0.0.2:9300").build())
+        Mockito.verify(repositoriesService).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+    }
+
+    fun `test changes in proxy_id for proxy-setup`() {
+        var clusterSetting = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        val discoveryNode = DiscoveryNode(
+                "node",
+                buildNewFakeTransportAddress(), emptyMap(),
+                DiscoveryNodeRole.BUILT_IN_ROLES,
+                Version.CURRENT
+        )
+        var clusterService  = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSetting)
+        val repositoriesService = Mockito.mock(RepositoriesService::class.java)
+        RemoteClusterRepositoriesService(Supplier { repositoriesService }, clusterService)
+        clusterSetting.applySettings(Settings.builder().put("cluster.remote.con-alias.mode", "proxy").put("cluster.remote.con-alias.proxy_address", "127.0.0.1:100").build())
+        Mockito.verify(repositoriesService).registerInternalRepository(REMOTE_REPOSITORY_PREFIX + "con-alias", REMOTE_REPOSITORY_TYPE)
+    }
+}

--- a/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/repository/RemoteClusterRepositoriesServiceTests.kt
@@ -1,5 +1,6 @@
 package org.opensearch.replication.repository
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
 import com.nhaarman.mockitokotlin2.times
 import org.mockito.Mockito
 import org.opensearch.Version
@@ -13,6 +14,7 @@ import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.threadpool.TestThreadPool
 import java.util.function.Supplier
 
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 class RemoteClusterRepositoriesServiceTests : OpenSearchTestCase() {
     var threadPool = TestThreadPool("ReplicationPluginTest")
 


### PR DESCRIPTION
Signed-off-by: Ishank Katiyar <ishankka@amazon.com>

### Description
For CCR connection setup between two cluster, we can update seed nodes of leader cluster into follower cluster or we can use `proxy` mode connection type in which we add a proxy_address of leader cluster onto follower cluster settings. Currently CCR does not have seems to work with proxy mode.
#### Why CCR does not work with proxy mode.
* Currently we do not have any listeners for changes in `proxy_address` in follower cluster settings, which is present for `seeds`. So any changes made in `proxy_address` like adding a new `proxy_address` is not honoured.
#### What are the changes to resolve
* We went ahead to add a listener for changes in `proxy_address` in followers cluster settings, so any changes made to `proxy_address` will be listened.
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/371
 
### Check List
- [ x ] New functionality includes testing.
  - [ x ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
