### PR TITLE
[Backport] Modified autofollow stats to rely on single source for failed indices (#708)

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -178,7 +178,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             TimeValue.timeValueSeconds(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.fetch_poll_interval", TimeValue.timeValueSeconds(30), TimeValue.timeValueSeconds(30),
                 TimeValue.timeValueHours(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
-        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.retry_poll_interval", TimeValue.timeValueHours(1), TimeValue.timeValueMinutes(30),
+        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.retry_poll_interval", TimeValue.timeValueHours(1), TimeValue.timeValueMinutes(1),
                 TimeValue.timeValueHours(4), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_METADATA_SYNC_INTERVAL = Setting.timeSetting("plugins.replication.follower.metadata_sync_interval",
                 TimeValue.timeValueSeconds(60), TimeValue.timeValueSeconds(5),

--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -63,7 +63,6 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
     override val followerIndexName: String = params.patternName //Special case for auto follow
     override val log = Loggers.getLogger(javaClass, leaderAlias)
     private var trackingIndicesOnTheCluster = setOf<String>()
-    private var failedIndices = ConcurrentSkipListSet<String>() // Failed indices for replication from this autofollow task
     private var replicationJobsQueue = ConcurrentSkipListSet<String>() // To keep track of outstanding replication jobs for this autofollow task
     private var retryScheduler: Scheduler.ScheduledCancellable? = null
     lateinit var stat: AutoFollowStat
@@ -90,14 +89,21 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
     }
 
     private fun addRetryScheduler() {
+        log.debug("Adding retry scheduler")
         if(retryScheduler != null && !retryScheduler!!.isCancelled) {
             return
         }
-        retryScheduler = try {
-            threadPool.schedule({ failedIndices.clear() }, replicationSettings.autofollowRetryPollDuration, ThreadPool.Names.GENERIC)
+         try {
+            retryScheduler = threadPool.schedule(
+                    {
+                        log.debug("Clearing failed indices to schedule for the next retry")
+                        stat.failedIndices.clear()
+                    },
+                    replicationSettings.autofollowRetryPollDuration,
+                    ThreadPool.Names.SAME)
         } catch (e: Exception) {
             log.error("Error scheduling retry on failed autofollow indices ${e.stackTraceToString()}")
-            null
+             retryScheduler = null
         }
     }
 
@@ -122,10 +128,10 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         } catch (e: Exception) {
             // Ideally, Calls to the remote cluster shouldn't fail and autofollow task should be able to pick-up the newly created indices
             // matching the pattern. Should be safe to retry after configured delay.
-            stat.failedLeaderCall++
-            if(stat.failedLeaderCall > 0 && stat.failedLeaderCall.rem(10) == 0L) {
+            if(stat.failedLeaderCall >= 0 && stat.failedLeaderCall.rem(10) == 0L) {
                 log.error("Fetching remote indices failed with error - ${e.stackTraceToString()}")
             }
+            stat.failedLeaderCall++
         }
 
         var currentIndices = clusterService.state().metadata().concreteAllIndices.asIterable() // All indices - open and closed on the cluster
@@ -137,7 +143,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
                 trackingIndicesOnTheCluster = currentIndices.toSet()
             }
         }
-        remoteIndices = remoteIndices.minus(currentIndices).minus(failedIndices).minus(replicationJobsQueue)
+        remoteIndices = remoteIndices.minus(currentIndices).minus(stat.failedIndices).minus(replicationJobsQueue)
 
         stat.failCounterForRun = 0
         startReplicationJobs(remoteIndices)
@@ -206,8 +212,6 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         } catch (e: OpenSearchSecurityException) {
             // For permission related failures, Adding as part of failed indices as autofollow role doesn't have required permissions.
             log.trace("Cannot start replication on $leaderIndex due to missing permissions $e")
-            failedIndices.add(leaderIndex)
-
         } catch (e: Exception) {
             // Any failure other than security exception can be safely retried and not adding to the failed indices
             log.warn("Failed to start replication for $leaderAlias:$leaderIndex -> $leaderIndex.", e)
@@ -248,7 +252,7 @@ class AutoFollowStat: Task.Status {
     val name :String
     val pattern :String
     var failCount: Long=0
-    var failedIndices :MutableSet<String> = mutableSetOf()
+    var failedIndices = ConcurrentSkipListSet<String>() // Failed indices for replication from this autofollow task
     var failCounterForRun :Long=0
     var successCount: Long=0
     var failedLeaderCall :Long=0
@@ -263,7 +267,8 @@ class AutoFollowStat: Task.Status {
         name = inp.readString()
         pattern = inp.readString()
         failCount = inp.readLong()
-        failedIndices = inp.readSet(StreamInput::readString)
+        val inpFailedIndices = inp.readList(StreamInput::readString)
+        failedIndices = ConcurrentSkipListSet<String>(inpFailedIndices)
         successCount = inp.readLong()
         failedLeaderCall = inp.readLong()
     }

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -381,6 +381,16 @@ fun RestHighLevelClient.updateReplicationStartBlockSetting(enabled: Boolean) {
     assertThat(response.isAcknowledged).isTrue()
 }
 
+fun RestHighLevelClient.updateAutofollowRetrySetting(duration: String) {
+    var settings: Settings = Settings.builder()
+            .put("plugins.replication.autofollow.retry_poll_interval", duration)
+            .build()
+    var updateSettingsRequest = ClusterUpdateSettingsRequest()
+    updateSettingsRequest.persistentSettings(settings)
+    val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
+    assertThat(response.isAcknowledged).isTrue()
+}
+
 fun RestHighLevelClient.updateAutoFollowConcurrentStartReplicationJobSetting(concurrentJobs: Int?) {
     val settings = if(concurrentJobs != null) {
         Settings.builder()

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -42,6 +42,7 @@ import org.opensearch.cluster.metadata.MetadataCreateIndexService
 import org.opensearch.replication.AutoFollowStats
 import org.opensearch.replication.ReplicationPlugin
 import org.opensearch.replication.updateReplicationStartBlockSetting
+import org.opensearch.replication.updateAutofollowRetrySetting
 import org.opensearch.replication.updateAutoFollowConcurrentStartReplicationJobSetting
 import org.opensearch.replication.waitForShardTaskStart
 import org.opensearch.test.OpenSearchTestCase.assertBusy
@@ -303,6 +304,8 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
         val leaderIndexName = createRandomIndex(leaderClient)
         try {
+            //modify retry duration to account for autofollow trigger in next retry
+            followerClient.updateAutofollowRetrySetting("1m")
             // Add replication start block
             followerClient.updateReplicationStartBlockSetting(true)
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
@@ -312,12 +315,19 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             // Autofollow task should still be up - 1 task
             Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(0)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+
+            var stats = followerClient.AutoFollowStats()
+            var failedIndices = stats["failed_indices"] as List<*>
+            assert(failedIndices.size == 1)
             // Remove replication start block
             followerClient.updateReplicationStartBlockSetting(false)
-            sleep(45000) // poll for auto follow in worst case
+            sleep(60000) // wait for auto follow trigger in the worst case
             // Index should be replicated and autofollow task should be present
             Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+            stats = followerClient.AutoFollowStats()
+            failedIndices = stats["failed_indices"] as List<*>
+            assert(failedIndices.isEmpty())
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
         }


### PR DESCRIPTION




### Description
Modified autofollow stats to rely on single source for failed indices and further improved logging for the initial failures during leader calls.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
