### PR TITLE
[Bug] Handle serialization issues with UpdateReplicationStateDetailsRequest

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateDetailsRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateDetailsRequest.kt
@@ -48,6 +48,7 @@ class UpdateReplicationStateDetailsRequest: AcknowledgedRequest<UpdateReplicatio
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
         out.writeString(followIndexName)
-        out.writeMap(replicationStateParams)
+        out.writeMap(replicationStateParams, StreamOutput::writeString, StreamOutput::writeString)
+        out.writeEnum(updateType)
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateDetailsRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateDetailsRequestTests.kt
@@ -1,0 +1,42 @@
+package org.opensearch.replication.action.replicationstatedetails
+
+import org.assertj.core.api.Assertions
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.test.OpenSearchTestCase
+
+class UpdateReplicationStateDetailsRequestTests: OpenSearchTestCase() {
+    companion object {
+        const val INDEX = "index"
+    }
+
+    fun `test serialization update type add`() {
+        val state = mapOf(Pair("k1", "v1"), Pair("k2", "v2"))
+        val request = UpdateReplicationStateDetailsRequest(INDEX, state, UpdateReplicationStateDetailsRequest.UpdateType.ADD)
+        val output = BytesStreamOutput()
+        request.writeTo(output)
+        val deserialized = UpdateReplicationStateDetailsRequest(output.bytes().streamInput())
+
+        assertEquals(UpdateReplicationStateDetailsRequest.UpdateType.ADD, deserialized.updateType)
+        assertEquals(INDEX, deserialized.followIndexName)
+        Assertions.assertThat(deserialized.replicationStateParams.containsKey("k1"))
+        Assertions.assertThat(deserialized.replicationStateParams.containsKey("k2"))
+        Assertions.assertThat("v1".equals(deserialized.replicationStateParams["k1"]))
+        Assertions.assertThat("v2".equals(deserialized.replicationStateParams["k2"]))
+    }
+
+    fun `test serialization update type delete`() {
+        val state = mapOf(Pair("k1", "v1"), Pair("k2", "v2"))
+        val request = UpdateReplicationStateDetailsRequest(INDEX, state, UpdateReplicationStateDetailsRequest.UpdateType.REMOVE)
+        val output = BytesStreamOutput()
+        request.writeTo(output)
+
+        val deserialized = UpdateReplicationStateDetailsRequest(output.bytes().streamInput())
+
+        assertEquals(UpdateReplicationStateDetailsRequest.UpdateType.REMOVE, deserialized.updateType)
+        assertEquals(INDEX, deserialized.followIndexName)
+        Assertions.assertThat(deserialized.replicationStateParams.containsKey("k1"))
+        Assertions.assertThat(deserialized.replicationStateParams.containsKey("k2"))
+        Assertions.assertThat("v1".equals(deserialized.replicationStateParams["k1"]))
+        Assertions.assertThat("v2".equals(deserialized.replicationStateParams["k2"]))
+    }
+}


### PR DESCRIPTION
### Description
UpdateReplicationStateDetailsRequest is not serialised and deserialised correctly.

Most of times this object doesn't require serialization as we're updating the state on cluster manager node where UpdateReplicationStateDetails action runs. 

 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/865
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
