### PR TITLE
BWC fix: Changed version to 2.6 and disabled rolling upgrade tests

### DIFF
--- a/.github/workflows/bwc.yml
+++ b/.github/workflows/bwc.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           echo "Running backwards compatibility tests ..."
           ./gradlew clean release -Dbuild.snapshot=true -x test -x IntegTest
-          ./gradlew mixedClusterTask --stacktrace
           ./gradlew fullRestartClusterTask --stacktrace
       - name: Upload failed logs
         uses: actions/upload-artifact@v2

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ buildscript {
 
 
         // for bwc tests
-        opensearch_previous_version = System.getProperty("bwc_older_version", "2.1.0")
+        opensearch_previous_version = System.getProperty("bwc_older_version", "2.6.0")
         plugin_previous_version = opensearch_previous_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
@@ -851,8 +851,9 @@ task "fullRestartClusterTask"(type: RestIntegTestTask) {
     - full cluster restart:  oldVersionClusterTask1 --> fullRestartClusterTask
  */
 task "bwcTestSuite"(type: RestIntegTestTask) {
-    useCluster testClusters.bwcLeader0
-    useCluster testClusters.bwcFollower0
+    // Disabling the bwcLeader0 & bwcFollower0 as rolling upgrade has been disabled.
+    //useCluster testClusters.bwcLeader0
+    //useCluster testClusters.bwcFollower0
     useCluster testClusters.bwcLeader1
     useCluster testClusters.bwcFollower1
     doFirst {
@@ -875,8 +876,9 @@ task "bwcTestSuite"(type: RestIntegTestTask) {
     }
     nonInputProperties.systemProperty('tests.cluster_suffix', "1")
     nonInputProperties.systemProperty('tests.bwcTask', "bwcTestSuite")
-    dependsOn tasks.named("mixedClusterTask")
-    dependsOn tasks.named("rollingUpgradeClusterTask")
+    // Disabling the rolling upgrade bwc tests as 2.x -> 3.0 is not supported yet.
+    //dependsOn tasks.named("mixedClusterTask")
+    //dependsOn tasks.named("rollingUpgradeClusterTask")
     dependsOn tasks.named("fullRestartClusterTask")
 }
 


### PR DESCRIPTION
### Description
BWC rolling upgrade tests are failing on main branch(more details in the issue below). Disabling the test as there is no way to do a rolling upgrade from 2.x -> 3.0 right now. 
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/620
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
