### PR TITLE
Extract number of nodes

### DIFF
--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -98,9 +98,12 @@ then
   leader=$(echo  $data | cut -d ',' -f1 | cut -d ':' -f1,2 )
   follower=$(echo $data  |  cut -d ',' -f2 | cut -d ':' -f1,2 )
   
+  # Get number of nodes, assuming both leader and follower have same number of nodes
+  numNodes=$((${follower##*:} - ${leader##*:}))
+  
   LTRANSPORT_PORT=$(echo  $data | cut -d ',' -f1 | cut -d ':' -f1,3 )
   FTRANSPORT_PORT=$(echo $data  |  cut -d ',' -f2 | cut -d ':' -f1,3 )
-  eval "./gradlew integTestRemote -Dleader.http_host=\"$leader\" -Dfollower.http_host=\"$follower\" -Dfollower.transport_host=\"$FTRANSPORT_PORT\"  -Dleader.transport_host=\"$LTRANSPORT_PORT\"  -Dsecurity_enabled=\"$SECURITY_ENABLED\" -Duser=\"$USERNAME\" -Dpassword=\"$PASSWORD\" --console=plain "
+  eval "./gradlew integTestRemote -Dleader.http_host=\"$leader\" -Dfollower.http_host=\"$follower\" -Dfollower.transport_host=\"$FTRANSPORT_PORT\"  -Dleader.transport_host=\"$LTRANSPORT_PORT\"  -Dsecurity_enabled=\"$SECURITY_ENABLED\" -Duser=\"$USERNAME\" -Dpassword=\"$PASSWORD\" -PnumNodes=$numNodes --console=plain "
 
 else
   # Single cluster

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -97,12 +97,18 @@ then
 
   leader=$(echo  $data | cut -d ',' -f1 | cut -d ':' -f1,2 )
   follower=$(echo $data  |  cut -d ',' -f2 | cut -d ':' -f1,2 )
+  echo "leader: $leader"
+  echo "follower: $follower"
   
   # Get number of nodes, assuming both leader and follower have same number of nodes
   numNodes=$((${follower##*:} - ${leader##*:}))
+  echo "numNodes: $numNodes"
   
   LTRANSPORT_PORT=$(echo  $data | cut -d ',' -f1 | cut -d ':' -f1,3 )
   FTRANSPORT_PORT=$(echo $data  |  cut -d ',' -f2 | cut -d ':' -f1,3 )
+  echo "LTRANSPORT_PORT: $LTRANSPORT_PORT"
+  echo "FTRANSPORT_PORT: $FTRANSPORT_PORT"
+  
   eval "./gradlew integTestRemote -Dleader.http_host=\"$leader\" -Dfollower.http_host=\"$follower\" -Dfollower.transport_host=\"$FTRANSPORT_PORT\"  -Dleader.transport_host=\"$LTRANSPORT_PORT\"  -Dsecurity_enabled=\"$SECURITY_ENABLED\" -Duser=\"$USERNAME\" -Dpassword=\"$PASSWORD\" -PnumNodes=$numNodes --console=plain "
 
 else


### PR DESCRIPTION
Extract number of nodes from the input to pass as PnumNodes

### Description
The check to determine if test is running on multi node cluster is defined like

```
if(totalNodes != null && totalNodes < "2") {
                isMultiNodeClusterConfiguration = false
            }
```

The script.sh invoked by opensearch-build does not pass numNodes,
With this change, the script will be able to calculate the number of nodes. This will ensure that multinode tests are skipped.
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/825
https://github.com/opensearch-project/cross-cluster-replication/issues/824

```bash
./myscript.sh -e '[                                                                                                                                               ─╯
{
"cluster_name": "leader",
"data_nodes": [
{
"endpoint": "localhost",
"port": 9200,
"transport": 9300
},
{
"endpoint": "localhost",
"port": 9201,
"transport": 9301
}
],
"cluster_manager_nodes": []
},
{
"cluster_name": "follower",
"data_nodes": [
{
"endpoint": "localhost",
"port": 9202,
"transport": 9302
},
{
"endpoint": "localhost",
"port": 9203,
"transport": 9303
}
],
"cluster_manager_nodes": []
}
]' -s true -v 2.7.0
leader: localhost:9200
follower: localhost:9202
numNodes: 2
LTRANSPORT_PORT: localhost:9300
FTRANSPORT_PORT: localhost:9302
./gradlew integTestRemote -Dleader.http_host="localhost:9200" -Dfollower.http_host="localhost:9202" -Dfollower.transport_host="localhost:9302"  -Dleader.transport_host="localhost:9300"  -Dsecurity_enabled="true" -Duser="admin" -Dpassword="admin" -PnumNodes=2 --console=plain 
```


```bash
Suite: Test class org.opensearch.replication.integ.rest.ClusterRerouteFollowerIT
  2> Mai 12, 2023 3:03:17 PM org.opensearch.client.RestClient logResponse
  2> WARNUNG: request [PUT https://localhost:9200/_template/all] returned 1 warnings: [299 OpenSearch-2.8.0-afde1589ee935846746bcf90ab7e658e4d594426 "Deprecated field [template] used, replaced by [index_patterns]"]
  2> REPRODUCE WITH: ./gradlew ':integTestRemote' --tests "org.opensearch.replication.integ.rest.ClusterRerouteFollowerIT.test replication works after rerouting a shard from one node to another in follower cluster" -Dtests.seed=53FBBA3548838764 -Dtests.security.manager=true -Dtests.locale=de -Dtests.timezone=Africa/Dakar -Druntime.java=17
  2> java.util.NoSuchElementException: No value present
        at __randomizedtesting.SeedInfo.seed([53FBBA3548838764:89F92960F20419FE]:0)
        at java.base/java.util.Optional.get(Optional.java:143)
        at org.opensearch.replication.integ.rest.ClusterRerouteFollowerIT.test replication works after rerouting a shard from one node to another in follower cluster(ClusterRerouteFollowerIT.kt:55)
  2> NOTE: leaving temporary files on disk at: /tmp/tmpwvibll9u/cross-cluster-replication/build/testrun/integTestRemote/temp/org.opensearch.replication.integ.rest.ClusterRerouteFollowerIT_53FBBA3548838764-001
  2> NOTE: test params are: codec=Asserting(Lucene95): {}, docValues:{}, maxPointsInLeafNode=457, maxMBSortInHeap=7.367045188021147, sim=Asserting(RandomSimilarity(queryNorm=false): {}), locale=de, timezone=Africa/Dakar
  2> NOTE: Linux 5.10.176-157.645.amzn2.x86_64 amd64/Eclipse Adoptium 17.0.3 (64-bit)/cpus=16,threads=1,free=294226368,total=536870912
  2> NOTE: All tests run in this JVM: [BasicReplicationIT, MultiClusterSetupIT, ReplicationIntegTestCaseIT, ClusterRerouteFollowerIT]

REPRODUCE WITH: ./gradlew ':integTestRemote' --tests "org.opensearch.replication.integ.rest.ClusterRerouteLeaderIT.test replication works after rerouting a shard from one node to another in leader cluster" -Dtests.seed=53FBBA3548838764 -Dtests.security.manager=true -Dtests.locale=es-ES -Dtests.timezone=CNT -Druntime.java=17


Suite: Test class org.opensearch.replication.integ.rest.ClusterRerouteLeaderIT
  2> REPRODUCE WITH: ./gradlew ':integTestRemote' --tests "org.opensearch.replication.integ.rest.ClusterRerouteLeaderIT.test replication works after rerouting a shard from one node to another in leader cluster" -Dtests.seed=53FBBA3548838764 -Dtests.security.manager=true -Dtests.locale=es-ES -Dtests.timezone=CNT -Druntime.java=17
  2> java.util.NoSuchElementException: No value present
        at __randomizedtesting.SeedInfo.seed([53FBBA3548838764:CCF1092F7C02DAA5]:0)
        at java.base/java.util.Optional.get(Optional.java:143)
        at org.opensearch.replication.integ.rest.ClusterRerouteLeaderIT.test replication works after rerouting a shard from one node to another in leader cluster(ClusterRerouteLeaderIT.kt:55)
  2> NOTE: leaving temporary files on disk at: /tmp/tmpwvibll9u/cross-cluster-replication/build/testrun/integTestRemote/temp/org.opensearch.replication.integ.rest.ClusterRerouteLeaderIT_53FBBA3548838764-001
  2> NOTE: test params are: codec=Asserting(Lucene95): {}, docValues:{}, maxPointsInLeafNode=1355, maxMBSortInHeap=5.603347255278435, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=es-ES, timezone=CNT
  2> NOTE: Linux 5.10.176-157.645.amzn2.x86_64 amd64/Eclipse Adoptium 17.0.3 (64-bit)/cpus=16,threads=1,free=245805376,total=536870912
  2> NOTE: All tests run in this JVM: [BasicReplicationIT, MultiClusterSetupIT, ReplicationIntegTestCaseIT, ClusterRerouteFollowerIT, ClusterRerouteLeaderIT]
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.gradle.api.internal.tasks.testing.worker.TestWorker (file:/usr/share/opensearch/.gradle/wrapper/dists/gradle-7.6.1-all/942lu1p9i6mhoyzmt401s4g74/gradle-7.6.1/lib/plugins/gradle-testing-base-7.6.1.jar)
WARNING: Please consider reporting this to the maintainers of org.gradle.api.internal.tasks.testing.worker.TestWorker
WARNING: System::setSecurityManager will be removed in a future release

103 tests completed, 2 failed, 4 skipped
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
