### PR TITLE
[backport 2.5]Add retention lease with followerClusterUUID (#833)

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -115,7 +115,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                 try {
                     val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(request.indexName)
                     val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
-                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+                    val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
                     retentionLeaseHelper.attemptRemoveRetentionLease(clusterService, replMetadata, request.indexName)
                 } catch(e: Exception) {
                     log.error("Failed to remove retention lease from the leader cluster", e)

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -57,6 +57,7 @@ import org.opensearch.index.store.Store
 import org.opensearch.indices.recovery.RecoverySettings
 import org.opensearch.indices.recovery.RecoveryState
 import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
+import org.opensearch.replication.seqno.RemoteClusterRetentionLeaseHelper
 import org.opensearch.replication.util.stackTraceToString
 import org.opensearch.repositories.IndexId
 import org.opensearch.repositories.Repository
@@ -285,7 +286,8 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
                 snapshotShardId.id)
         restoreUUID = UUIDs.randomBase64UUID()
         val getStoreMetadataRequest = GetStoreMetadataRequest(restoreUUID, leaderShardNode, leaderShardId,
-                clusterService.clusterName.value(), followerShardId)
+            RemoteClusterRetentionLeaseHelper.getFollowerClusterNameWithUUID(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID()),
+             followerShardId)
 
         // Gets the remote store metadata
         val metadataResponse = executeActionOnRemote(GetStoreMetadataAction.INSTANCE, getStoreMetadataRequest, followerIndexName)

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -23,29 +23,42 @@ import org.opensearch.index.seqno.RetentionLeaseAlreadyExistsException
 import org.opensearch.index.seqno.RetentionLeaseInvalidRetainingSeqNoException
 import org.opensearch.index.seqno.RetentionLeaseNotFoundException
 import org.opensearch.index.shard.ShardId
-import org.opensearch.replication.action.stop.TransportStopIndexReplicationAction
 import org.opensearch.replication.metadata.store.ReplicationMetadata
+import org.opensearch.replication.repository.RemoteClusterRepository
 import org.opensearch.replication.task.index.IndexReplicationParams
 import org.opensearch.replication.util.stackTraceToString
 import org.opensearch.replication.util.suspending
 
-class RemoteClusterRetentionLeaseHelper constructor(val followerClusterName: String, val client: Client) {
+class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithUUID: String, val client: Client) {
 
-    private val retentionLeaseSource = retentionLeaseSource(followerClusterName)
+    private val retentionLeaseSource = retentionLeaseSource(followerClusterNameWithUUID)
+    private var followerClusterUUID : String = ""
+    private var followerClusterName : String = ""
+
+    constructor(followerClusterName: String, followerClusterUUID: String, client: Client) :this(followerClusterName, client){
+        this.followerClusterUUID = followerClusterUUID
+        this.followerClusterName = followerClusterName
+        this.followerClusterNameWithUUID = getFollowerClusterNameWithUUID(followerClusterName, followerClusterUUID)
+    }
 
     companion object {
         private val log = LogManager.getLogger(RemoteClusterRetentionLeaseHelper::class.java)
         const val RETENTION_LEASE_PREFIX = "replication:"
-        fun retentionLeaseSource(followerClusterName: String): String = "${RETENTION_LEASE_PREFIX}${followerClusterName}"
+        fun retentionLeaseSource(followerClusterName: String): String
+        = "${RETENTION_LEASE_PREFIX}${followerClusterName}"
 
         fun retentionLeaseIdForShard(followerClusterName: String, followerShardId: ShardId): String {
             val retentionLeaseSource = retentionLeaseSource(followerClusterName)
             return "$retentionLeaseSource:${followerShardId}"
         }
+
+        fun getFollowerClusterNameWithUUID(followerClusterName: String, followerClusterUUID: String): String{
+            return "$followerClusterName:$followerClusterUUID"
+        }
     }
 
-    public suspend fun verifyRetentionLeaseExist(leaderShardId: ShardId, followerShardId: ShardId): Boolean  {
-        val retentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
+    public suspend fun verifyRetentionLeaseExist(leaderShardId: ShardId, followerShardId: ShardId, seqNo: Long): Boolean  {
+        val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
         // Currently there is no API to describe/list the retention leases .
         // So we are verifying the existence of lease by trying to renew a lease by same name .
         // If retention lease doesn't exist, this will throw an RetentionLeaseNotFoundException exception
@@ -60,15 +73,60 @@ class RemoteClusterRetentionLeaseHelper constructor(val followerClusterName: Str
             return true
         }
         catch (e: RetentionLeaseNotFoundException) {
+            return addNewRetentionLeaseIfOldExists(leaderShardId, followerShardId, seqNo)
+        }catch (e : Exception) {
             return false
         }
         return true
     }
 
+    private suspend fun addNewRetentionLeaseIfOldExists(leaderShardId: ShardId, followerShardId: ShardId, seqNo: Long): Boolean {
+        //Check for old retention lease id
+        val oldRetentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
+        val requestForOldId = RetentionLeaseActions.RenewRequest(leaderShardId, oldRetentionLeaseId, RetentionLeaseActions.RETAIN_ALL, retentionLeaseSource)
+        try {
+            client.suspendExecute(RetentionLeaseActions.Renew.INSTANCE, requestForOldId)
+        } catch (ex: RetentionLeaseInvalidRetainingSeqNoException) {
+            //old retention lease id present, will add new retention lease
+            log.info("Old retention lease Id ${oldRetentionLeaseId} present with invalid seq number, adding new retention lease with ID:" +
+                    "${retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)} ")
+            return addNewRetentionLease(leaderShardId, seqNo, followerShardId, RemoteClusterRepository.REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC )
+        }catch (ex: Exception){
+            log.info("Encountered Exception while checking for old retention lease: ${ex.stackTraceToString()}")
+            return false
+        }
+        log.info("Old retention lease Id ${oldRetentionLeaseId}, adding new retention lease with ID:" +
+                "${retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)} ")
+        return  addNewRetentionLease(leaderShardId,seqNo, followerShardId, RemoteClusterRepository.REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC )
+    }
+
+
+    private suspend fun addNewRetentionLease(leaderShardId: ShardId, seqNo: Long, followerShardId: ShardId, timeout: Long): Boolean {
+        val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
+        val request = RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
+        try {
+            client.suspendExecute(RetentionLeaseActions.Add.INSTANCE, request)
+            return true
+        } catch (e: Exception) {
+            log.info("Exception while adding new retention lease with i: $retentionLeaseId")
+            return false
+        }
+    }
+
     public suspend fun renewRetentionLease(leaderShardId: ShardId, seqNo: Long, followerShardId: ShardId) {
-        val retentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
+        val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
         val request = RetentionLeaseActions.RenewRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
-        client.suspendExecute(RetentionLeaseActions.Renew.INSTANCE, request)
+        try {
+            client.suspendExecute(RetentionLeaseActions.Renew.INSTANCE, request)
+        }catch (e: RetentionLeaseNotFoundException){
+            //New retention lease not found, checking presense of old retention lease
+            log.info("Retention lease with ID: ${retentionLeaseId} not found," +
+                    " checking for old retention lease with ID: ${retentionLeaseIdForShard(followerClusterName, followerShardId)}")
+            if(!addNewRetentionLeaseIfOldExists(leaderShardId, followerShardId, seqNo)){
+                log.info("Both new $retentionLeaseId and old ${retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)} retention lease not found.")
+                throw e
+            }
+        }
     }
 
     public suspend fun attemptRemoveRetentionLease(clusterService: ClusterService, replMetadata: ReplicationMetadata,
@@ -78,7 +136,7 @@ class RemoteClusterRetentionLeaseHelper constructor(val followerClusterName: Str
             val params = IndexReplicationParams(replMetadata.connectionName, remoteMetadata.index, followerIndexName)
             val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
             val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName).shards()
-            val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+            val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), followerClusterUUID, remoteClient)
             shards.forEach {
                 val followerShardId = it.value.shardId
                 log.debug("Removing lease for $followerShardId.id ")
@@ -102,7 +160,7 @@ class RemoteClusterRetentionLeaseHelper constructor(val followerClusterName: Str
 
 
     public suspend fun attemptRetentionLeaseRemoval(leaderShardId: ShardId, followerShardId: ShardId) {
-        val retentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
+        val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
         val request = RetentionLeaseActions.RemoveRequest(leaderShardId, retentionLeaseId)
         try {
             client.suspendExecute(RetentionLeaseActions.Remove.INSTANCE, request)
@@ -123,7 +181,7 @@ class RemoteClusterRetentionLeaseHelper constructor(val followerClusterName: Str
      */
     public fun addRetentionLease(leaderShardId: ShardId, seqNo: Long,
                                  followerShardId: ShardId, timeout: Long) {
-        val retentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
+        val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
         val request = RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
         try {
             client.execute(RetentionLeaseActions.Add.INSTANCE, request).actionGet(timeout)
@@ -138,7 +196,7 @@ class RemoteClusterRetentionLeaseHelper constructor(val followerClusterName: Str
 
     public fun renewRetentionLease(leaderShardId: ShardId, seqNo: Long,
                                    followerShardId: ShardId, timeout: Long) {
-        val retentionLeaseId = retentionLeaseIdForShard(followerClusterName, followerShardId)
+        val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
         val request = RetentionLeaseActions.RenewRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
         client.execute(RetentionLeaseActions.Renew.INSTANCE, request).actionGet(timeout)
     }

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -132,7 +132,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     override val followerIndexName = params.followerIndexName
 
     override val log = Loggers.getLogger(javaClass, Index(params.followerIndexName, ClusterState.UNKNOWN_UUID))
-    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
     private var shouldCallEvalMonitoring = true
     private var updateSettingsContinuousFailCount = 0
     private var updateAliasContinousFailCount = 0

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -69,7 +69,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
     private val leaderShardId = params.leaderShardId
     private val followerShardId = params.followerShardId
     private val remoteClient = client.getRemoteClusterClient(leaderAlias)
-    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), remoteClient)
+    private val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
     private var lastLeaseRenewalMillis = System.currentTimeMillis()
 
     //Start backOff for exceptions with a second


### PR DESCRIPTION
### Description
Currently, "{followerClusterName}:{followerShardId}" is used as retention lease identifier which results in overlapping usage when two followers are configured for same leader domain with same remote-alias.


The retention lease ID should also include follower cluster specific ID which would provide distinction between retention lease ID’s when 2 follower clusters are connected to a single leader cluster.

New retention lease will be of the format {followerClusterUUID}:{followerClusterName}:{followerShardId}

 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/554
 