### PR TITLE
Update UpdateIndexHandler.kt to use org.opensearch.core.common.Strings;

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt
@@ -17,7 +17,7 @@ import org.opensearch.replication.task.index.IndexReplicationExecutor.Companion.
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.client.Requests
 import org.opensearch.client.node.NodeClient
-import org.opensearch.common.Strings
+import org.opensearch.core.common.Strings
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestChannel


### PR DESCRIPTION
Update UpdateIndexHandler.kt to use org.opensearch.core.common.Strings;

### Description
Upstream change https://github.com/opensearch-project/OpenSearch/commit/1e08b5a075fa6018be6c0af959b2d638c2743d56

The change moved from 
import org.opensearch.common.Strings; to import org.opensearch.core.common.Strings;

This started breaking changes
```
> Task :clean
> Task :compileKotlin
e: /Users/runner/work/cross-cluster-replication/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt: (43, 77): Unresolved reference: splitStringByCommaToArray
```
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
