### PR TITLE
Bulk api 2.x

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -11,6 +11,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/CancelBulkReplicationTaskAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/CancelBulkReplicationTaskAction.kt
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk
+
+import org.opensearch.action.ActionType
+import org.opensearch.action.support.master.AcknowledgedResponse
+
+class CancelBulkReplicationTaskAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
+    companion object {
+        const val NAME = "indices:admin/plugins/replication/bulk/cancel"
+        val INSTANCE: CancelBulkReplicationTaskAction = CancelBulkReplicationTaskAction()
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/CancelBulkReplicationTaskRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/CancelBulkReplicationTaskRequest.kt
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk
+
+import org.opensearch.replication.metadata.store.KEY_SETTINGS
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.IndicesRequest
+import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.core.ParseField
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.settings.Settings
+import org.opensearch.core.xcontent.ObjectParser
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContent.Params
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
+import java.io.IOException
+import java.util.Collections
+import java.util.function.BiConsumer
+import kotlin.collections.HashMap
+
+class CancelBulkReplicationTaskRequest : AcknowledgedRequest<CancelBulkReplicationTaskRequest>, IndicesRequest.Replaceable, ToXContentObject {
+
+    lateinit var indexPattern: String
+
+    var useRoles: HashMap<String, String>? = null // roles to use - {leader_fgac_role: role1, follower_fgac_role: role2}
+    // Used for integ tests to wait until the restore from leader cluster completes
+    var waitForRestore: Boolean = false
+    // Triggered from autofollow to skip permissions check based on user as this is already validated
+    var isAutoFollowRequest: Boolean = false
+
+    var settings :Settings = Settings.EMPTY
+
+    private constructor() {
+    }
+
+    constructor(followerIndex: String, leaderAlias: String, leaderIndex: String, settings: Settings = Settings.EMPTY) : super() {
+        this.settings = settings
+    }
+
+    companion object {
+
+        val NAME: String? = "Monu"
+        private val BULK_PAUSE_PARSER = ObjectParser<CancelBulkReplicationTaskRequest, Void>("BulkPauseRequestParser") { CancelBulkReplicationTaskRequest() }
+
+        const val LEADER_CLUSTER_ROLE = "leader_cluster_role"
+        const val FOLLOWER_CLUSTER_ROLE = "follower_cluster_role"
+        val FGAC_ROLES_PARSER = ObjectParser<HashMap<String, String>, Void>("UseRolesParser") { HashMap() }
+        init {
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[LEADER_CLUSTER_ROLE] = role},
+                ParseField(LEADER_CLUSTER_ROLE))
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[FOLLOWER_CLUSTER_ROLE] = role},
+                ParseField(FOLLOWER_CLUSTER_ROLE))
+
+            BULK_PAUSE_PARSER.declareString(CancelBulkReplicationTaskRequest::indexPattern::set, ParseField("index_pattern"))
+//            BULK_STOP_PARSER.declareString(BulkStopReplicationRequest::leaderIndex::set, ParseField("leader_index"))
+            BULK_PAUSE_PARSER.declareObjectOrDefault(BiConsumer { reqParser: CancelBulkReplicationTaskRequest, roles: HashMap<String, String> -> reqParser.useRoles = roles},
+                FGAC_ROLES_PARSER, null, ParseField("use_roles"))
+            BULK_PAUSE_PARSER.declareObjectOrDefault(
+                { request: CancelBulkReplicationTaskRequest, settings: Settings -> request.settings = settings},
+                { p: XContentParser?, _: Void? -> Settings.fromXContent(p) },
+                null, ParseField(KEY_SETTINGS))
+        }
+
+        @Throws(IOException::class)
+        fun fromXContent(parser: XContentParser): CancelBulkReplicationTaskRequest {
+            val bulkPauseRequest = BULK_PAUSE_PARSER.parse(parser, null)
+            if(bulkPauseRequest.useRoles?.size == 0) {
+                bulkPauseRequest.useRoles = null
+            }
+            return bulkPauseRequest
+        }
+    }
+
+    override fun validate(): ActionRequestValidationException? {
+
+        var validationException = ActionRequestValidationException()
+        if (!this::indexPattern.isInitialized) {
+            validationException.addValidationError("Mandatory params are missing for the request")
+        }
+
+        if(useRoles != null && (useRoles!!.size < 2 || useRoles!![LEADER_CLUSTER_ROLE] == null ||
+                    useRoles!![FOLLOWER_CLUSTER_ROLE] == null)) {
+            validationException.addValidationError("Need roles for $LEADER_CLUSTER_ROLE and $FOLLOWER_CLUSTER_ROLE")
+        }
+        return if(validationException.validationErrors().isEmpty()) return null else validationException
+    }
+
+    override fun indices(vararg indices: String?): IndicesRequest {
+        return this
+    }
+
+    override fun indices(): Array<String> {
+        TODO("Not yet implemented")
+    }
+
+
+    fun indexPatern(): Array<String?> {
+        return arrayOf(indexPattern)
+    }
+
+
+    override fun indicesOptions(): IndicesOptions {
+        return IndicesOptions.strictSingleIndexNoExpandForbidClosed()
+    }
+
+    constructor(inp: StreamInput) : super(inp) {
+        indexPattern = inp.readString()
+
+
+        var leaderClusterRole = inp.readOptionalString()
+        var followerClusterRole = inp.readOptionalString()
+        useRoles = HashMap()
+        if(leaderClusterRole != null) useRoles!![LEADER_CLUSTER_ROLE] = leaderClusterRole
+        if(followerClusterRole != null) useRoles!![FOLLOWER_CLUSTER_ROLE] = followerClusterRole
+
+        waitForRestore = inp.readBoolean()
+        isAutoFollowRequest = inp.readBoolean()
+        settings = Settings.readSettingsFromStream(inp)
+
+    }
+
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeString(indexPattern)
+        out.writeOptionalString(useRoles?.get(LEADER_CLUSTER_ROLE))
+        out.writeOptionalString(useRoles?.get(FOLLOWER_CLUSTER_ROLE))
+        out.writeBoolean(waitForRestore)
+        out.writeBoolean(isAutoFollowRequest)
+
+        Settings.writeSettingsToStream(settings, out);
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: Params): XContentBuilder {
+        builder.startObject()
+        builder.field("index_pattern", indexPattern)
+        if(useRoles != null && useRoles!!.size == 2) {
+            builder.field("use_roles")
+            builder.startObject()
+            builder.field(LEADER_CLUSTER_ROLE, useRoles!![LEADER_CLUSTER_ROLE])
+            builder.field(FOLLOWER_CLUSTER_ROLE, useRoles!![FOLLOWER_CLUSTER_ROLE])
+            builder.endObject()
+        }
+        builder.field("wait_for_restore", waitForRestore)
+        builder.field("is_autofollow_request", isAutoFollowRequest)
+
+        builder.startObject(KEY_SETTINGS)
+        settings.toXContent(builder, ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
+        builder.endObject()
+
+        builder.endObject()
+
+        return builder
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/TransportCancelBulkReplicationTaskAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/TransportCancelBulkReplicationTaskAction.kt
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.ActionListener
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.master.TransportMasterNodeAction
+import org.opensearch.client.Client
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.block.ClusterBlockException
+import org.opensearch.cluster.block.ClusterBlockLevel
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.persistent.AllocatedPersistentTask
+import org.opensearch.persistent.PersistentTasksClusterService
+import org.opensearch.persistent.PersistentTasksCustomMetadata
+import org.opensearch.replication.metadata.ReplicationMetadataManager
+import org.opensearch.replication.task.bulk.BulkCrossClusterReplicationTask
+import org.opensearch.replication.task.bulk.BulkExecuter
+import org.opensearch.replication.task.bulk.BulkParams
+import org.opensearch.replication.util.*
+import org.opensearch.tasks.CancellableTask
+import org.opensearch.tasks.TaskManager
+import org.opensearch.tasks.TaskResourceTrackingService
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.Header
+import org.opensearch.transport.TransportService
+import java.io.IOException
+
+
+class TransportCancelBulkReplicationTaskAction @Inject constructor(transportService: TransportService,
+                                                          clusterService: ClusterService,
+                                                          threadPool: ThreadPool,
+                                                          actionFilters: ActionFilters,
+                                                          indexNameExpressionResolver:
+                                                          IndexNameExpressionResolver,
+                                                          val client: Client,
+                                                          val replicationMetadataManager: ReplicationMetadataManager) :
+    TransportMasterNodeAction<CancelBulkReplicationTaskRequest, AcknowledgedResponse> (
+        CancelBulkReplicationTaskAction.NAME,
+        transportService, clusterService, threadPool, actionFilters, ::CancelBulkReplicationTaskRequest,
+        indexNameExpressionResolver), CoroutineScope by GlobalScope {
+
+    companion object {
+        private val log = LogManager.getLogger(TransportCancelBulkReplicationTaskAction::class.java)
+    }
+
+    override fun checkBlock(request: CancelBulkReplicationTaskRequest, state: ClusterState): ClusterBlockException? {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
+    }
+
+    @Throws(Exception::class)
+    override fun masterOperation(request: CancelBulkReplicationTaskRequest, state: ClusterState,
+                                 listener: ActionListener<AcknowledgedResponse>) {
+        launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
+            try {
+                log.info("Cancelling task now")
+
+                listener.onResponse(AcknowledgedResponse(true))
+
+            } catch (e: Exception) {
+//                log.error("Stop replication failed for index[${request.indexName}] with error ${e.stackTraceToString()}")
+                listener.onFailure(e)
+            }
+        }
+    }
+
+    override fun executor(): String {
+        return ThreadPool.Names.SAME
+    }
+
+    @Throws(IOException::class)
+    override fun read(inp: StreamInput): AcknowledgedResponse {
+        return AcknowledgedResponse(inp)
+    }
+
+
+
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/pause/BulkPauseReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/pause/BulkPauseReplicationAction.kt
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk.pause
+
+import org.opensearch.action.ActionType
+import org.opensearch.action.support.master.AcknowledgedResponse
+
+class BulkPauseReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
+    companion object {
+        const val NAME = "indices:admin/plugins/replication/bulk/pause"
+        val INSTANCE: BulkPauseReplicationAction = BulkPauseReplicationAction()
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/pause/BulkPauseReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/pause/BulkPauseReplicationRequest.kt
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk.pause
+
+import org.opensearch.replication.metadata.store.KEY_SETTINGS
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.IndicesRequest
+import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.core.ParseField
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.settings.Settings
+import org.opensearch.core.xcontent.ObjectParser
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContent.Params
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
+import java.io.IOException
+import java.util.Collections
+import java.util.function.BiConsumer
+import kotlin.collections.HashMap
+
+class BulkPauseReplicationRequest : AcknowledgedRequest<BulkPauseReplicationRequest>, IndicesRequest.Replaceable, ToXContentObject {
+
+    lateinit var indexPattern: String
+
+    var useRoles: HashMap<String, String>? = null // roles to use - {leader_fgac_role: role1, follower_fgac_role: role2}
+    // Used for integ tests to wait until the restore from leader cluster completes
+    var waitForRestore: Boolean = false
+    // Triggered from autofollow to skip permissions check based on user as this is already validated
+    var isAutoFollowRequest: Boolean = false
+
+    var settings :Settings = Settings.EMPTY
+
+    private constructor() {
+    }
+
+    constructor(followerIndex: String, leaderAlias: String, leaderIndex: String, settings: Settings = Settings.EMPTY) : super() {
+        this.settings = settings
+    }
+
+    companion object {
+
+        val NAME: String? = "Monu"
+        private val BULK_PAUSE_PARSER = ObjectParser<BulkPauseReplicationRequest, Void>("BulkPauseRequestParser") { BulkPauseReplicationRequest() }
+
+        const val LEADER_CLUSTER_ROLE = "leader_cluster_role"
+        const val FOLLOWER_CLUSTER_ROLE = "follower_cluster_role"
+        val FGAC_ROLES_PARSER = ObjectParser<HashMap<String, String>, Void>("UseRolesParser") { HashMap() }
+        init {
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[LEADER_CLUSTER_ROLE] = role},
+                ParseField(LEADER_CLUSTER_ROLE))
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[FOLLOWER_CLUSTER_ROLE] = role},
+                ParseField(FOLLOWER_CLUSTER_ROLE))
+
+            BULK_PAUSE_PARSER.declareString(BulkPauseReplicationRequest::indexPattern::set, ParseField("index_pattern"))
+//            BULK_STOP_PARSER.declareString(BulkStopReplicationRequest::leaderIndex::set, ParseField("leader_index"))
+            BULK_PAUSE_PARSER.declareObjectOrDefault(BiConsumer { reqParser: BulkPauseReplicationRequest, roles: HashMap<String, String> -> reqParser.useRoles = roles},
+                FGAC_ROLES_PARSER, null, ParseField("use_roles"))
+            BULK_PAUSE_PARSER.declareObjectOrDefault(
+                { request: BulkPauseReplicationRequest, settings: Settings -> request.settings = settings},
+                { p: XContentParser?, _: Void? -> Settings.fromXContent(p) },
+                null, ParseField(KEY_SETTINGS))
+        }
+
+        @Throws(IOException::class)
+        fun fromXContent(parser: XContentParser): BulkPauseReplicationRequest {
+            val bulkPauseRequest = BULK_PAUSE_PARSER.parse(parser, null)
+            if(bulkPauseRequest.useRoles?.size == 0) {
+                bulkPauseRequest.useRoles = null
+            }
+            return bulkPauseRequest
+        }
+    }
+
+    override fun validate(): ActionRequestValidationException? {
+
+        var validationException = ActionRequestValidationException()
+        if (!this::indexPattern.isInitialized) {
+            validationException.addValidationError("Mandatory params are missing for the request")
+        }
+
+        if(useRoles != null && (useRoles!!.size < 2 || useRoles!![LEADER_CLUSTER_ROLE] == null ||
+                    useRoles!![FOLLOWER_CLUSTER_ROLE] == null)) {
+            validationException.addValidationError("Need roles for $LEADER_CLUSTER_ROLE and $FOLLOWER_CLUSTER_ROLE")
+        }
+        return if(validationException.validationErrors().isEmpty()) return null else validationException
+    }
+
+    override fun indices(vararg indices: String?): IndicesRequest {
+        return this
+    }
+
+    override fun indices(): Array<String> {
+        TODO("Not yet implemented")
+    }
+
+
+    fun indexPatern(): Array<String?> {
+        return arrayOf(indexPattern)
+    }
+
+
+    override fun indicesOptions(): IndicesOptions {
+        return IndicesOptions.strictSingleIndexNoExpandForbidClosed()
+    }
+
+    constructor(inp: StreamInput) : super(inp) {
+        indexPattern = inp.readString()
+
+
+        var leaderClusterRole = inp.readOptionalString()
+        var followerClusterRole = inp.readOptionalString()
+        useRoles = HashMap()
+        if(leaderClusterRole != null) useRoles!![LEADER_CLUSTER_ROLE] = leaderClusterRole
+        if(followerClusterRole != null) useRoles!![FOLLOWER_CLUSTER_ROLE] = followerClusterRole
+
+        waitForRestore = inp.readBoolean()
+        isAutoFollowRequest = inp.readBoolean()
+        settings = Settings.readSettingsFromStream(inp)
+
+    }
+
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeString(indexPattern)
+        out.writeOptionalString(useRoles?.get(LEADER_CLUSTER_ROLE))
+        out.writeOptionalString(useRoles?.get(FOLLOWER_CLUSTER_ROLE))
+        out.writeBoolean(waitForRestore)
+        out.writeBoolean(isAutoFollowRequest)
+
+        Settings.writeSettingsToStream(settings, out);
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: Params): XContentBuilder {
+        builder.startObject()
+        builder.field("index_pattern", indexPattern)
+        if(useRoles != null && useRoles!!.size == 2) {
+            builder.field("use_roles")
+            builder.startObject()
+            builder.field(LEADER_CLUSTER_ROLE, useRoles!![LEADER_CLUSTER_ROLE])
+            builder.field(FOLLOWER_CLUSTER_ROLE, useRoles!![FOLLOWER_CLUSTER_ROLE])
+            builder.endObject()
+        }
+        builder.field("wait_for_restore", waitForRestore)
+        builder.field("is_autofollow_request", isAutoFollowRequest)
+
+        builder.startObject(KEY_SETTINGS)
+        settings.toXContent(builder, ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
+        builder.endObject()
+
+        builder.endObject()
+
+        return builder
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/pause/TransportPauseReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/pause/TransportPauseReplicationAction.kt
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk.pause
+
+import org.opensearch.replication.metadata.ReplicationMetadataManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.ActionListener
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.master.TransportMasterNodeAction
+import org.opensearch.client.Client
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.block.ClusterBlockException
+import org.opensearch.cluster.block.ClusterBlockLevel
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.persistent.PersistentTasksCustomMetadata
+import org.opensearch.replication.task.bulk.BulkExecuter
+import org.opensearch.replication.task.bulk.BulkParams
+import org.opensearch.replication.util.*
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import java.io.IOException
+
+class TransportPauseReplicationAction @Inject constructor(transportService: TransportService,
+                                                              clusterService: ClusterService,
+                                                              threadPool: ThreadPool,
+                                                              actionFilters: ActionFilters,
+                                                              indexNameExpressionResolver:
+                                                              IndexNameExpressionResolver,
+                                                              val client: Client,
+                                                              val replicationMetadataManager: ReplicationMetadataManager) :
+    TransportMasterNodeAction<BulkPauseReplicationRequest, AcknowledgedResponse> (
+        BulkPauseReplicationAction.NAME,
+        transportService, clusterService, threadPool, actionFilters, ::BulkPauseReplicationRequest,
+        indexNameExpressionResolver), CoroutineScope by GlobalScope {
+
+    companion object {
+        private val log = LogManager.getLogger(TransportPauseReplicationAction::class.java)
+    }
+
+    override fun checkBlock(request: BulkPauseReplicationRequest, state: ClusterState): ClusterBlockException? {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
+    }
+
+    @Throws(Exception::class)
+    override fun masterOperation(request: BulkPauseReplicationRequest, state: ClusterState,
+                                 listener: ActionListener<AcknowledgedResponse>) {
+        launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
+            try {
+                log.info("Will work on ${request.indexPattern}")
+                var indicesList = clusterService.state().metadata().concreteAllIndices.asIterable()
+                indicesList = indicesList.toList()
+                log.info(indicesList)
+
+                log.info("Pattern is ${request.indexPattern}")
+                startBulkTaskPause(request.indexPattern, "test")
+
+                //TODO return taskid
+                listener.onResponse(AcknowledgedResponse(true, ))
+//
+//
+            } catch (e: Exception) {
+//                log.error("Stop replication failed for index[${request.indexName}] with error ${e.stackTraceToString()}")
+                listener.onFailure(e)
+            }
+        }
+    }
+
+
+    private suspend fun startBulkTaskPause(patternName: String, clusterName: String): PersistentTasksCustomMetadata.PersistentTask<BulkParams> {
+        val response = persistentTasksService.startTask("BulkkCrossClusterReplicationTask",
+            BulkExecuter.TASK_NAME,
+            BulkParams("PAUSE", patternName)
+        )
+        return response
+    }
+
+    override fun executor(): String {
+        return ThreadPool.Names.SAME
+    }
+
+    @Throws(IOException::class)
+    override fun read(inp: StreamInput): AcknowledgedResponse {
+        return AcknowledgedResponse(inp)
+    }
+
+
+
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/stop/BulkStopReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/stop/BulkStopReplicationAction.kt
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk.stop
+
+import org.opensearch.action.ActionType
+import org.opensearch.action.support.master.AcknowledgedResponse
+
+class BulkStopReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
+    companion object {
+        const val NAME = "indices:admin/plugins/replication/bulk/stop"
+        val INSTANCE: BulkStopReplicationAction = BulkStopReplicationAction()
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/stop/BulkStopReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/stop/BulkStopReplicationRequest.kt
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk.stop
+
+import org.opensearch.replication.metadata.store.KEY_SETTINGS
+import org.opensearch.replication.util.ValidationUtil.validateName
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.IndicesRequest
+import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.core.ParseField
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.settings.Settings
+import org.opensearch.core.xcontent.ObjectParser
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContent.Params
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
+import java.io.IOException
+import java.util.Collections
+import java.util.function.BiConsumer
+import kotlin.collections.HashMap
+
+class BulkStopReplicationRequest : AcknowledgedRequest<BulkStopReplicationRequest>, IndicesRequest.Replaceable, ToXContentObject {
+
+    lateinit var indexPattern: String
+
+    var useRoles: HashMap<String, String>? = null // roles to use - {leader_fgac_role: role1, follower_fgac_role: role2}
+    // Used for integ tests to wait until the restore from leader cluster completes
+    var waitForRestore: Boolean = false
+    // Triggered from autofollow to skip permissions check based on user as this is already validated
+    var isAutoFollowRequest: Boolean = false
+
+    var settings :Settings = Settings.EMPTY
+
+    private constructor() {
+    }
+
+    constructor(followerIndex: String, leaderAlias: String, leaderIndex: String, settings: Settings = Settings.EMPTY) : super() {
+        this.settings = settings
+    }
+
+    companion object {
+
+        val NAME: String? = "Monu"
+        private val BULK_STOP_PARSER = ObjectParser<BulkStopReplicationRequest, Void>("BulkStopRequestParser") { BulkStopReplicationRequest() }
+
+        const val LEADER_CLUSTER_ROLE = "leader_cluster_role"
+        const val FOLLOWER_CLUSTER_ROLE = "follower_cluster_role"
+        val FGAC_ROLES_PARSER = ObjectParser<HashMap<String, String>, Void>("UseRolesParser") { HashMap() }
+        init {
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[LEADER_CLUSTER_ROLE] = role},
+                ParseField(LEADER_CLUSTER_ROLE))
+            FGAC_ROLES_PARSER.declareStringOrNull({useRoles: HashMap<String, String>, role: String -> useRoles[FOLLOWER_CLUSTER_ROLE] = role},
+                ParseField(FOLLOWER_CLUSTER_ROLE))
+
+            BULK_STOP_PARSER.declareString(BulkStopReplicationRequest::indexPattern::set, ParseField("index_pattern"))
+//            BULK_STOP_PARSER.declareString(BulkStopReplicationRequest::leaderIndex::set, ParseField("leader_index"))
+            BULK_STOP_PARSER.declareObjectOrDefault(BiConsumer {reqParser: BulkStopReplicationRequest, roles: HashMap<String, String> -> reqParser.useRoles = roles},
+                FGAC_ROLES_PARSER, null, ParseField("use_roles"))
+            BULK_STOP_PARSER.declareObjectOrDefault(
+                { request: BulkStopReplicationRequest, settings: Settings -> request.settings = settings},
+                { p: XContentParser?, _: Void? -> Settings.fromXContent(p) },
+                null, ParseField(KEY_SETTINGS))
+        }
+
+        @Throws(IOException::class)
+        fun fromXContent(parser: XContentParser): BulkStopReplicationRequest {
+            val bulkStopReqeust = BULK_STOP_PARSER.parse(parser, null)
+            if(bulkStopReqeust.useRoles?.size == 0) {
+                bulkStopReqeust.useRoles = null
+            }
+            return bulkStopReqeust
+        }
+    }
+
+    override fun validate(): ActionRequestValidationException? {
+
+        var validationException = ActionRequestValidationException()
+        if (!this::indexPattern.isInitialized) {
+            validationException.addValidationError("Mandatory params are missing for the request")
+        }
+
+        if(useRoles != null && (useRoles!!.size < 2 || useRoles!![LEADER_CLUSTER_ROLE] == null ||
+                    useRoles!![FOLLOWER_CLUSTER_ROLE] == null)) {
+            validationException.addValidationError("Need roles for $LEADER_CLUSTER_ROLE and $FOLLOWER_CLUSTER_ROLE")
+        }
+        return if(validationException.validationErrors().isEmpty()) return null else validationException
+    }
+
+    override fun indices(vararg indices: String?): IndicesRequest {
+        return this
+    }
+
+    override fun indices(): Array<String> {
+        TODO("Not yet implemented")
+    }
+
+
+    fun indexPatern(): Array<String?> {
+        return arrayOf(indexPattern)
+    }
+
+
+    override fun indicesOptions(): IndicesOptions {
+        return IndicesOptions.strictSingleIndexNoExpandForbidClosed()
+    }
+
+    constructor(inp: StreamInput) : super(inp) {
+        indexPattern = inp.readString()
+
+
+        var leaderClusterRole = inp.readOptionalString()
+        var followerClusterRole = inp.readOptionalString()
+        useRoles = HashMap()
+        if(leaderClusterRole != null) useRoles!![LEADER_CLUSTER_ROLE] = leaderClusterRole
+        if(followerClusterRole != null) useRoles!![FOLLOWER_CLUSTER_ROLE] = followerClusterRole
+
+        waitForRestore = inp.readBoolean()
+        isAutoFollowRequest = inp.readBoolean()
+        settings = Settings.readSettingsFromStream(inp)
+
+    }
+
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeString(indexPattern)
+        out.writeOptionalString(useRoles?.get(LEADER_CLUSTER_ROLE))
+        out.writeOptionalString(useRoles?.get(FOLLOWER_CLUSTER_ROLE))
+        out.writeBoolean(waitForRestore)
+        out.writeBoolean(isAutoFollowRequest)
+
+        Settings.writeSettingsToStream(settings, out);
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: Params): XContentBuilder {
+        builder.startObject()
+        builder.field("index_pattern", indexPattern)
+        if(useRoles != null && useRoles!!.size == 2) {
+            builder.field("use_roles")
+            builder.startObject()
+            builder.field(LEADER_CLUSTER_ROLE, useRoles!![LEADER_CLUSTER_ROLE])
+            builder.field(FOLLOWER_CLUSTER_ROLE, useRoles!![FOLLOWER_CLUSTER_ROLE])
+            builder.endObject()
+        }
+        builder.field("wait_for_restore", waitForRestore)
+        builder.field("is_autofollow_request", isAutoFollowRequest)
+
+        builder.startObject(KEY_SETTINGS)
+        settings.toXContent(builder, ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
+        builder.endObject()
+
+        builder.endObject()
+
+        return builder
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/stop/TransportBulkStopReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/stop/TransportBulkStopReplicationAction.kt
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.bulk.stop
+
+import org.opensearch.replication.metadata.ReplicationMetadataManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.ActionListener
+import org.opensearch.action.support.ActionFilters
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.master.TransportMasterNodeAction
+import org.opensearch.client.Client
+import org.opensearch.cluster.AckedClusterStateUpdateTask
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.block.ClusterBlockException
+import org.opensearch.cluster.block.ClusterBlockLevel
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.inject.Inject
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.persistent.AllocatedPersistentTask
+import org.opensearch.persistent.PersistentTasksCustomMetadata
+import org.opensearch.replication.task.bulk.BulkExecuter
+import org.opensearch.replication.task.bulk.BulkParams
+import org.opensearch.replication.util.*
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.TransportService
+import java.io.IOException
+
+class TransportBulkStopReplicationAction @Inject constructor(transportService: TransportService,
+                                                              clusterService: ClusterService,
+                                                              threadPool: ThreadPool,
+                                                              actionFilters: ActionFilters,
+                                                              indexNameExpressionResolver:
+                                                              IndexNameExpressionResolver,
+                                                              val client: Client,
+                                                              val replicationMetadataManager: ReplicationMetadataManager) :
+    TransportMasterNodeAction<BulkStopReplicationRequest, AcknowledgedResponse> (
+        BulkStopReplicationAction.NAME,
+        transportService, clusterService, threadPool, actionFilters, ::BulkStopReplicationRequest,
+        indexNameExpressionResolver), CoroutineScope by GlobalScope {
+
+    companion object {
+        private val log = LogManager.getLogger(TransportBulkStopReplicationAction::class.java)
+    }
+
+    override fun checkBlock(request: BulkStopReplicationRequest, state: ClusterState): ClusterBlockException? {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
+    }
+
+    @Throws(Exception::class)
+    override fun masterOperation(request: BulkStopReplicationRequest, state: ClusterState,
+                                 listener: ActionListener<AcknowledgedResponse>) {
+        launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
+            try {
+//                log.info("Stopping index replication on index:" + request.indexName)
+                log.info("Will work on ${request.indexPattern}")
+                var indicesList = clusterService.state().metadata().concreteAllIndices.asIterable()
+                indicesList = indicesList.toList()
+                log.info(indicesList)
+                 startBulkTask(request.indexPattern, "test")
+
+                listener.onResponse(AcknowledgedResponse(true, ))
+
+            } catch (e: Exception) {
+//                log.error("Stop replication failed for index[${request.indexName}] with error ${e.stackTraceToString()}")
+                listener.onFailure(e)
+            }
+        }
+    }
+
+
+    private suspend fun startBulkTask(patternName: String, clusterName: String): PersistentTasksCustomMetadata.PersistentTask<BulkParams> {
+
+        val response = persistentTasksService.startTask("BulkkCrossClusterReplicationTask",
+            BulkExecuter.TASK_NAME,
+            BulkParams( "STOP", patternName)
+        )
+
+        return response
+    }
+
+    override fun executor(): String {
+        return ThreadPool.Names.SAME
+    }
+
+    @Throws(IOException::class)
+    override fun read(inp: StreamInput): AcknowledgedResponse {
+        return AcknowledgedResponse(inp)
+    }
+
+    class StopReplicationTask(val request: BulkStopReplicationRequest, listener: ActionListener<AcknowledgedResponse>) :
+        AckedClusterStateUpdateTask<AcknowledgedResponse>(request, listener) {
+
+        override fun execute(currentState: ClusterState): ClusterState {
+            val newState = ClusterState.builder(currentState)
+
+            return newState.build()
+        }
+
+        override fun newResponse(acknowledged: Boolean) = AcknowledgedResponse(acknowledged)
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationRequest.kt
@@ -43,6 +43,12 @@ class PauseIndexReplicationRequest : AcknowledgedRequest<PauseIndexReplicationRe
         reason = inp.readString()
     }
 
+    constructor(index: String): super() {
+        indexName = index
+
+    }
+
+
     companion object {
         private val PARSER = ObjectParser<PauseIndexReplicationRequest, Void>("PauseReplicationRequestParser") {
             PauseIndexReplicationRequest()

--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -140,6 +140,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
             } catch (e: Exception) {
                 log.error("Stop replication failed for index[${request.indexName}] with error ${e.stackTraceToString()}")
                 listener.onFailure(e)
+
             }
         }
     }

--- a/src/main/kotlin/org/opensearch/replication/rest/bulk/BulkPauseIndexReplicationHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/bulk/BulkPauseIndexReplicationHandler.kt
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.rest.bulk
+
+import org.opensearch.replication.action.stop.StopIndexReplicationAction
+import org.opensearch.client.node.NodeClient
+import org.opensearch.replication.action.bulk.pause.BulkPauseReplicationAction
+import org.opensearch.replication.action.bulk.pause.BulkPauseReplicationRequest
+import org.opensearch.replication.action.bulk.stop.BulkStopReplicationAction
+import org.opensearch.replication.action.bulk.stop.BulkStopReplicationRequest
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.action.RestToXContentListener
+import java.io.IOException
+
+class BulkPauseIndexReplicationHandler : BaseRestHandler() {
+
+    override fun routes(): List<RestHandler.Route> {
+        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_plugins/_replication/_bulk_pause"))
+    }
+
+    override fun getName(): String {
+        return "plugins_index_bulk_pause_replicate_action"
+    }
+
+    @Throws(IOException::class)
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        request.contentOrSourceParamParser().use { parser ->
+
+            val bulkPauseReplicationRequest = BulkPauseReplicationRequest.fromXContent(parser)
+            return RestChannelConsumer { channel: RestChannel? ->
+                client.admin().cluster()
+                    .execute(BulkPauseReplicationAction.INSTANCE, bulkPauseReplicationRequest, RestToXContentListener(channel))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/rest/bulk/BulkStopIndexReplicationHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/bulk/BulkStopIndexReplicationHandler.kt
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.rest.bulk
+
+import org.opensearch.client.node.NodeClient
+import org.opensearch.replication.action.bulk.stop.BulkStopReplicationAction
+import org.opensearch.replication.action.bulk.stop.BulkStopReplicationRequest
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.action.RestToXContentListener
+import java.io.IOException
+
+class BulkStopReplicationHandler : BaseRestHandler() {
+
+    override fun routes(): List<RestHandler.Route> {
+        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_plugins/_replication/_bulk_stop"))
+    }
+
+    override fun getName(): String {
+        return "plugins_index_bulk_stop_replicate_action"
+    }
+
+    @Throws(IOException::class)
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        request.contentOrSourceParamParser().use { parser ->
+
+            val bulkStopReplicationRequest = BulkStopReplicationRequest.fromXContent(parser)
+            return RestChannelConsumer { channel: RestChannel? ->
+                client.admin().cluster()
+                    .execute(BulkStopReplicationAction.INSTANCE, bulkStopReplicationRequest, RestToXContentListener(channel))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/rest/bulk/CancelBulkReplicationTaskHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/bulk/CancelBulkReplicationTaskHandler.kt
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.rest.bulk
+
+import org.opensearch.client.node.NodeClient
+import org.opensearch.replication.action.bulk.CancelBulkReplicationTaskAction
+import org.opensearch.replication.action.bulk.CancelBulkReplicationTaskRequest
+import org.opensearch.replication.action.bulk.stop.BulkStopReplicationAction
+import org.opensearch.replication.action.bulk.stop.BulkStopReplicationRequest
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestHandler
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.action.RestToXContentListener
+import java.io.IOException
+
+class CancelBulkReplicationTaskHandler : BaseRestHandler() {
+
+    override fun routes(): List<RestHandler.Route> {
+        return listOf(RestHandler.Route(RestRequest.Method.POST, "/_plugins/_replication/_bulk_cancel"))
+    }
+
+    override fun getName(): String {
+        return "plugins_index_bulk_cancel_replication_task"
+    }
+
+    @Throws(IOException::class)
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        request.contentOrSourceParamParser().use { parser ->
+
+            val cancelBulkReplicationTaskRequest = CancelBulkReplicationTaskRequest.fromXContent(parser)
+            return RestChannelConsumer { channel: RestChannel? ->
+                client.admin().cluster()
+                    .execute(CancelBulkReplicationTaskAction.INSTANCE, cancelBulkReplicationTaskRequest, RestToXContentListener(channel))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/task/bulk/BulkCrossClusterReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/bulk/BulkCrossClusterReplicationTask.kt
@@ -1,0 +1,102 @@
+package org.opensearch.replication.task.bulk
+
+import kotlinx.coroutines.*
+import org.opensearch.action.ActionFuture
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.persistent.AllocatedPersistentTask
+import org.opensearch.persistent.PersistentTaskState
+import org.opensearch.persistent.PersistentTasksService
+import org.opensearch.replication.action.pause.PauseIndexReplicationAction
+import org.opensearch.replication.action.pause.PauseIndexReplicationRequest
+import org.opensearch.replication.action.resume.ResumeIndexReplicationAction
+import org.opensearch.replication.action.resume.ResumeIndexReplicationRequest
+import org.opensearch.replication.action.stop.StopIndexReplicationAction
+import org.opensearch.replication.action.stop.StopIndexReplicationRequest
+import org.opensearch.replication.task.index.IndexReplicationExecutor.Companion.log
+import org.opensearch.replication.util.coroutineContext
+import org.opensearch.tasks.TaskId
+import org.opensearch.tasks.TaskManager
+import org.opensearch.threadpool.ThreadPool
+
+
+class BulkCrossClusterReplicationTask(
+    id: Long, type: String?, action: String?, description: String?, parentTask: TaskId?,
+    headers: Map<String, String>,
+    threadPool: ThreadPool,
+    protected val executor: String,
+    protected val clusterService: ClusterService,
+    protected val client: Client,
+    val params: BulkParams
+) :
+    AllocatedPersistentTask(id, type, action, description, parentTask, headers) {
+
+    private val overallTaskScope = CoroutineScope(threadPool.coroutineContext(executor))
+    @Volatile private lateinit var taskManager: TaskManager
+    fun init(persistentTasksService: PersistentTasksService, taskManager: TaskManager,
+                      persistentTaskId: String, allocationId: Long, indexPattern: String) {
+        super.init(persistentTasksService, taskManager, persistentTaskId, allocationId)
+        this.taskManager = taskManager
+
+    }
+
+    fun run(initialState: PersistentTaskState? = null) {
+        overallTaskScope.launch {
+
+            log.info("Starting bulk cross cluster replication task")
+            log.info("Pattern2 is ${params.patternName}")
+//            log.info(getAllEligibleIndices(indexPattern).toList())
+
+            val current_time = System.currentTimeMillis()
+            val failures = mutableListOf<String>()
+            val myList = getAllEligibleIndices(params.patternName)
+            if (myList != null){
+                myList.forEach{
+                    val stopReplicationRequest =
+                    try {
+                        val response = BulkActionRequest(it)
+                        log.info(response.actionGet())
+
+                    }catch (e: Exception){
+                        log.info("inside exception")
+                        log.info("message ${e.message}")
+                        e.message?.let { it1 -> failures.add(it1) }
+
+                    } finally {
+
+                        log.info("Finally block")
+                        log.info("Parent task Id is ${taskManager.tasks}")
+                    }
+
+                }
+            }
+            markAsCompleted()
+            log.info("************************")
+            log.info(System.currentTimeMillis() - current_time)
+        }
+    }
+
+    private fun BulkActionRequest(it: String): ActionFuture<AcknowledgedResponse>{
+        return if (params.actionType == "STOP"){
+            client.admin().cluster().execute(StopIndexReplicationAction.INSTANCE, StopIndexReplicationRequest(it))
+        } else if (params.actionType == "PAUSE"){
+            client.admin().cluster().execute(PauseIndexReplicationAction.INSTANCE, PauseIndexReplicationRequest(it))
+        }else {
+            client.admin().cluster().execute(ResumeIndexReplicationAction.INSTANCE, ResumeIndexReplicationRequest(it))
+        }
+    }
+
+
+
+    private fun getAllEligibleIndices(indexPattern: String): Iterable<String> {
+        //TODO remove system indices
+        var currentIndices = clusterService.state().metadata().concreteAllIndices.asIterable().toList()
+        currentIndices = currentIndices.filter { indexPattern.replace("*", ".*").toRegex().matches(it) }
+        return currentIndices
+    }
+
+
+
+
+}

--- a/src/main/kotlin/org/opensearch/replication/task/bulk/BulkExecuter.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/bulk/BulkExecuter.kt
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.task.bulk
+
+import org.opensearch.replication.ReplicationSettings
+import org.opensearch.replication.metadata.ReplicationMetadataManager
+import org.opensearch.client.Client
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.persistent.AllocatedPersistentTask
+import org.opensearch.persistent.PersistentTaskState
+import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask
+import org.opensearch.persistent.PersistentTasksExecutor
+import org.opensearch.replication.util.persistentTasksService
+import org.opensearch.replication.util.removeTask
+import org.opensearch.tasks.TaskId
+import org.opensearch.threadpool.ThreadPool
+
+class BulkExecuter(executor: String, private val clusterService: ClusterService,
+                   private val threadPool: ThreadPool, private val client: Client,
+                   private val replicationMetadataManager: ReplicationMetadataManager,
+                   private val replicationSettings: ReplicationSettings,
+                    private  val indexPattern: String) :
+    PersistentTasksExecutor<BulkParams>(TASK_NAME, executor) {
+
+    companion object {
+        const val TASK_NAME = "cluster:admin/plugins/replication/autofollow"
+    }
+
+    override fun nodeOperation(task: AllocatedPersistentTask, params: BulkParams, state: PersistentTaskState?) {
+        if (task is BulkCrossClusterReplicationTask) {
+            task.run()
+        } else {
+            task.markAsFailed(IllegalArgumentException("unknown task type : ${task::class.java}"))
+        }
+    }
+
+    override fun createTask(id: Long, type: String, action: String, parentTaskId: TaskId,
+                            taskInProgress: PersistentTask<BulkParams>,
+                            headers: Map<String, String>): AllocatedPersistentTask {
+
+       val myBulkCrossClusterReplicationTask = BulkCrossClusterReplicationTask(id, type, action, getDescription(taskInProgress),
+       parentTaskId, headers, threadPool, executor, clusterService, client,taskInProgress.params!! )
+        return myBulkCrossClusterReplicationTask
+    }
+
+    suspend fun cancelMyTask(){
+        persistentTasksService.removeTask("test")
+    }
+
+    override fun getDescription(taskInProgress: PersistentTask<BulkParams>): String {
+        return "replication auto follow task for leader cluster:  with pattern " +
+                "${taskInProgress.params?.patternName}"
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/task/bulk/BulkParams.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/bulk/BulkParams.kt
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.task.bulk
+
+import org.opensearch.Version
+import org.opensearch.core.ParseField
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.core.xcontent.ObjectParser
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.persistent.PersistentTaskParams
+import java.io.IOException
+
+class BulkParams : PersistentTaskParams {
+
+    lateinit var actionType: String
+    lateinit var patternName: String
+
+    companion object {
+        const val NAME = BulkExecuter.TASK_NAME
+
+        private val PARSER = ObjectParser<BulkParams, Void>(NAME, true) { BulkParams() }
+        init {
+            PARSER.declareString(BulkParams::actionType::set, ParseField("action_type"))
+            PARSER.declareString(BulkParams::patternName::set, ParseField("pattern_name"))
+
+        }
+
+        @Throws(IOException::class)
+        fun fromXContent(parser: XContentParser): BulkParams {
+            return PARSER.parse(parser, null)
+        }
+    }
+
+    private constructor() {
+    }
+
+    constructor(actionType: String, patternName: String, ) {
+        this.actionType = actionType
+        this.patternName = patternName
+
+    }
+
+    constructor(inp: StreamInput) : this(inp.readString(), inp.readString())
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(actionType)
+        out.writeString(patternName)
+
+    }
+
+    override fun getWriteableName() = NAME
+
+    override fun getMinimalSupportedVersion() = Version.CURRENT
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return builder.startObject()
+            .field("action_type", actionType)
+            .field("pattern_name", patternName)
+            .endObject()
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -92,7 +92,6 @@ import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask
 import org.opensearch.persistent.PersistentTasksNodeService
 import org.opensearch.persistent.PersistentTasksService
 import org.opensearch.replication.ReplicationException
-import org.opensearch.replication.MappingNotAvailableException
 import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
 import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.TaskId
@@ -104,8 +103,6 @@ import java.util.stream.Collectors
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
-import kotlin.streams.toList
-import org.opensearch.cluster.DiffableUtils
 
 open class IndexReplicationTask(id: Long, type: String, action: String, description: String,
                            parentTask: TaskId,

--- a/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
@@ -33,6 +33,7 @@ import org.opensearch.index.shard.IndexShard
 import org.opensearch.persistent.PersistentTaskParams
 import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask
 import org.opensearch.persistent.PersistentTasksService
+import org.opensearch.replication.task.autofollow.AutoFollowParams
 import org.opensearch.threadpool.ThreadPool
 import java.util.concurrent.TimeoutException
 import kotlin.coroutines.*


### PR DESCRIPTION
### Description
To allow users to control replication on multiple indices without having to list down every index, we will allow users to select indices based on wildcard patterns, this will allow users to quickly stop/pause/resume replication for multiple indices. This method will also allow users to use * as pattern to select all indices.

 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/812
https://github.com/opensearch-project/cross-cluster-replication/issues/765
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
