### PR TITLE
Remove numNodes parameter in security tests

### DIFF
--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build and run Replication tests
         run: |
           ls -al src/test/resources/security/plugin
-          ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -PnumNodes=1 -Psecurity=true
+          ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -Psecurity=true
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
### Description
Some of the integ tests like those for wait_for_active_shards need atleast 2 nodes in the cluster to run successfully. Removing the numNodes=1 parameter so that by default 2 node cluster is created
 
### Issues Resolved
NA
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
