### PR TITLE
Add retention lease with followerClusterUUID

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -21,13 +21,6 @@ import org.opensearch.replication.task.ReplicationState
 import org.opensearch.replication.task.index.IndexReplicationExecutor
 import org.opensearch.replication.task.index.IndexReplicationParams
 import org.opensearch.replication.task.index.IndexReplicationState
-import org.opensearch.replication.util.ValidationUtil
-import org.opensearch.replication.util.completeWith
-import org.opensearch.replication.util.coroutineContext
-import org.opensearch.replication.util.persistentTasksService
-import org.opensearch.replication.util.startTask
-import org.opensearch.replication.util.suspending
-import org.opensearch.replication.util.waitForTaskCondition
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -55,6 +48,7 @@ import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.env.Environment
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.shard.ShardId
+import org.opensearch.replication.util.*
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 import java.io.IOException
@@ -132,10 +126,14 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
         var isResumable = true
         val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
         val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName)?.shards()
-        val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+        val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(),clusterService.clusterName.value(), remoteClient)
         shards?.forEach {
             val followerShardId = it.value.shardId
-            if  (!retentionLeaseHelper.verifyRetentionLeaseExist(ShardId(params.leaderIndex, followerShardId.id), followerShardId)) {
+
+            val followerIndexService = indicesService.indexServiceSafe(followerShardId.index)
+            val indexShard = followerIndexService.getShard(followerShardId.id)
+
+            if  (!retentionLeaseHelper.verifyRetentionLeaseExist(ShardId(params.leaderIndex, followerShardId.id), followerShardId, indexShard.lastSyncedGlobalCheckpoint+1)) {
                 isResumable = false
             }
         }

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -21,6 +21,13 @@ import org.opensearch.replication.task.ReplicationState
 import org.opensearch.replication.task.index.IndexReplicationExecutor
 import org.opensearch.replication.task.index.IndexReplicationParams
 import org.opensearch.replication.task.index.IndexReplicationState
+import org.opensearch.replication.util.ValidationUtil
+import org.opensearch.replication.util.completeWith
+import org.opensearch.replication.util.coroutineContext
+import org.opensearch.replication.util.persistentTasksService
+import org.opensearch.replication.util.startTask
+import org.opensearch.replication.util.suspending
+import org.opensearch.replication.util.waitForTaskCondition
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -42,17 +49,16 @@ import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
-import org.opensearch.replication.ReplicationPlugin.Companion.KNN_INDEX_SETTING
-import org.opensearch.replication.ReplicationPlugin.Companion.KNN_PLUGIN_PRESENT_SETTING
+
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.env.Environment
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.shard.ShardId
-import org.opensearch.replication.util.*
+import org.opensearch.replication.util.indicesService
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 import java.io.IOException
-import java.lang.IllegalStateException
+
 
 class TransportResumeIndexReplicationAction @Inject constructor(transportService: TransportService,
                                                                 clusterService: ClusterService,

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -126,7 +126,7 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
         var isResumable = true
         val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
         val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName)?.shards()
-        val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(),clusterService.clusterName.value(), remoteClient)
+        val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
         shards?.forEach {
             val followerShardId = it.value.shardId
 

--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -115,7 +115,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                 try {
                     val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(request.indexName)
                     val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
-                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(), clusterService.clusterName.value(), remoteClient)
+                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
                     retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
                 } catch(e: Exception) {
                     log.error("Failed to remove retention lease from the leader cluster", e)

--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -115,7 +115,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                 try {
                     val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(request.indexName)
                     val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
-                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(), clusterService.clusterName.value(), remoteClient)
                     retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
                 } catch(e: Exception) {
                     log.error("Failed to remove retention lease from the leader cluster", e)

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -280,7 +280,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
                 snapshotShardId.id)
         restoreUUID = UUIDs.randomBase64UUID()
         val getStoreMetadataRequest = GetStoreMetadataRequest(restoreUUID, leaderShardNode, leaderShardId,
-                clusterService.clusterName.value(), followerShardId)
+                clusterService.state().metadata.clusterUUID() + ":" + clusterService.clusterName.value(), followerShardId)
 
         // Gets the remote store metadata
         val metadataResponse = executeActionOnRemote(GetStoreMetadataAction.INSTANCE, getStoreMetadataRequest, followerIndexName)

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -57,6 +57,7 @@ import org.opensearch.index.store.Store
 import org.opensearch.indices.recovery.RecoverySettings
 import org.opensearch.indices.recovery.RecoveryState
 import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
+import org.opensearch.replication.seqno.RemoteClusterRetentionLeaseHelper
 import org.opensearch.replication.util.stackTraceToString
 import org.opensearch.repositories.IndexId
 import org.opensearch.repositories.Repository
@@ -280,7 +281,8 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
                 snapshotShardId.id)
         restoreUUID = UUIDs.randomBase64UUID()
         val getStoreMetadataRequest = GetStoreMetadataRequest(restoreUUID, leaderShardNode, leaderShardId,
-                clusterService.state().metadata.clusterUUID() + ":" + clusterService.clusterName.value(), followerShardId)
+            RemoteClusterRetentionLeaseHelper.getFollowerClusterNameWithId(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID()),
+             followerShardId)
 
         // Gets the remote store metadata
         val metadataResponse = executeActionOnRemote(GetStoreMetadataAction.INSTANCE, getStoreMetadataRequest, followerIndexName)

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -281,7 +281,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
                 snapshotShardId.id)
         restoreUUID = UUIDs.randomBase64UUID()
         val getStoreMetadataRequest = GetStoreMetadataRequest(restoreUUID, leaderShardNode, leaderShardId,
-            RemoteClusterRetentionLeaseHelper.getFollowerClusterNameWithId(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID()),
+            RemoteClusterRetentionLeaseHelper.getFollowerClusterNameWithUUID(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID()),
              followerShardId)
 
         // Gets the remote store metadata

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -73,14 +73,14 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
             return true
         }
         catch (e: RetentionLeaseNotFoundException) {
-            return AddNewRetentionLeaseIfOldExists(leaderShardId, followerShardId, seqNo)
+            return addNewRetentionLeaseIfOldExists(leaderShardId, followerShardId, seqNo)
         }catch (e : Exception) {
             return false
         }
         return true
     }
 
-    private suspend fun AddNewRetentionLeaseIfOldExists(leaderShardId: ShardId, followerShardId: ShardId, seqNo: Long): Boolean {
+    private suspend fun addNewRetentionLeaseIfOldExists(leaderShardId: ShardId, followerShardId: ShardId, seqNo: Long): Boolean {
         //Check for old retention lease id
         val oldRetentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
         val requestForOldId = RetentionLeaseActions.RenewRequest(leaderShardId, oldRetentionLeaseId, seqNo, retentionLeaseSource)
@@ -122,7 +122,7 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
             //New retention lease not found, checking presense of old retention lease
             log.info("Retention lease with ID: ${retentionLeaseId} not found," +
                     " checking for old retention lease with ID: ${retentionLeaseIdForShard(followerClusterName, followerShardId)}")
-            if(!AddNewRetentionLeaseIfOldExists(leaderShardId, followerShardId, seqNo)){
+            if(!addNewRetentionLeaseIfOldExists(leaderShardId, followerShardId, seqNo)){
                 log.info("Both new $retentionLeaseId and old ${retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)} retention lease not found.")
                 throw e
             }

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -105,7 +105,7 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
         val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
         val request = RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
         try {
-            client.execute(RetentionLeaseActions.Add.INSTANCE, request).actionGet(timeout)
+            client.suspendExecute(RetentionLeaseActions.Add.INSTANCE, request)
             return true
         } catch (e: Exception) {
             log.info("Exception while adding new retention lease with i: $retentionLeaseId")

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -83,7 +83,7 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
     private suspend fun addNewRetentionLeaseIfOldExists(leaderShardId: ShardId, followerShardId: ShardId, seqNo: Long): Boolean {
         //Check for old retention lease id
         val oldRetentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
-        val requestForOldId = RetentionLeaseActions.RenewRequest(leaderShardId, oldRetentionLeaseId, seqNo, retentionLeaseSource)
+        val requestForOldId = RetentionLeaseActions.RenewRequest(leaderShardId, oldRetentionLeaseId, RetentionLeaseActions.RETAIN_ALL, retentionLeaseSource)
         try {
             client.suspendExecute(RetentionLeaseActions.Renew.INSTANCE, requestForOldId)
         } catch (ex: RetentionLeaseInvalidRetainingSeqNoException) {

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -123,7 +123,8 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
             log.info("Retention lease with ID: ${retentionLeaseId} not found," +
                     " checking for old retention lease with ID: ${retentionLeaseIdForShard(followerClusterName, followerShardId)}")
             if(!AddNewRetentionLeaseIfOldExists(leaderShardId, followerShardId, seqNo)){
-                throw RetentionLeaseNotFoundException("Retention lease not found 1 $retentionLeaseId")
+                log.info("Both new $retentionLeaseId and old ${retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)} retention lease not found.")
+                throw e
             }
         }
     }
@@ -178,7 +179,6 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
     /**
      * Remove these once the callers are moved to above APIs
      */
-    //Is
     public fun addRetentionLease(leaderShardId: ShardId, seqNo: Long,
                                  followerShardId: ShardId, timeout: Long) {
         val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -182,7 +182,6 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
     public fun addRetentionLease(leaderShardId: ShardId, seqNo: Long,
                                  followerShardId: ShardId, timeout: Long) {
         val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
-        log.info("bottle 1, adding retention lease id with id ${retentionLeaseId}")
         val request = RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
         try {
             client.execute(RetentionLeaseActions.Add.INSTANCE, request).actionGet(timeout)

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -132,7 +132,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     override val followerIndexName = params.followerIndexName
 
     override val log = Loggers.getLogger(javaClass, Index(params.followerIndexName, ClusterState.UNKNOWN_UUID))
-    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(), clusterService.clusterName.value(), remoteClient)
+    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
     private var shouldCallEvalMonitoring = true
     private var updateSettingsContinuousFailCount = 0
     private var updateAliasContinousFailCount = 0

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -132,7 +132,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     override val followerIndexName = params.followerIndexName
 
     override val log = Loggers.getLogger(javaClass, Index(params.followerIndexName, ClusterState.UNKNOWN_UUID))
-    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(), clusterService.clusterName.value(), remoteClient)
     private var shouldCallEvalMonitoring = true
     private var updateSettingsContinuousFailCount = 0
     private var updateAliasContinousFailCount = 0

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -69,7 +69,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
     private val leaderShardId = params.leaderShardId
     private val followerShardId = params.followerShardId
     private val remoteClient = client.getRemoteClusterClient(leaderAlias)
-    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(), clusterService.clusterName.value(), remoteClient)
+    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
     private var lastLeaseRenewalMillis = System.currentTimeMillis()
 
     //Start backOff for exceptions with a second

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -69,7 +69,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
     private val leaderShardId = params.leaderShardId
     private val followerShardId = params.followerShardId
     private val remoteClient = client.getRemoteClusterClient(leaderAlias)
-    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.state().metadata.clusterUUID(), clusterService.clusterName.value(), remoteClient)
     private var lastLeaseRenewalMillis = System.currentTimeMillis()
 
     //Start backOff for exceptions with a second

--- a/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
@@ -146,14 +146,13 @@ class BackwardsCompatibilityIT : MultiClusterRestTestCase() {
             }, 60, TimeUnit.SECONDS)
 
             assertBusy ({
-                assertBusy{
+
                     val followerClusterInfo : Map<String, Any>   = OpenSearchRestTestCase.entityAsMap(follower.lowLevelClient.performRequest(Request("GET", "/")))
                     val clusterUUID = (followerClusterInfo["cluster_uuid"] as String)
                     assert(clusterUUID.isNotEmpty())
                     val retentionLeaseinfo = leader.lowLevelClient.performRequest(Request("GET", "/$LEADER_INDEX/_stats/docs?level=shards"))
                     val retentionLeaseInfoString = EntityUtils.toString(retentionLeaseinfo.entity)
                     assertTrue(retentionLeaseInfoString.contains(clusterUUID))
-                }
             }, 60, TimeUnit.SECONDS)
 
         } catch (e: Exception) {

--- a/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
@@ -125,8 +125,6 @@ class BackwardsCompatibilityIT : MultiClusterRestTestCase() {
         val follower = getClientForCluster(followerName)
         val leader = getClientForCluster(leaderName)
 
-
-
         // Update the seed nodes.
         createConnectionBetweenClusters(followerName, leaderName, CONNECTION_NAME)
 

--- a/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
@@ -1,5 +1,6 @@
 package org.opensearch.replication.bwc;
 
+import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.assertj.core.api.Assertions
 import org.junit.Assert
 import org.junit.BeforeClass
@@ -8,6 +9,7 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
 import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.index.IndexRequest
+import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
 import org.opensearch.client.indices.CreateIndexRequest
 import org.opensearch.replication.MultiClusterAnnotations
@@ -15,6 +17,7 @@ import org.opensearch.replication.MultiClusterRestTestCase
 import org.opensearch.replication.StartReplicationRequest
 import org.opensearch.replication.startReplication
 import org.opensearch.test.OpenSearchTestCase.assertBusy
+import org.opensearch.test.rest.OpenSearchRestTestCase
 import java.util.Collections
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
@@ -122,6 +125,8 @@ class BackwardsCompatibilityIT : MultiClusterRestTestCase() {
         val follower = getClientForCluster(followerName)
         val leader = getClientForCluster(leaderName)
 
+
+
         // Update the seed nodes.
         createConnectionBetweenClusters(followerName, leaderName, CONNECTION_NAME)
 
@@ -139,6 +144,18 @@ class BackwardsCompatibilityIT : MultiClusterRestTestCase() {
                 Assertions.assertThat(getResponse.isExists).isTrue()
                 Assertions.assertThat(getResponse.sourceAsMap).isEqualTo(source)
             }, 60, TimeUnit.SECONDS)
+
+            assertBusy ({
+                assertBusy{
+                    val followerClusterInfo : Map<String, Any>   = OpenSearchRestTestCase.entityAsMap(follower.lowLevelClient.performRequest(Request("GET", "/")))
+                    val clusterUUID = (followerClusterInfo["cluster_uuid"] as String)
+                    assert(clusterUUID.isNotEmpty())
+                    val retentionLeaseinfo = leader.lowLevelClient.performRequest(Request("GET", "/$LEADER_INDEX/_stats/docs?level=shards"))
+                    val retentionLeaseInfoString = EntityUtils.toString(retentionLeaseinfo.entity)
+                    assertTrue(retentionLeaseInfoString.contains(clusterUUID))
+                }
+            }, 60, TimeUnit.SECONDS)
+
         } catch (e: Exception) {
             logger.info("Exception while verifying the replication ${e.printStackTrace()}")
             throw e

--- a/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
@@ -168,7 +168,7 @@ class BackwardsCompatibilityIT : MultiClusterRestTestCase() {
                 assert(clusterUUID.isNotEmpty())
                 assert(clusterName.isNotEmpty())
                 val expectedRetentionLeaseId =
-                    "replication" + ":" + clusterName + ":" + clusterUUID + ":[" + LEADER_INDEX + "][0]"
+                    "replication" + ":" + clusterName + ":" + clusterUUID + ":[" + LEADER_INDEX + "]"
 
                 val retentionLeaseinfo =
                     leader.lowLevelClient.performRequest(Request("GET", "/$LEADER_INDEX/_stats/docs?level=shards"))

--- a/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/bwc/BackwardsCompatibilityIT.kt
@@ -11,6 +11,7 @@ import org.opensearch.action.get.GetRequest
 import org.opensearch.action.index.IndexRequest
 import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
+import org.opensearch.client.RestHighLevelClient
 import org.opensearch.client.indices.CreateIndexRequest
 import org.opensearch.replication.MultiClusterAnnotations
 import org.opensearch.replication.MultiClusterRestTestCase
@@ -144,21 +145,36 @@ class BackwardsCompatibilityIT : MultiClusterRestTestCase() {
             }, 60, TimeUnit.SECONDS)
 
             //Check for latest retention lease when full cluster restart is done
-            if(ClusterStatus.from(System.getProperty("tests.bwcTask")) == ClusterStatus.FULL_CLUSTER_RESTART){
-                assertBusy ({
-                    val followerClusterInfo : Map<String, Any>   = OpenSearchRestTestCase.entityAsMap(follower.lowLevelClient.performRequest(Request("GET", "/")))
-                    val clusterUUID = (followerClusterInfo["cluster_uuid"] as String)
-                    assert(clusterUUID.isNotEmpty())
-                    val retentionLeaseinfo = leader.lowLevelClient.performRequest(Request("GET", "/$LEADER_INDEX/_stats/docs?level=shards"))
-                    val retentionLeaseInfoString = EntityUtils.toString(retentionLeaseinfo.entity)
-                    assertTrue(retentionLeaseInfoString.contains(clusterUUID))
-                }, 60, TimeUnit.SECONDS)
+            if (ClusterStatus.from(System.getProperty("tests.bwcTask")) == ClusterStatus.FULL_CLUSTER_RESTART || ClusterStatus.from(
+                    System.getProperty("tests.bwcTask")) == ClusterStatus.ROLLING_UPGRADED) {
+                validateNewRetentionLeaseId(follower, leader)
             }
 
         } catch (e: Exception) {
             logger.info("Exception while verifying the replication ${e.printStackTrace()}")
             throw e
         }
+    }
+
+    private fun validateNewRetentionLeaseId(
+        follower: RestHighLevelClient,
+        leader: RestHighLevelClient
+    ) {
+            assertBusy({
+                val followerClusterInfo: Map<String, Any> =
+                    OpenSearchRestTestCase.entityAsMap(follower.lowLevelClient.performRequest(Request("GET", "/")))
+                val clusterUUID = (followerClusterInfo["cluster_uuid"] as String)
+                val clusterName = (followerClusterInfo["cluster_name"] as String)
+                assert(clusterUUID.isNotEmpty())
+                assert(clusterName.isNotEmpty())
+                val expectedRetentionLeaseId =
+                    "replication" + ":" + clusterName + ":" + clusterUUID + ":[" + LEADER_INDEX + "][0]"
+
+                val retentionLeaseinfo =
+                    leader.lowLevelClient.performRequest(Request("GET", "/$LEADER_INDEX/_stats/docs?level=shards"))
+                val retentionLeaseInfoString = EntityUtils.toString(retentionLeaseinfo.entity)
+                assertTrue(retentionLeaseInfoString.contains(expectedRetentionLeaseId))
+            }, 60, TimeUnit.SECONDS)
     }
 
     // Verifies that replication plugin is installed on all the nodes og the cluster.


### PR DESCRIPTION
### Description
Currently, "{followerClusterName}:{followerShardId}" is used as retention lease identifier which results in overlapping usage when two followers are configured for same leader domain with same remote-alias.


The retention lease ID should also include follower cluster specific ID which would provide distinction between retention lease ID’s when 2 follower clusters are connected to a single leader cluster.

New retention lease will be of the format {followerClusterUUID}:{followerClusterName}:{followerShardId}

 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/554
 


Test for backward compatibility 
```
[2023-05-19T07:33:02,895][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:33:02,897][INFO ][o.o.o.i.ObservabilityMetricsIndex] [node-local] observability:Mapping Template ss4o_metric_template creation Acknowledged
[2023-05-19T07:33:02,929][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:33:02,933][INFO ][o.o.r.t.s.ShardReplicationExecutor] [node-local] starting persistent replication task: {"leader_alias":"leader-cluster","leader_shard":"[fruit-2][0]","leader_index_uuid":"i-XZbWzQTT2N98mTVwxSog","follower_shard":"[follower-2][0]","follower_index_uuid":"RB-QC0A1RqGcwfrxEkedAQ"}, org.opensearch.replication.task.shard.FollowingState@564728b8, 87, {"state":"STARTED"}
[2023-05-19T07:33:02,975][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:33:02,984][INFO ][o.o.r.s.RemoteClusterRetentionLeaseHelper] [node-local] Retention lease with ID: replication:local:gMWj938sRy-dzGJWbY-OHw:[follower-2][0] not found, checking for old retention lease with ID: replication:local:[follower-2][0]
[2023-05-19T07:33:02,987][INFO ][o.o.r.s.RemoteClusterRetentionLeaseHelper] [node-local] Old retention lease Id replication:local:[follower-2][0], adding new retention lease with ID:replication:local:gMWj938sRy-dzGJWbY-OHw:[follower-2][0]
[2023-05-19T07:34:00,977][INFO ][o.o.i.i.ManagedIndexCoordinator] [node-local] Performing move cluster state metadata.
[2023-05-19T07:34:00,978][INFO ][o.o.i.i.MetadataService  ] [node-local] ISM config index not exist, so we cancel the metadata migration job.
[2023-05-19T07:34:03,019][WARN ][o.o.r.t.s.ShardReplicationTask] [node-local] [follower-2][0] Encountered a failure while executing in org.opensearch.replication.action.changes.GetChangesRequest@60f94f90. Retrying in 10 seconds.
org.opensearch.OpenSearchTimeoutException: 1m
	at org.opensearch.replication.util.CoroutinesKt$waitForGlobalCheckpoint$2$listener$1.accept(Coroutines.kt:113) ~[?:?]
	at org.opensearch.index.shard.GlobalCheckpointListeners.lambda$notifyListener$3(GlobalCheckpointListeners.java:244) ~[opensearch-2.7.0.jar:2.7.0]
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95) ~[?:?]
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571) ~[?:?]
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750) ~[?:?]
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678) ~[?:?]
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665) ~[?:?]
[2023-05-19T07:34:17,623][INFO ][o.o.r.a.r.TransportResumeIndexReplicationAction] [node-local] Resuming index replication on index:follower-1
[2023-05-19T07:34:17,635][INFO ][o.o.r.s.RemoteClusterRetentionLeaseHelper] [node-local] Old retention lease Id replication:local:[follower-1][0], adding new retention lease with ID:replication:local:gMWj938sRy-dzGJWbY-OHw:[follower-1][0]
[2023-05-19T07:34:17,740][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:34:17,781][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:34:17,813][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:34:17,815][INFO ][o.o.r.t.i.IndexReplicationTask] [node-local] [follower-1] Starting shard tasks
[2023-05-19T07:34:17,815][INFO ][o.o.r.t.i.IndexReplicationTask] [node-local] [follower-1] Adding index block for replication
[2023-05-19T07:34:17,827][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:34:17,852][INFO ][o.o.a.u.d.DestinationMigrationCoordinator] [node-local] Detected cluster change event for destination migration
[2023-05-19T07:34:17,854][INFO ][o.o.r.t.s.ShardReplicationExecutor] [node-local] starting persistent replication task: {"leader_alias":"leader-cluster","leader_shard":"[fruit-1][0]","leader_index_uuid":"cLxqnAzFTyyPdmn4MHofig","follower_shard":"[follower-1][0]","follower_index_uuid":"yxVOAzTlQpKQYNFiCT3z9w"}, null, 89, {"state":"STARTED"}
```


```
[ec2-user@ip-172-31-87-165 ~]$ curl  "http://localhost:9200/_plugins/_replication/follower-1/_status?pretty"
curl  "http://localhost:9200/_plugins/_replication/follower-2/_status?pretty"
{
  "status" : "PAUSED",
  "reason" : "User initiated",
  "leader_alias" : "leader-cluster",
  "leader_index" : "fruit-1",
  "follower_index" : "follower-1"
}
{
  "status" : "SYNCING",
  "reason" : "User initiated",
  "leader_alias" : "leader-cluster",
  "leader_index" : "fruit-2",
  "follower_index" : "follower-2",
  "syncing_details" : {
    "leader_checkpoint" : 0,
    "follower_checkpoint" : 0,
    "seq_no" : 1
  }
}
[ec2-user@ip-172-31-87-165 ~]$ 
```
## Upgrade leader
```
[ec2-user@ip-172-31-87-165 ~]$ curl  "http://localhost:9200/_plugins/_replication/follower-1/_status?pretty"
curl  "http://localhost:9200/_plugins/_replication/follower-2/_status?pretty"
{
  "status" : "SYNCING",
  "reason" : "User initiated",
  "leader_alias" : "leader-cluster",
  "leader_index" : "fruit-1",
  "follower_index" : "follower-1",
  "syncing_details" : {
    "leader_checkpoint" : 1,
    "follower_checkpoint" : 0,
    "seq_no" : 1
  }
}
{
  "status" : "SYNCING",
  "reason" : "User initiated",
  "leader_alias" : "leader-cluster",
  "leader_index" : "fruit-2",
  "follower_index" : "follower-2",
  "syncing_details" : {
    "leader_checkpoint" : 1,
    "follower_checkpoint" : 1,
    "seq_no" : 2
  }
}
```
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
