### PR TITLE
Weak password fix

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityBase.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityBase.kt
@@ -18,6 +18,8 @@ import org.apache.hc.core5.http.io.entity.StringEntity
 import org.opensearch.client.Request
 import org.junit.BeforeClass
 
+const val INTEG_TEST_PASSWORD = "ccr-integ-test@123"
+
 abstract class SecurityBase : MultiClusterRestTestCase()   {
     companion object {
         var initialized : Boolean = false
@@ -282,17 +284,17 @@ abstract class SecurityBase : MultiClusterRestTestCase()   {
         }
 
         private fun addUsers(){
-            addUserToCluster("testUser1","password", FOLLOWER)
-            addUserToCluster("testUser1","password", LEADER)
-            addUserToCluster("testUser2","password", FOLLOWER)
-            addUserToCluster("testUser2","password", LEADER)
-            addUserToCluster("testUser3","password", FOLLOWER)
-            addUserToCluster("testUser4","password", FOLLOWER)
-            addUserToCluster("testUser5","password", FOLLOWER)
-            addUserToCluster("testUser6","password", LEADER)
-            addUserToCluster("testUser6","password", FOLLOWER)
-            addUserToCluster("testUser7","password", LEADER)
-            addUserToCluster("testUser7","password", FOLLOWER)
+            addUserToCluster("testUser1", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser1", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser2", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser2", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser3", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser4", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser5", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser6", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser6", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser7", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser7", INTEG_TEST_PASSWORD, FOLLOWER)
         }
 
         private fun addUserToCluster(userName: String, password: String, clusterName: String) {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -60,7 +60,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD), waitForRestore = true)
         assertBusy {
             Assertions.assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
@@ -79,7 +79,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD)) }
                     .isInstanceOf(ResponseException::class.java)
                     .hasMessageContaining("403 Forbidden")
     }
@@ -89,7 +89,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         Assertions.assertThatThrownBy {
             followerClient.stopReplication("follower-index1",
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("No replication in progress for index:follower-index1")
     }
@@ -99,7 +99,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         Assertions.assertThatThrownBy {
             followerClient.stopReplication("follower-index1",
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -115,7 +115,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
-        var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")
+        var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                 requestOptions = requestOptions)
 
@@ -145,11 +145,11 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         Assertions.assertThatThrownBy {
             followerClient.pauseReplication(followerIndexName,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -167,11 +167,11 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest,  waitForRestore = true,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         assertBusy {
             `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
         }
     }
 
@@ -188,11 +188,11 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         Assertions.assertThatThrownBy {
             followerClient.replicationStatus(followerIndexName,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -215,7 +215,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
             useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
-            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         assertBusy {
             Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
@@ -234,7 +234,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 .put("index.shard.check_on_startup", "checksum")
                 .build()
         followerClient.updateReplication(followerIndexName, settings,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         // Wait for the settings to get updated at follower cluster.
         assertBusy ({
@@ -260,7 +260,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD), waitForRestore = true)
         assertBusy {
             Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
@@ -279,7 +279,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 .build()
         Assertions.assertThatThrownBy {
             followerClient.updateReplication(followerIndexName, settings,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -297,7 +297,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"),
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             // Verify that existing index matching the pattern are replicated.
             assertBusy ({
                 Assertions.assertThat(followerClient.indices()
@@ -326,7 +326,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThatThrownBy {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"),
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -358,7 +358,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
             //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
             assertBusy ({
@@ -370,7 +370,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
             }, 1, TimeUnit.MINUTES)
             assertBusy {
                 `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }
 
             updateRole(followerIndexName,"followerRoleValidPerms", false)
@@ -378,7 +378,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
             assertBusy ({
                 validatePausedState(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }, 100, TimeUnit.SECONDS)
         } finally {
             updateRole(followerIndexName,"followerRoleValidPerms", true)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
@@ -47,7 +47,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleNoPerms",followerClusterRole = "followerRoleValidPerms"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser6","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser6",INTEG_TEST_PASSWORD)) }
                 .isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("403 Forbidden")
                 .hasMessageContaining("no permissions for [indices:admin/plugins/replication/index/setup/validate]")
@@ -64,7 +64,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
             //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
             assertBusy ({
@@ -76,13 +76,13 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
             }, 1, TimeUnit.MINUTES)
             assertBusy {
                 `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }
             updateRole(followerIndexName,"leaderRoleValidPerms", false)
             insertDocToIndex(LEADER, "2", "dummy data 2",leaderIndexName)
             assertBusy ({
                 validatePausedState(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }, 100, TimeUnit.SECONDS)
         } finally {
             updateRole(followerIndexName,"leaderRoleValidPerms", true)
@@ -101,10 +101,10 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             updateFileChunkPermissions("","leaderRoleValidPerms", false)
             followerClient.startReplication(startReplicationRequest,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             assertBusy ({
                 validateFailedState(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }, 60, TimeUnit.SECONDS)
         } catch (ex : Exception) {
             logger.info("Exception is", ex)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
@@ -49,7 +49,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerDlsRole"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password")) }
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD)) }
                 .isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
                 .hasMessageContaining("403 Forbidden")
@@ -59,7 +59,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         val followerClient = getClientForCluster(FOLLOWER)
         Assertions.assertThatThrownBy {
             followerClient.stopReplication("follower-index1-stop-forbidden",
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -75,10 +75,10 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         Assertions.assertThatThrownBy {
             followerClient.pauseReplication(followerIndexName,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -94,10 +94,10 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         Assertions.assertThatThrownBy {
             followerClient.replicationStatus(followerIndexName,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -116,7 +116,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD), waitForRestore = true)
         assertBusy {
             Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
@@ -135,7 +135,7 @@ class SecurityDlsFlsIT: SecurityBase() {
                 .build()
         Assertions.assertThatThrownBy {
             followerClient.updateReplication(followerIndexName, settings,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -151,7 +151,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFlsRole"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser4","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser4",INTEG_TEST_PASSWORD)) }
         .isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -167,7 +167,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser5","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser5",INTEG_TEST_PASSWORD)) }
         .isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -190,7 +190,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         )
         followerClient.startReplication(
             startReplicationRequest,
-            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser7", "password"),
+            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser7", INTEG_TEST_PASSWORD),
             waitForRestore = true
         )
         OpenSearchTestCase.assertBusy {


### PR DESCRIPTION
### Description
Integ test are failing when run with security enabled. This is because [new validation](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/dlic/rest/validation/PasswordValidator.java) has been added in security plugin to ensure that password is not weak. 
Modifying the password in our integ tests to make it strong.
 
### Issues Resolved
#908 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
