### PR TITLE
Upgrade gradle version and remove remaining use of ImmutableOpenMap

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -11,6 +11,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -131,9 +131,9 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
     private suspend fun isResumable(params :IndexReplicationParams): Boolean {
         var isResumable = true
         val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
-        val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName).shards()
+        val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName)?.shards()
         val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
-        shards.forEach {
+        shards?.forEach {
             val followerShardId = it.value.shardId
             if  (!retentionLeaseHelper.verifyRetentionLeaseExist(ShardId(params.leaderIndex, followerShardId.id), followerShardId)) {
                 isResumable = false
@@ -146,7 +146,7 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
 
         // clean up all retention leases we may have accidentally took while doing verifyRetentionLeaseExist .
         // Idempotent Op which does no harm
-        shards.forEach {
+        shards?.forEach {
             val followerShardId = it.value.shardId
             log.debug("Removing lease for $followerShardId.id ")
             retentionLeaseHelper.attemptRetentionLeaseRemoval(ShardId(params.leaderIndex, followerShardId.id), followerShardId)

--- a/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
@@ -274,8 +274,8 @@ class TransportUpdateMetadataAction @Inject constructor(
             val indexAsArray = arrayOf(concreteIndex)
             val aliasMetadata = metadata.findAliases(action, indexAsArray)
             val finalAliases: MutableList<String> = ArrayList()
-            for (curAliases in aliasMetadata.values()) {
-                for (aliasMeta in curAliases.value) {
+            for (curAliases in aliasMetadata.values) {
+                for (aliasMeta in curAliases) {
                     finalAliases.add(aliasMeta.alias())
                 }
             }

--- a/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTask.kt
@@ -22,10 +22,10 @@ import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.block.ClusterBlockLevel
 import org.opensearch.cluster.block.ClusterBlocks
 import org.opensearch.cluster.service.ClusterService
-import org.opensearch.common.collect.ImmutableOpenMap
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.rest.RestStatus
-import java.util.*
+import java.util.Collections
+import java.util.EnumSet
 
 
 /* This is our custom index block to prevent changes to follower
@@ -49,11 +49,11 @@ fun checkIfIndexBlockedWithLevel(clusterService: ClusterService,
                                  clusterBlockLevel: ClusterBlockLevel) {
     clusterService.state().routingTable.index(indexName) ?:
     throw IndexNotFoundException("Index with name:$indexName doesn't exist")
-    val writeIndexBlockMap : ImmutableOpenMap<String, Set<ClusterBlock>> = clusterService.state().blocks()
+    val writeIndexBlockMap : Map<String, Set<ClusterBlock>> = clusterService.state().blocks()
             .indices(clusterBlockLevel)
     if (!writeIndexBlockMap.containsKey(indexName))
         return
-    val clusterBlocksSet : Set<ClusterBlock> = writeIndexBlockMap.get(indexName)
+    val clusterBlocksSet : Set<ClusterBlock> = writeIndexBlockMap.getOrDefault(indexName, Collections.emptySet())
     if (clusterBlocksSet.contains(INDEX_REPLICATION_BLOCK)
             && clusterBlocksSet.size > 1)
         throw ClusterBlockException(clusterBlocksSet)

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -238,7 +238,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         builder.remove(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key)
 
         val indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder)
-        indexMetadata.aliases.valuesIt().forEach {
+        indexMetadata.aliases.values.forEach {
             indexMdBuilder.putAlias(it)
         }
         return indexMdBuilder.build()

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -77,9 +77,9 @@ class RemoteClusterRetentionLeaseHelper constructor(val followerClusterName: Str
             val remoteMetadata = getLeaderIndexMetadata(replMetadata.connectionName, replMetadata.leaderContext.resource)
             val params = IndexReplicationParams(replMetadata.connectionName, remoteMetadata.index, followerIndexName)
             val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
-            val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName).shards()
+            val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName)?.shards()
             val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
-            shards.forEach {
+            shards?.forEach {
                 val followerShardId = it.value.shardId
                 log.debug("Removing lease for $followerShardId.id ")
                 retentionLeaseHelper.attemptRetentionLeaseRemoval(ShardId(params.leaderIndex, followerShardId.id), followerShardId)

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -346,9 +346,9 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         val clusterState = clusterService.state()
         val persistentTasks = clusterState.metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
 
-        val followerShardIds = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
-            .map {  shard -> shard.value.shardId }
-            .stream().collect(Collectors.toSet())
+        val followerShardIds = clusterService.state().routingTable.indicesRouting().get(followerIndexName)?.shards()
+            ?.map { shard -> shard.value.shardId }
+            ?.stream()?.collect(Collectors.toSet()).orEmpty()
         val runningShardTasksForIndex = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
                 .map { task -> task.params as ShardReplicationParams }
                 .filter {taskParam -> followerShardIds.contains(taskParam.followerShardId) }
@@ -434,16 +434,16 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 // If we we want to retrieve just the version of settings and alias versions, there are two options
                 // 1. Include this in GetChanges and communicate it to IndexTask via Metadata
                 // 2. Add another API to retrieve version of settings & aliases. Persist current version in Metadata
-                var leaderSettings = settingsResponse.indexToSettings.get(this.leaderIndex.name)
-                leaderSettings = leaderSettings.filter { k: String? ->
+                var leaderSettings = settingsResponse.indexToSettings.getOrDefault(this.leaderIndex.name, Settings.EMPTY)
+                leaderSettings = leaderSettings.filter { k: String ->
                     !blockListedSettings.contains(k)
                 }
 
                 gsr = GetSettingsRequest().includeDefaults(false).indices(this.followerIndexName)
                 settingsResponse = client.suspending(client.admin().indices()::getSettings, injectSecurityContext = true)(gsr)
-                var followerSettings = settingsResponse.indexToSettings.get(this.followerIndexName)
+                var followerSettings = settingsResponse.indexToSettings.getOrDefault(this.followerIndexName, Settings.EMPTY)
 
-                followerSettings = followerSettings.filter { k: String? ->
+                followerSettings = followerSettings.filter { k: String ->
                     k != REPLICATED_INDEX_SETTING.key
                 }
 
@@ -516,11 +516,11 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 //Alias
                 var getAliasesRequest = GetAliasesRequest().indices(this.leaderIndex.name)
                 var getAliasesRes = remoteClient.suspending(remoteClient.admin().indices()::getAliases, injectSecurityContext = true)(getAliasesRequest)
-                var leaderAliases = getAliasesRes.aliases.get(this.leaderIndex.name)
+                var leaderAliases = getAliasesRes.aliases.getOrDefault(this.leaderIndex.name, Collections.emptyList())
 
                 getAliasesRequest = GetAliasesRequest().indices(followerIndexName)
                 getAliasesRes = client.suspending(client.admin().indices()::getAliases, injectSecurityContext = true)(getAliasesRequest)
-                var followerAliases = getAliasesRes.aliases.get(followerIndexName)
+                var followerAliases = getAliasesRes.aliases.getOrDefault(followerIndexName, Collections.emptyList())
 
                 var request  :IndicesAliasesRequest?
 
@@ -606,8 +606,8 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
             try {
                 //Step 1 : Remove the tasks
-                val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
-                shards.forEach {
+                val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName)?.shards()
+                shards?.forEach {
                     persistentTasksService.removeTask(ShardReplicationTask.taskIdForShard(it.value.shardId))
                 }
 
@@ -748,7 +748,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
     suspend fun startNewOrMissingShardTasks():  Map<ShardId, PersistentTask<ShardReplicationParams>> {
         assert(clusterService.state().routingTable.hasIndex(followerIndexName)) { "Can't find index $followerIndexName" }
-        val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
+        val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName)?.shards()
         val persistentTasks = clusterService.state().metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
         val runningShardTasks = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
             .map { task -> task as PersistentTask<ShardReplicationParams> }
@@ -757,14 +757,14 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 {t: PersistentTask<ShardReplicationParams> -> t.params!!.followerShardId},
                 {t: PersistentTask<ShardReplicationParams> -> t}))
 
-        val tasks = shards.map {
+        val tasks = shards?.map {
             it.value.shardId
-        }.associate { shardId ->
+        }?.associate { shardId ->
             val task = runningShardTasks.getOrElse(shardId) {
                 startReplicationTask(ShardReplicationParams(leaderAlias, ShardId(leaderIndex, shardId.id), shardId))
             }
             return@associate shardId to task
-        }
+        }.orEmpty()
 
         return tasks
     }
@@ -865,9 +865,9 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     This can happen if there was a badly timed cluster manager node failure.""".trimIndent())
             }
         } else if (restore.state() == RestoreInProgress.State.FAILURE) {
-            val failureReason = restore.shards().values().find {
-                it.value.state() == RestoreInProgress.State.FAILURE
-            }!!.value.reason()
+            val failureReason = restore.shards().values.find {
+                it.state() == RestoreInProgress.State.FAILURE
+            }!!.reason()
             return FailedState(Collections.emptyMap(), failureReason)
         } else {
             return InitFollowState

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -227,7 +227,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
 
         settings = Settings.builder()
@@ -242,7 +242,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                     "checksum",
                     followerClient.indices()
                             .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
+                            .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.shard.check_on_startup"]
             )
         }, 30L, TimeUnit.SECONDS)
     }
@@ -272,7 +272,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put("index.shard.check_on_startup", "checksum")

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
@@ -128,7 +128,7 @@ class SecurityDlsFlsIT: SecurityBase() {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put("index.shard.check_on_startup", "checksum")

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -130,7 +130,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                     "3",
                     followerClient.indices()
                             .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                            .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
         }, 15, TimeUnit.SECONDS)
     }
@@ -289,7 +289,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "0",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
         }, 30L, TimeUnit.SECONDS)
     }
@@ -448,7 +448,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "0",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
@@ -469,14 +469,14 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "2",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
             assertEqualAliases()
         }, 30L, TimeUnit.SECONDS)
         // Case 2 :  Blocklisted  setting are not copied
         Assert.assertNull(followerClient.indices()
                 .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                .indexToSettings[followerIndexName].get("index.routing.allocation.enable"))
+                .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY).get("index.routing.allocation.enable"))
         //Alias test case 2: Update existing alias
         aliasAction = IndicesAliasesRequest.AliasActions.add()
                 .index(leaderIndexName)
@@ -500,19 +500,19 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "3",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
             Assert.assertEquals(
                 "10s",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.search.idle.after"]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.search.idle.after"]
             )
             Assert.assertEquals(
                 "none",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.routing.allocation.enable"]
             )
             assertEqualAliases()
         }, 30L, TimeUnit.SECONDS)
@@ -539,7 +539,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 null,
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.search.idle.after"]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.search.idle.after"]
             )
             assertEqualAliases()
         }, 30L, TimeUnit.SECONDS)
@@ -568,7 +568,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put("index.shard.check_on_startup", "checksum")
@@ -579,7 +579,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "checksum",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.shard.check_on_startup"]
         )
     }
 
@@ -1064,7 +1064,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                         "2",
                         leaderClient.indices()
                                 .getSettings(getLeaderSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                                .indexToSettings.getOrDefault(leaderIndexName, Settings.EMPTY)[IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
                 )
             }, 15, TimeUnit.SECONDS)
 
@@ -1124,7 +1124,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                         "2",
                         leaderClient.indices()
                                 .getSettings(getLeaderSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                                .indexToSettings.getOrDefault(leaderIndexName, Settings.EMPTY)[IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
                 )
             }, 15, TimeUnit.SECONDS)
 
@@ -1176,7 +1176,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                         "2",
                         followerClient.indices()
                                 .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[followerIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                                .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
                 )
             }, 15, TimeUnit.SECONDS)
         } finally {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -170,7 +170,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                         "3",
                         followerClient.indices()
                                 .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                                .indexToSettings.getOrDefault(leaderIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
                 )
                 followerClient.waitForShardTaskStart(leaderIndexName, waitForShardTask)
             }, 15, TimeUnit.SECONDS)

--- a/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
@@ -30,7 +30,6 @@ import org.opensearch.action.get.GetResponse
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.common.UUIDs
 import org.opensearch.common.bytes.BytesReference
-import org.opensearch.common.collect.ImmutableOpenMap
 import org.opensearch.common.settings.Settings
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
@@ -55,8 +54,7 @@ import org.opensearch.snapshots.RestoreInfo
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.test.client.NoOpNodeClient
 import java.lang.reflect.Field
-import java.util.ArrayList
-import java.util.HashMap
+import java.util.*
 
 open class NoOpClient(testName :String) : NoOpNodeClient(testName) {
     @Override
@@ -109,9 +107,7 @@ open class NoOpClient(testName :String) : NoOpNodeClient(testName) {
 
             val indexToSettings = HashMap<String, Settings>()
             indexToSettings[IndexReplicationTaskTests.followerIndex] =  desiredSettingsBuilder.build()
-
-            val settingsMap = ImmutableOpenMap.builder<String, Settings>().putAll(indexToSettings).build()
-            var settingResponse = GetSettingsResponse(settingsMap, settingsMap)
+            var settingResponse = GetSettingsResponse(indexToSettings, indexToSettings)
             listener.onResponse(settingResponse as Response)
         } else if (action == RecoveryAction.INSTANCE) {
             val shardRecoveryStates: MutableMap<String, List<RecoveryState>> = HashMap()


### PR DESCRIPTION
### Description
Changes made

* upgraded gradle version from gradle-7.4.2 to gradle-7.6
* Replaced existing uses of import java.util.* to relevant imports
* Removed uses of ImmutableOpenMap and changed to Map
* Added Null safety


 
### Issues Resolved
Current builds started failing due to upstream changes in Opensearch

Opensearch removed the remaining uses of ImmutableOpenMap to Map.
the get() of ImmutableOpenMap return non-null empty set however the get() method of Map can return null. To avoid this we changed the uses of get() to getOrDefault() to handle null cases gracefully.

https://github.com/opensearch-project/OpenSearch/commit/d984f5028e77e281ed08386d43de4e64e06f2bf8
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
