### PR TITLE
Modify autofollow retry scheduler logic check to account for completed runs (#839) (#953)

### DIFF
--- a/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/com/amazon/elasticsearch/replication/task/autofollow/AutoFollowTask.kt
@@ -49,6 +49,7 @@ import org.elasticsearch.tasks.TaskId
 import org.elasticsearch.threadpool.Scheduler
 import org.elasticsearch.threadpool.ThreadPool
 import java.util.concurrent.ConcurrentSkipListSet
+import java.util.concurrent.TimeUnit
 
 class AutoFollowTask(id: Long, type: String, action: String, description: String, parentTask: TaskId,
                      headers: Map<String, String>,
@@ -95,7 +96,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
 
     private fun addRetryScheduler() {
         log.debug("Adding retry scheduler")
-        if(retryScheduler != null && !retryScheduler!!.isCancelled) {
+        if(retryScheduler != null && retryScheduler!!.getDelay(TimeUnit.NANOSECONDS) > 0L) {
             return
         }
          try {


### PR DESCRIPTION
### Description
Modify autofollow retry scheduler logic check to account for completed runs

(cherry picked from commit 689ae33791610d69dada452a466ee8795fd3bc23)
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
