### PR TITLE
Refresh dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build and run Replication tests
         run: |
-          ./gradlew clean release -D"build.snapshot=true"
+          ./gradlew --refresh-dependencies clean release -D"build.snapshot=true"
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         uses: actions/checkout@v2
       - name: Build and run Replication tests
         run: |
-          ./gradlew clean release -D"build.snapshot=true" -x test -x IntegTest
+          ./gradlew --refresh-dependencies clean release -D"build.snapshot=true" -x test -x IntegTest

--- a/.github/workflows/bwc.yml
+++ b/.github/workflows/bwc.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build and run Replication tests
         run: |
           echo "Running backwards compatibility tests ..."
-          ./gradlew clean release -Dbuild.snapshot=true -x test -x IntegTest
+          ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -x test -x IntegTest
           ./gradlew fullRestartClusterTask --stacktrace
       - name: Upload failed logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build and run Replication tests
         run: |
           ls -al src/test/resources/security/plugin
-          ./gradlew clean release -Dbuild.snapshot=true -PnumNodes=1 -Psecurity=true
+          ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -PnumNodes=1 -Psecurity=true
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build and run Replication tests
         run: |
-          ./gradlew clean release -Dbuild.snapshot=true -PnumNodes=1  -Dtests.class=org.opensearch.replication.BasicReplicationIT   -Dtests.method="test knn index replication"  -Pknn=true
+          ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -PnumNodes=1  -Dtests.class=org.opensearch.replication.BasicReplicationIT   -Dtests.method="test knn index replication"  -Pknn=true
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
### Description
Github workflow runs everytime there is a commit push, in case of PR, the dependencies dont refresh when there is upstream changes leading to workflow runs with stale dependencies.

The option --refresh-dependencies tells Gradle to ignore all cached entries for resolved modules and artifacts
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
