### PR TITLE
Autofollow concurrent job execution and single source for failed indices (#321) (#933)

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationPlugin.kt
@@ -179,7 +179,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             TimeValue.timeValueSeconds(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.fetch_poll_interval", TimeValue.timeValueSeconds(30), TimeValue.timeValueSeconds(30),
                 TimeValue.timeValueHours(1), Setting.Property.Dynamic, Setting.Property.NodeScope)
-        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.retry_poll_interval", TimeValue.timeValueHours(1), TimeValue.timeValueMinutes(30),
+        val REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL = Setting.timeSetting ("plugins.replication.autofollow.retry_poll_interval", TimeValue.timeValueHours(1), TimeValue.timeValueMinutes(1),
                 TimeValue.timeValueHours(4), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_METADATA_SYNC_INTERVAL = Setting.timeSetting("plugins.replication.follower.metadata_sync_interval",
                 TimeValue.timeValueSeconds(60), TimeValue.timeValueSeconds(5),
@@ -188,6 +188,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             TimeValue.timeValueHours(12), Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_FOLLOWER_BLOCK_START: Setting<Boolean> = Setting.boolSetting("plugins.replication.follower.block.start", false,
                 Setting.Property.Dynamic, Setting.Property.NodeScope)
+        val REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size", 3, 1, 10,
+            Setting.Property.Dynamic, Setting.Property.NodeScope)
     }
 
     override fun createComponents(client: Client, clusterService: ClusterService, threadPool: ThreadPool,
@@ -344,7 +346,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
                 REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE, REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS,
                 REPLICATION_PARALLEL_READ_POLL_INTERVAL, REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,
                 REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL, REPLICATION_METADATA_SYNC_INTERVAL,
-                REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, REPLICATION_FOLLOWER_BLOCK_START)
+                REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, REPLICATION_FOLLOWER_BLOCK_START, REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE)
     }
 
     override fun getInternalRepositories(env: Environment, namedXContentRegistry: NamedXContentRegistry,

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/ReplicationSettings.kt
@@ -17,6 +17,7 @@ class ReplicationSettings(clusterService: ClusterService) {
     @Volatile var metadataSyncInterval = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL)
     @Volatile var leaseRenewalMaxFailureDuration: TimeValue = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION)
     @Volatile var followerBlockStart: Boolean = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START)
+    @Volatile var autofollowConcurrentJobsTriggerSize: Int = clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE)
 
     init {
         listenForUpdates(clusterService.clusterSettings)
@@ -33,5 +34,6 @@ class ReplicationSettings(clusterService: ClusterService) {
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL) { autofollowRetryPollDuration = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL) { metadataSyncInterval = it }
         clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START) { followerBlockStart = it }
+        clusterSettings.addSettingsUpdateConsumer(ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE) { autofollowConcurrentJobsTriggerSize = it }
     }
 }

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardInfoResponse.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/action/status/ShardInfoResponse.kt
@@ -18,6 +18,11 @@ class ShardInfoResponse : BroadcastShardResponse, ToXContentObject {
     lateinit var replayDetails: ReplayDetails
     lateinit var restoreDetails: RestoreDetails
 
+    companion object {
+        const val BOOTSTRAPPING = "BOOTSTRAPPING"
+        const val SYNCING = "SYNCING"
+    }
+
     constructor(si: StreamInput) : super(si) {
         this.status = si.readString()
         if (status.equals("SYNCING"))

--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
@@ -39,6 +39,9 @@ import org.elasticsearch.common.io.stream.StreamOutput
 import org.elasticsearch.common.logging.Loggers
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentBuilder
+import com.amazon.elasticsearch.replication.action.status.ReplicationStatusAction
+import com.amazon.elasticsearch.replication.action.status.ShardInfoRequest
+import com.amazon.elasticsearch.replication.action.status.ShardInfoResponse
 import org.elasticsearch.persistent.PersistentTaskState
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.tasks.Task
@@ -64,7 +67,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
     override val followerIndexName: String = params.patternName //Special case for auto follow
     override val log = Loggers.getLogger(javaClass, leaderAlias)
     private var trackingIndicesOnTheCluster = setOf<String>()
-    private var failedIndices = ConcurrentSkipListSet<String>() // Failed indices for replication from this autofollow task
+    private var replicationJobsQueue = ConcurrentSkipListSet<String>() // To keep track of outstanding replication jobs for this autofollow task
     private var retryScheduler: Scheduler.ScheduledCancellable? = null
     lateinit var stat: AutoFollowStat
 
@@ -73,7 +76,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         while (scope.isActive) {
             try {
                 addRetryScheduler()
-                autoFollow()
+                pollForIndices()
                 stat.lastExecutionTime = System.currentTimeMillis()
                 delay(replicationSettings.autofollowFetchPollDuration.millis)
             }
@@ -91,14 +94,21 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
     }
 
     private fun addRetryScheduler() {
+        log.debug("Adding retry scheduler")
         if(retryScheduler != null && !retryScheduler!!.isCancelled) {
             return
         }
-        retryScheduler = try {
-            threadPool.schedule({ failedIndices.clear() }, replicationSettings.autofollowRetryPollDuration, ThreadPool.Names.GENERIC)
+         try {
+            retryScheduler = threadPool.schedule(
+                    {
+                        log.debug("Clearing failed indices to schedule for the next retry")
+                        stat.failedIndices.clear()
+                    },
+                    replicationSettings.autofollowRetryPollDuration,
+                    ThreadPool.Names.SAME)
         } catch (e: Exception) {
             log.error("Error scheduling retry on failed autofollow indices ${e.stackTraceToString()}")
-            null
+             retryScheduler = null
         }
     }
 
@@ -106,7 +116,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         retryScheduler?.cancel()
     }
 
-    private suspend fun autoFollow() {
+    private suspend fun pollForIndices() {
         log.debug("Checking $leaderAlias under pattern name $patternName for new indices to auto follow")
         val entry = replicationMetadata.leaderContext.resource
 
@@ -123,10 +133,10 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         } catch (e: Exception) {
             // Ideally, Calls to the remote cluster shouldn't fail and autofollow task should be able to pick-up the newly created indices
             // matching the pattern. Should be safe to retry after configured delay.
-            stat.failedLeaderCall++
-            if(stat.failedLeaderCall > 0 && stat.failedLeaderCall.rem(10) == 0L) {
+            if(stat.failedLeaderCall >= 0 && stat.failedLeaderCall.rem(10) == 0L) {
                 log.error("Fetching remote indices failed with error - ${e.stackTraceToString()}")
             }
+            stat.failedLeaderCall++
         }
 
         var currentIndices = clusterService.state().metadata().concreteAllIndices.asIterable() // All indices - open and closed on the cluster
@@ -138,13 +148,44 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
                 trackingIndicesOnTheCluster = currentIndices.toSet()
             }
         }
-        remoteIndices = remoteIndices.minus(currentIndices).minus(failedIndices)
+        remoteIndices = remoteIndices.minus(currentIndices).minus(stat.failedIndices).minus(replicationJobsQueue)
 
         stat.failCounterForRun = 0
-        for (newRemoteIndex in remoteIndices) {
-            startReplication(newRemoteIndex)
-        }
+        startReplicationJobs(remoteIndices)
         stat.failCount = stat.failCounterForRun
+    }
+
+    private suspend fun startReplicationJobs(remoteIndices: Iterable<String>) {
+        val completedJobs = ConcurrentSkipListSet<String>()
+        for(index in replicationJobsQueue) {
+            val statusReq = ShardInfoRequest(index, false)
+            try {
+                val statusRes = client.suspendExecute(ReplicationStatusAction.INSTANCE, statusReq, injectSecurityContext = true)
+                if(statusRes.status != ShardInfoResponse.BOOTSTRAPPING) {
+                    completedJobs.add(index)
+                }
+            } catch (ex: Exception) {
+                log.error("Error while fetching the status for index $index", ex)
+            }
+        }
+
+        // Remove the indices in "syncing" state from the queue
+        replicationJobsQueue.removeAll(completedJobs)
+        val concurrentJobsAllowed = replicationSettings.autofollowConcurrentJobsTriggerSize
+        if(replicationJobsQueue.size >= concurrentJobsAllowed) {
+            log.debug("Max concurrent replication jobs already in the queue for autofollow task[${params.patternName}]")
+            return
+        }
+
+        var totalJobsToTrigger = concurrentJobsAllowed - replicationJobsQueue.size
+        for (newRemoteIndex in remoteIndices) {
+            if(totalJobsToTrigger <= 0) {
+                break
+            }
+            startReplication(newRemoteIndex)
+            replicationJobsQueue.add(newRemoteIndex)
+            totalJobsToTrigger--
+        }
     }
 
     private suspend fun startReplication(leaderIndex: String) {
@@ -176,8 +217,6 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         } catch (e: ElasticsearchSecurityException) {
             // For permission related failures, Adding as part of failed indices as autofollow role doesn't have required permissions.
             log.trace("Cannot start replication on $leaderIndex due to missing permissions $e")
-            failedIndices.add(leaderIndex)
-
         } catch (e: Exception) {
             // Any failure other than security exception can be safely retried and not adding to the failed indices
             log.warn("Failed to start replication for $leaderAlias:$leaderIndex -> $leaderIndex.", e)
@@ -218,7 +257,7 @@ class AutoFollowStat: Task.Status {
     val name :String
     val pattern :String
     var failCount: Long=0
-    var failedIndices :MutableSet<String> = mutableSetOf()
+    var failedIndices = ConcurrentSkipListSet<String>() // Failed indices for replication from this autofollow task
     var failCounterForRun :Long=0
     var successCount: Long=0
     var failedLeaderCall :Long=0
@@ -234,7 +273,8 @@ class AutoFollowStat: Task.Status {
         name = inp.readString()
         pattern = inp.readString()
         failCount = inp.readLong()
-        failedIndices = inp.readSet(StreamInput::readString)
+        val inpFailedIndices = inp.readList(StreamInput::readString)
+        failedIndices = ConcurrentSkipListSet<String>(inpFailedIndices)
         successCount = inp.readLong()
         failedLeaderCall = inp.readLong()
         lastExecutionTime = inp.readLong()

--- a/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/com/amazon/elasticsearch/replication/ReplicationHelpers.kt
@@ -384,3 +384,29 @@ fun RestHighLevelClient.updateReplicationStartBlockSetting(enabled: Boolean) {
     val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
     assertThat(response.isAcknowledged).isTrue()
 }
+
+fun RestHighLevelClient.updateAutofollowRetrySetting(duration: String) {
+    var settings: Settings = Settings.builder()
+            .put("plugins.replication.autofollow.retry_poll_interval", duration)
+            .build()
+    var updateSettingsRequest = ClusterUpdateSettingsRequest()
+    updateSettingsRequest.persistentSettings(settings)
+    val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
+    assertThat(response.isAcknowledged).isTrue()
+}
+
+fun RestHighLevelClient.updateAutoFollowConcurrentStartReplicationJobSetting(concurrentJobs: Int?) {
+    val settings = if(concurrentJobs != null) {
+        Settings.builder()
+            .put("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size", concurrentJobs)
+            .build()
+    } else {
+        Settings.builder()
+            .putNull("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size")
+            .build()
+    }
+    val updateSettingsRequest = ClusterUpdateSettingsRequest()
+    updateSettingsRequest.persistentSettings(settings)
+    val response = this.cluster().putSettings(updateSettingsRequest, RequestOptions.DEFAULT)
+    assertThat(response.isAcknowledged).isTrue()
+}


### PR DESCRIPTION
### Description
Enhanced autofollow to trigger concurrent replication jobs based on setting and Modified autofollow stats to rely on single source for failed indices and further improved logging for the initial failures during leader calls.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
