### PR TITLE
Modify autofollow retry scheduler logic to account for completed runs

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -45,6 +45,7 @@ import org.opensearch.tasks.TaskId
 import org.opensearch.threadpool.Scheduler
 import org.opensearch.threadpool.ThreadPool
 import java.util.concurrent.ConcurrentSkipListSet
+import java.util.concurrent.TimeUnit
 
 class AutoFollowTask(id: Long, type: String, action: String, description: String, parentTask: TaskId,
                      headers: Map<String, String>,
@@ -91,7 +92,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
 
     private fun addRetryScheduler() {
         log.debug("Adding retry scheduler")
-        if(retryScheduler != null && !retryScheduler!!.isCancelled) {
+        if(retryScheduler != null && retryScheduler!!.getDelay(TimeUnit.NANOSECONDS) > 0L) {
             return
         }
          try {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -23,6 +23,7 @@ import org.opensearch.replication.task.index.IndexReplicationExecutor
 import org.apache.hc.core5.http.HttpStatus
 import org.apache.hc.core5.http.ContentType
 import org.apache.hc.core5.http.io.entity.StringEntity
+import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
@@ -41,6 +42,7 @@ import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.metadata.MetadataCreateIndexService
 import org.opensearch.replication.AutoFollowStats
 import org.opensearch.replication.ReplicationPlugin
+import org.opensearch.replication.action.changes.TransportGetChangesAction
 import org.opensearch.replication.updateReplicationStartBlockSetting
 import org.opensearch.replication.updateAutofollowRetrySetting
 import org.opensearch.replication.updateAutoFollowConcurrentStartReplicationJobSetting
@@ -61,6 +63,10 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
     private val connectionAlias = "test_conn"
     private val longIndexPatternName = "index_".repeat(43)
     private val waitForShardTask = TimeValue.timeValueSeconds(10)
+
+    companion object {
+        private val log = LogManager.getLogger(UpdateAutoFollowPatternIT::class.java)
+    }
 
     fun `test auto follow pattern`() {
         val followerClient = getClientForCluster(FOLLOWER)
@@ -315,36 +321,43 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
     }
 
-    fun `test autofollow task with start replication block`() {
+    fun `test autofollow task with start replication block and retries`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
-        val leaderIndexName = createRandomIndex(leaderClient)
         try {
             //modify retry duration to account for autofollow trigger in next retry
             followerClient.updateAutofollowRetrySetting("1m")
-            // Add replication start block
-            followerClient.updateReplicationStartBlockSetting(true)
-            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
-            sleep(30000) // Default poll for auto follow in worst case
-            // verify both index replication tasks and autofollow tasks
-            // Replication shouldn't have been started - 0 tasks
-            // Autofollow task should still be up - 1 task
-            Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(0)
-            Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+            for (repeat in 1..2) {
+                log.info("Current Iteration $repeat")
+                // Add replication start block
+                followerClient.updateReplicationStartBlockSetting(true)
+                createRandomIndex(leaderClient)
+                followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
+                sleep(95000) // wait for auto follow trigger in the worst case
+                // verify both index replication tasks and autofollow tasks
+                // Replication shouldn't have been started - (repeat-1) tasks as for current loop index shouldn't be
+                // created yet.
+                // Autofollow task should still be up - 1 task
+                Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(repeat-1)
+                Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
 
-            var stats = followerClient.AutoFollowStats()
-            var failedIndices = stats["failed_indices"] as List<*>
-            assert(failedIndices.size == 1)
-            // Remove replication start block
-            followerClient.updateReplicationStartBlockSetting(false)
-            sleep(60000) // wait for auto follow trigger in the worst case
-            // Index should be replicated and autofollow task should be present
-            Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
-            Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
-            stats = followerClient.AutoFollowStats()
-            failedIndices = stats["failed_indices"] as List<*>
-            assert(failedIndices.isEmpty())
+                var stats = followerClient.AutoFollowStats()
+                var failedIndices = stats["failed_indices"] as List<*>
+                // Every time failed replication task will be 1 as
+                // there are already running jobs in the previous iteration
+                log.info("Current failed indices $failedIndices")
+                assert(failedIndices.size == 1)
+                // Remove replication start block
+                followerClient.updateReplicationStartBlockSetting(false)
+                sleep(95000) // wait for auto follow trigger in the worst case
+                // Index should be replicated and autofollow task should be present
+                Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(repeat)
+                Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+                stats = followerClient.AutoFollowStats()
+                failedIndices = stats["failed_indices"] as List<*>
+                assert(failedIndices.isEmpty())
+            }
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
         }


### PR DESCRIPTION
### Description
Modify autofollow retry scheduler logic to account for completed runs - 
- Currently, under the retry logic for failed indices under the autofollow, reference to scheduled retry object is kept around even after completion.
- This fix addresses this issue by seeing the overall delay to schedule the next retry (rather than just checking the reference).
 
### Issues Resolved
N/A

### Tests
Tests are successful on local
```
./gradlew integTest -Dtests.class=org.opensearch.replication.integ.rest.UpdateAutoFollowPatternIT -Dtests.method="test autofollow task with start replication block and retries"

> Task :integTest
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.BootstrapForTesting (file:/Users/karanas/.gradle/caches/modules-2/files-2.1/org.opensearch.test/framework/3.0.0-SNAPSHOT/8502a0524196af3d0212351cfea45fa220e4bdae/framework-3.0.0-SNAPSHOT.jar)
WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.BootstrapForTesting
WARNING: System::setSecurityManager will be removed in a future release
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.gradle.api.internal.tasks.testing.worker.TestWorker (file:/Users/karanas/.gradle/wrapper/dists/gradle-7.6.1-all/942lu1p9i6mhoyzmt401s4g74/gradle-7.6.1/lib/plugins/gradle-testing-base-7.6.1.jar)
WARNING: Please consider reporting this to the maintainers of org.gradle.api.internal.tasks.testing.worker.TestWorker
WARNING: System::setSecurityManager will be removed in a future release

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 11m 10s
12 actionable tasks: 5 executed, 7 up-to-date
```
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
