### PR TITLE
[Backport] Enhanced autofollow to trigger concurrent replication jobs based on setting (#321) (#932)

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -177,7 +177,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             TimeValue.timeValueSeconds(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.fetch_poll_interval", TimeValue.timeValueSeconds(30), TimeValue.timeValueSeconds(30),
                 TimeValue.timeValueHours(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
-        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.retry_poll_interval", TimeValue.timeValueHours(1), TimeValue.timeValueMinutes(30),
+        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.retry_poll_interval", TimeValue.timeValueHours(1), TimeValue.timeValueMinutes(1),
                 TimeValue.timeValueHours(4), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_METADATA_SYNC_INTERVAL = Setting.timeSetting("plugins.replication.follower.metadata_sync_interval",
                 TimeValue.timeValueSeconds(60), TimeValue.timeValueSeconds(5),
@@ -186,6 +186,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             TimeValue.timeValueHours(12), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_FOLLOWER_BLOCK_START: Setting<Boolean> = Setting.boolSetting("plugins.replication.follower.block.start", false,
                 Setting.Property.Dynamic, Setting.Property.NodeScope)
+        val REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size", 3, 1, 10,
+            Setting.Property.Dynamic, Setting.Property.NodeScope)
     }
 
     override fun createComponents(client: Client, clusterService: ClusterService, threadPool: ThreadPool,
@@ -342,7 +344,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
                 REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE, REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS,
                 REPLICATION_PARALLEL_READ_POLL_INTERVAL, REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,
                 REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL, REPLICATION_METADATA_SYNC_INTERVAL,
-                REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, REPLICATION_FOLLOWER_BLOCK_START)
+                REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, REPLICATION_FOLLOWER_BLOCK_START, REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE)
     }
 
     override fun getInternalRepositories(env: Environment, namedXContentRegistry: NamedXContentRegistry,

--- a/src/main/kotlin/org/opensearch/replication/ReplicationSettings.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationSettings.kt
@@ -31,6 +31,7 @@ open class ReplicationSettings(clusterService: ClusterService) {
     @Volatile var metadataSyncInterval = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL)
     @Volatile var leaseRenewalMaxFailureDuration: TimeValue = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION)
     @Volatile var followerBlockStart: Boolean = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START)
+    @Volatile var autofollowConcurrentJobsTriggerSize: Int = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE)
 
     init {
         listenForUpdates(clusterService.clusterSettings)
@@ -47,5 +48,6 @@ open class ReplicationSettings(clusterService: ClusterService) {
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL) { autofollowRetryPollDuration = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL) { metadataSyncInterval = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START) { followerBlockStart = it }
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE) { autofollowConcurrentJobsTriggerSize = it }
     }
 }

--- a/src/main/kotlin/org/opensearch/replication/action/status/ShardInfoResponse.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/status/ShardInfoResponse.kt
@@ -11,7 +11,6 @@
 
 package org.opensearch.replication.action.status
 
-import org.apache.logging.log4j.LogManager
 import org.opensearch.action.support.broadcast.BroadcastResponse
 import org.opensearch.action.support.broadcast.BroadcastShardResponse
 import org.opensearch.common.ParseField
@@ -28,6 +27,11 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     val status: String
     lateinit var replayDetails: ReplayDetails
     lateinit var restoreDetails: RestoreDetails
+
+    companion object {
+        const val BOOTSTRAPPING = "BOOTSTRAPPING"
+        const val SYNCING = "SYNCING"
+    }
 
     constructor(si: StreamInput) : super(si) {
         this.status = si.readString()

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -380,3 +380,29 @@ fun RestHighLevelClient.updateReplicationStartBlockSetting(enabled: Boolean) {
     val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
     assertThat(response.isAcknowledged).isTrue()
 }
+
+fun RestHighLevelClient.updateAutofollowRetrySetting(duration: String) {
+    var settings: Settings = Settings.builder()
+            .put("plugins.replication.autofollow.retry_poll_interval", duration)
+            .build()
+    var updateSettingsRequest = ClusterUpdateSettingsRequest()
+    updateSettingsRequest.persistentSettings(settings)
+    val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
+    assertThat(response.isAcknowledged).isTrue()
+}
+
+fun RestHighLevelClient.updateAutoFollowConcurrentStartReplicationJobSetting(concurrentJobs: Int?) {
+    val settings = if(concurrentJobs != null) {
+        Settings.builder()
+            .put("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size", concurrentJobs)
+            .build()
+    } else {
+        Settings.builder()
+            .putNull("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size")
+            .build()
+    }
+    val updateSettingsRequest = ClusterUpdateSettingsRequest()
+    updateSettingsRequest.persistentSettings(settings)
+    val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
+    assertThat(response.isAcknowledged).isTrue()
+}

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -400,118 +400,143 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 .build()
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
-            waitForRestore = true)
-        assertBusy {
-            assertThat(followerClient.indices()
-                    .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
-                    .isEqualTo(true)
-        }
-        settings = Settings.builder()
-                .build()
-        followerClient.updateReplication( followerIndexName, settings)
-        val getSettingsRequest = GetSettingsRequest()
-        getSettingsRequest.indices(followerIndexName)
-        getSettingsRequest.includeDefaults(true)
-        Assert.assertEquals(
-                "0",
-                followerClient.indices()
+        try {
+            followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName),
+                waitForRestore = true)
+            assertBusy {
+                assertThat(followerClient.indices()
+                        .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
+                        .isEqualTo(true)
+            }
+
+            settings = Settings.builder()
+                    .build()
+
+            followerClient.updateReplication( followerIndexName, settings)
+
+            val getSettingsRequest = GetSettingsRequest()
+            getSettingsRequest.indices(followerIndexName)
+            getSettingsRequest.includeDefaults(true)
+            Assert.assertEquals(
+                    "0",
+                    followerClient.indices()
+                            .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+            )
+
+            settings = Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
+                    .put("routing.allocation.enable", "none")
+                    .build()
+
+            leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
+
+            var indicesAliasesRequest = IndicesAliasesRequest()
+            var aliasAction = IndicesAliasesRequest.AliasActions.add()
+                    .index(leaderIndexName)
+                    .alias("alias1")
+            indicesAliasesRequest.addAliasAction(aliasAction)
+            leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
+
+            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+            getSettingsRequest.indices(followerIndexName)
+            // Leader setting is copied
+            assertBusy({
+                Assert.assertEquals(
+                    "2",
+                    followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
                         .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-        )
-        settings = Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
-                .put("routing.allocation.enable", "none")
-                .build()
-        leaderClient.indices().putSettings(UpdateSettingsRequest(leaderIndexName).settings(settings), RequestOptions.DEFAULT)
-        var indicesAliasesRequest = IndicesAliasesRequest()
-        var aliasAction = IndicesAliasesRequest.AliasActions.add()
-                .index(leaderIndexName)
-                .alias("alias1").filter("{\"term\":{\"year\":2016}}").routing("1")
-        indicesAliasesRequest.addAliasAction(aliasAction)
-        leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
-        TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
-        getSettingsRequest.indices(followerIndexName)
-        // Leader setting is copied
-        assertBusy({
-            Assert.assertEquals(
-                "2",
-                followerClient.indices()
+                )
+                assertEqualAliases()
+            }, 30L, TimeUnit.SECONDS)
+
+
+            // Case 2 :  Blocklisted  setting are not copied
+            Assert.assertNull(followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings[followerIndexName].get("index.routing.allocation.enable"))
+
+            //Alias test case 2: Update existing alias
+            aliasAction = IndicesAliasesRequest.AliasActions.add()
+                    .index(leaderIndexName)
+                    .routing("2")
+                    .alias("alias1")
+                    .writeIndex(true)
+                    .isHidden(false)
+            indicesAliasesRequest.addAliasAction(aliasAction)
+            leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
+
+            //Use Update API
+            settings = Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3)
+                    .put("index.routing.allocation.enable", "none")
+                    .put("index.search.idle.after", "10s")
+                    .build()
+
+            followerClient.updateReplication( followerIndexName, settings)
+            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+
+            // Case 3 : Updated Settings take higher priority.  Blocklisted  settins shouldn't matter for that
+            assertBusy({
+                Assert.assertEquals(
+                    "3",
+                    followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                )
+
+                Assert.assertEquals(
+                    "10s",
+                    followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName]["index.search.idle.after"]
+                )
+
+                Assert.assertEquals(
+                    "none",
+                    followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
+                )
+
+                assertEqualAliases()
+            }, 30L, TimeUnit.SECONDS)
+
+            //Clear the settings
+            settings = Settings.builder()
+                    .build()
+            followerClient.updateReplication( followerIndexName, settings)
+
+            //Alias test case 3: Delete one alias and add another alias
+            aliasAction = IndicesAliasesRequest.AliasActions.remove()
+                    .index(leaderIndexName)
+                    .alias("alias1")
+            indicesAliasesRequest.addAliasAction(aliasAction
             )
-            assertEqualAliases()
-        }, 30L, TimeUnit.SECONDS)
-        // Case 2 :  Blocklisted  setting are not copied
-        Assert.assertNull(followerClient.indices()
-                .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                .indexToSettings[followerIndexName].get("index.routing.allocation.enable"))
-        //Alias test case 2: Update existing alias
-        aliasAction = IndicesAliasesRequest.AliasActions.add()
-                .index(leaderIndexName)
-                .routing("2")
-                .alias("alias1")
-                .writeIndex(true)
-                .isHidden(false)
-        indicesAliasesRequest.addAliasAction(aliasAction)
-        leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
-        //Use Update API
-        settings = Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 3)
-                .put("index.routing.allocation.enable", "none")
-                .put("index.search.idle.after", "10s")
-                .build()
-        followerClient.updateReplication( followerIndexName, settings)
-        TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
-        // Case 3 : Updated Settings take higher priority.  Blocklisted  settins shouldn't matter for that
-        assertBusy({
-            Assert.assertEquals(
-                "3",
-                followerClient.indices()
-                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
-            )
-            Assert.assertEquals(
-                "10s",
-                followerClient.indices()
-                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.search.idle.after"]
-            )
-            Assert.assertEquals(
-                "none",
-                followerClient.indices()
-                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
-            )
-            assertEqualAliases()
-        }, 30L, TimeUnit.SECONDS)
-        //Clear the settings
-        settings = Settings.builder()
-                .build()
-        followerClient.updateReplication( followerIndexName, settings)
-        //Alias test case 3: Delete one alias and add another alias
-        aliasAction = IndicesAliasesRequest.AliasActions.remove()
-                .index(leaderIndexName)
-                .alias("alias1")
-        indicesAliasesRequest.addAliasAction(aliasAction
-        )
-        leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
-        var aliasAction2 = IndicesAliasesRequest.AliasActions.add()
-                .index(leaderIndexName)
-                .routing("12")
-                .alias("alias2")
-                .indexRouting("indexRouting")
-        indicesAliasesRequest.addAliasAction(aliasAction2)
-        TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
-        assertBusy({
-            Assert.assertEquals(
-                null,
-                followerClient.indices()
-                    .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.search.idle.after"]
-            )
-            assertEqualAliases()
-        }, 30L, TimeUnit.SECONDS)
+            leaderClient.indices().updateAliases(indicesAliasesRequest, RequestOptions.DEFAULT)
+            var aliasAction2 = IndicesAliasesRequest.AliasActions.add()
+                    .index(leaderIndexName)
+                    .routing("12")
+                    .alias("alias2")
+                    .indexRouting("indexRouting")
+            indicesAliasesRequest.addAliasAction(aliasAction2)
+
+            TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC)
+
+            assertBusy({
+                Assert.assertEquals(
+                    null,
+                    followerClient.indices()
+                        .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
+                        .indexToSettings[followerIndexName]["index.search.idle.after"]
+                )
+                assertEqualAliases()
+            }, 30L, TimeUnit.SECONDS)
+
+        } finally {
+            followerClient.stopReplication(followerIndexName)
+        }
     }
 
     fun `test that static index settings are getting replicated `() {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StopReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StopReplicationIT.kt
@@ -40,7 +40,7 @@ import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.index.mapper.MapperService
-import java.util.Random
+import org.opensearch.common.Randomness
 import java.util.concurrent.TimeUnit
 
 
@@ -247,7 +247,7 @@ class StopReplicationIT: MultiClusterRestTestCase() {
         createConnectionBetweenClusters(FOLLOWER, LEADER, "source")
         val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
         assertThat(createIndexResponse.isAcknowledged).isTrue()
-        val snapshotSuffix = Random().nextInt(1000).toString()
+        val snapshotSuffix = Randomness.get().nextInt(1000).toString()
         followerClient.startReplication(
                 StartReplicationRequest("source", leaderIndexName, followerIndexName),
                 TimeValue.timeValueSeconds(10),

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -42,6 +42,8 @@ import org.opensearch.cluster.metadata.MetadataCreateIndexService
 import org.opensearch.replication.AutoFollowStats
 import org.opensearch.replication.ReplicationPlugin
 import org.opensearch.replication.updateReplicationStartBlockSetting
+import org.opensearch.replication.updateAutofollowRetrySetting
+import org.opensearch.replication.updateAutoFollowConcurrentStartReplicationJobSetting
 import org.opensearch.replication.waitForShardTaskStart
 import org.opensearch.test.OpenSearchTestCase.assertBusy
 import java.lang.Thread.sleep
@@ -320,6 +322,8 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
         val leaderIndexName = createRandomIndex(leaderClient)
         try {
+            //modify retry duration to account for autofollow trigger in next retry
+            followerClient.updateAutofollowRetrySetting("1m")
             // Add replication start block
             followerClient.updateReplicationStartBlockSetting(true)
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
@@ -329,14 +333,98 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             // Autofollow task should still be up - 1 task
             Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(0)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+
+            var stats = followerClient.AutoFollowStats()
+            var failedIndices = stats["failed_indices"] as List<*>
+            assert(failedIndices.size == 1)
             // Remove replication start block
             followerClient.updateReplicationStartBlockSetting(false)
-            sleep(45000) // poll for auto follow in worst case
+            sleep(60000) // wait for auto follow trigger in the worst case
             // Index should be replicated and autofollow task should be present
             Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+            stats = followerClient.AutoFollowStats()
+            failedIndices = stats["failed_indices"] as List<*>
+            assert(failedIndices.isEmpty())
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+        }
+    }
+
+    fun `test autofollow task with concurrent job setting set to run parallel jobs`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+
+        // create two leader indices and test autofollow to trigger to trigger jobs based on setting
+        val leaderIndexName1 = createRandomIndex(leaderClient)
+        val leaderIndexName2 = createRandomIndex(leaderClient)
+
+        followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(2)
+        try {
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
+
+            // Verify that existing index matching the pattern are replicated.
+            assertBusy {
+                Assertions.assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(leaderIndexName1), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
+            }
+
+            assertBusy {
+                Assertions.assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(leaderIndexName2), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
+            }
+
+            sleep(30000) // Default poll for auto follow in worst case
+
+            Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+
+        } finally {
+            // Reset default autofollow setting
+            followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(null)
+            followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+            followerClient.stopReplication(leaderIndexName1)
+            followerClient.stopReplication(leaderIndexName2)
+        }
+    }
+
+    fun `test autofollow task with concurrent job setting set to run single job`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+
+        // create two leader indices and test autofollow to trigger to trigger jobs based on setting
+        val leaderIndexName1 = createRandomIndex(leaderClient)
+        val leaderIndexName2 = createRandomIndex(leaderClient)
+
+        followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(1)
+        try {
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
+
+            // Verify that existing index matching the pattern are replicated.
+            assertBusy {
+                // check that the index replication task is created for only index
+                Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(1)
+            }
+
+            sleep(30000) // Default poll for auto follow in worst case
+
+            assertBusy {
+                // check that the index replication task is created for only index
+                Assertions.assertThat(getIndexReplicationTasks(FOLLOWER).size).isEqualTo(2)
+            }
+
+            sleep(30000) // Default poll for auto follow in worst case
+            Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)
+
+        } finally {
+            // Reset default autofollow setting
+            followerClient.updateAutoFollowConcurrentStartReplicationJobSetting(null)
+            followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+            followerClient.stopReplication(leaderIndexName1)
+            followerClient.stopReplication(leaderIndexName2)
         }
     }
 

--- a/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
@@ -240,8 +240,7 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
                 .routingTable(routingTableBuilder.build())
                 .nodes(discoveryNodesBuilder.build()).build()
         setState(clusterService, newClusterState)
-        assertThat(replicationTask.isTrackingTaskForIndex()).isTrue()
-
+        assert(replicationTask.isTrackingTaskForIndex() == true)
 
         // when index replication task is not valid
         tasks = PersistentTasksCustomMetadata.builder()
@@ -264,7 +263,7 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
                 .routingTable(routingTableBuilder.build())
                 .nodes(discoveryNodesBuilder.build()).build()
         setState(clusterService, newClusterState)
-        assertThat(replicationTask.isTrackingTaskForIndex()).isFalse()
+        assert(replicationTask.isTrackingTaskForIndex() == false)
     }
 
     private fun createIndexReplicationTask() : IndexReplicationTask {


### PR DESCRIPTION
### Description
Enhanced autofollow to trigger concurrent replication jobs based on setting and Modified autofollow stats to rely on single source for failed indices and further improved logging for the initial failures during leader calls.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
