### PR TITLE
[backport 1.1]  Replication auto pauses on follower cluster having wait_for_active_shards true

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -148,7 +148,8 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
                 EnableAllocationDecider.INDEX_ROUTING_REBALANCE_ENABLE_SETTING,
                 EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING,
-                IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING
+                IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING,
+                IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS
         )
 
         val blockListedSettings :Set<String> = blSettings.stream().map { k -> k.key }.collect(Collectors.toSet())

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -1052,6 +1052,187 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         )
     }
 
+    fun `test that wait_for_active_shards setting is set on leader and not on follower`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+
+        val settings = Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put(IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), Integer.toString(2))
+                .build()
+
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+            assertBusy {
+                assertThat(followerClient.indices()
+                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                        .isEqualTo(true)
+            }
+            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+
+            // Verify the setting on leader
+            val getLeaderSettingsRequest = GetSettingsRequest()
+            getLeaderSettingsRequest.indices(leaderIndexName)
+            getLeaderSettingsRequest.includeDefaults(true)
+
+            assertBusy ({
+                Assert.assertEquals(
+                        "2",
+                        leaderClient.indices()
+                                .getSettings(getLeaderSettingsRequest, RequestOptions.DEFAULT)
+                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                )
+            }, 15, TimeUnit.SECONDS)
+
+            // Verify that the setting is not updated on follower and follower has default value of the setting
+            val getSettingsRequest = GetSettingsRequest()
+            getSettingsRequest.indices(followerIndexName)
+            getSettingsRequest.includeDefaults(true)
+
+            assertBusy ({
+                Assert.assertEquals(
+                        "1",
+                        followerClient.indices()
+                                .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                                .getSetting(followerIndexName, IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.key)
+                )
+            }, 15, TimeUnit.SECONDS)
+        } finally {
+            followerClient.stopReplication(followerIndexName)
+        }
+    }
+
+    fun `test that wait_for_active_shards setting is updated on leader and not on follower`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+            assertBusy {
+                assertThat(followerClient.indices()
+                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                        .isEqualTo(true)
+            }
+            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+
+            //Use Update API
+            val settingsBuilder = Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                    .put(IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), Integer.toString(2))
+
+            val settingsUpdateResponse = leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName)
+                    .settings(settingsBuilder.build()), RequestOptions.DEFAULT)
+            Assert.assertEquals(settingsUpdateResponse.isAcknowledged, true)
+
+            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+
+            // Verify the setting on leader
+            val getLeaderSettingsRequest = GetSettingsRequest()
+            getLeaderSettingsRequest.indices(leaderIndexName)
+            getLeaderSettingsRequest.includeDefaults(true)
+
+            assertBusy ({
+                Assert.assertEquals(
+                        "2",
+                        leaderClient.indices()
+                                .getSettings(getLeaderSettingsRequest, RequestOptions.DEFAULT)
+                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                )
+            }, 15, TimeUnit.SECONDS)
+
+
+            val getSettingsRequest = GetSettingsRequest()
+            getSettingsRequest.indices(followerIndexName)
+            getSettingsRequest.includeDefaults(true)
+
+            assertBusy ({
+                Assert.assertEquals(
+                        "1",
+                        followerClient.indices()
+                                .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                                .getSetting(followerIndexName, IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.key)
+                )
+            }, 15, TimeUnit.SECONDS)
+        } finally {
+            followerClient.stopReplication(followerIndexName)
+        }
+    }
+
+    fun `test that wait_for_active_shards setting is updated on follower through start replication api`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+
+        val settings = Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put(IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), Integer.toString(2))
+                .build()
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName, settings = settings))
+            assertBusy {
+                assertThat(followerClient.indices()
+                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                        .isEqualTo(true)
+            }
+            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+
+            val getSettingsRequest = GetSettingsRequest()
+            getSettingsRequest.indices(followerIndexName)
+            getSettingsRequest.includeDefaults(true)
+            assertBusy ({
+                Assert.assertEquals(
+                        "2",
+                        followerClient.indices()
+                                .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                                .indexToSettings[followerIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                )
+            }, 15, TimeUnit.SECONDS)
+        } finally {
+            followerClient.stopReplication(followerIndexName)
+        }
+    }
+
+    private fun excludeAllClusterNodes(clusterName: String) {
+        val transientSettingsRequest = Request("PUT", "_cluster/settings")
+        // Get IPs directly from the cluster to handle all cases - single node cluster, multi node cluster and remote test cluster.
+        val excludeIps = getClusterNodeIPs(clusterName)
+        val entityAsString = """
+                        {
+                          "transient": {
+                             "cluster.routing.allocation.exclude._ip": "${excludeIps.joinToString()}"
+                          }
+                        }""".trimMargin()
+        transientSettingsRequest.entity = NStringEntity(entityAsString, ContentType.APPLICATION_JSON)
+        val transientSettingsResponse = getNamedCluster(clusterName).lowLevelClient.performRequest(transientSettingsRequest)
+        assertEquals(HttpStatus.SC_OK.toLong(), transientSettingsResponse.statusLine.statusCode.toLong())
+    }
+
+    private fun getClusterNodeIPs(clusterName: String): List<String> {
+        val clusterClient = getNamedCluster(clusterName).lowLevelClient
+        val nodesRequest = Request("GET", "_cat/nodes?format=json")
+        val nodesResponse =  EntityUtils.toString(clusterClient.performRequest(nodesRequest).entity)
+        val nodeIPs = arrayListOf<String>()
+        val parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, nodesResponse)
+        parser.list().forEach {
+            it as Map<*, *>
+            nodeIPs.add(it["ip"] as String)
+        }
+        return nodeIPs
+    }
+
     private fun assertValidationFailure(client: RestHighLevelClient, leader: String, follower: String, errrorMsg: String) {
         assertThatThrownBy {
             client.startReplication(StartReplicationRequest("source", leader, follower))


### PR DESCRIPTION
## Description

The leader index setting "wait_for_active_shards" is not copied/applied on the follower cluster. The default value of said setting is assumed at the follower cluster unless specified or changed specifically for the follower cluster.

Following is the expected behaviour in the identified scenarios relating to the "wait_for_active_shards" index setting,

* If the wait_for_active_shards setting is set to “all” during index creation, the index replication will succeed but the said setting will not be copied to the follower cluster(Verify through the “_settings” API). If one of the follower node goes down, the replication should still continue.

* If the wait_for_active_shards setting is set to “all” during index creation, and is later changed dynamically to any other valid value, on applying replication again, replication should not be affected and the setting value should also not change on the follower-cluster.

* If the wait_for_active_shards setting is set to “default/any valid value”, and later changed to “all”, then the setting change should be ignored at the follower-cluster. No change in replication or the said setting's value.
    NOTE- In all the above cases, the setting “wait_for_active_shards” value should be “default” on the follower-cluster.

* If the follower index setting "wait_for_active_shards" is set to valid value in “start-replication” API, then that should be applied to the follower cluster.

* If the follower index setting "wait_for_active_shards" is set to valid value in “update-settings” API for the follower cluster, then that should be applied on the follower cluster.

## Issues Resolved

https://github.com/opensearch-project/cross-cluster-replication/issues/544