### PR TITLE
Update to set remoteTranslogEnabled=false

### DIFF
--- a/src/test/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicyTests.kt
+++ b/src/test/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicyTests.kt
@@ -177,7 +177,8 @@ class ReplicationTranslogDeletionPolicyTests : OpenSearchTestCase() {
                 randomNonNegativeLong(),
                 TragicExceptionHolder(),
                 { },
-                BigArrays.NON_RECYCLING_INSTANCE
+                BigArrays.NON_RECYCLING_INSTANCE,
+                false
             )
             writer = Mockito.spy(writer)
             Mockito.doReturn(now - (numberOfReaders - gen + 1) * 1000).`when`(writer).lastModifiedTime


### PR DESCRIPTION
Upstream change:
https://github.com/opensearch-project/OpenSearch/commit/613f4aa046912b583925a9a03cb2294efd2a002c#diff-73db07f833f37213626303b1b984703bdf4cfb539529aa72e2ad8f55cea0a5e7R168
Above change started failing builds due to mandatory param `remoteTranslogEnabled`

### Description
set remoteTranslogEnabled=false
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
