### PR TITLE
Fix for Generic error for persistent task on starting replication

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 * @saikaranam-amazon
 * @soosinha
 * @gbbafna
+* @monusingh-1

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
@@ -127,7 +127,8 @@ class TransportReplicateIndexClusterManagerNodeAction @Inject constructor(transp
                 persistentTasksService.waitForTaskCondition(task.id, replicateIndexReq.timeout()) { t ->
                     val replicationState = (t.state as IndexReplicationState?)?.state
                     replicationState == ReplicationState.FOLLOWING ||
-                            (!replicateIndexReq.waitForRestore && replicationState == ReplicationState.RESTORING)
+                            (!replicateIndexReq.waitForRestore && replicationState == ReplicationState.RESTORING) ||
+                            (!replicateIndexReq.waitForRestore && replicationState == ReplicationState.FAILED)
                 }
 
                 listener.onResponse(AcknowledgedResponse(true))

--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -54,6 +54,8 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.settings.Settings
 import org.opensearch.replication.util.stackTraceToString
+import org.opensearch.persistent.PersistentTasksCustomMetadata
+import org.opensearch.persistent.RemovePersistentTaskAction
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 import java.io.IOException
@@ -136,6 +138,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                     }
                 }
                 replicationMetadataManager.deleteIndexReplicationMetadata(request.indexName)
+                removeStaleReplicationTasksFromClusterState(request)
                 listener.onResponse(AcknowledgedResponse(true))
             } catch (e: Exception) {
                 log.error("Stop replication failed for index[${request.indexName}] with error ${e.stackTraceToString()}")
@@ -144,6 +147,32 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
         }
     }
 
+    private suspend fun removeStaleReplicationTasksFromClusterState(request: StopIndexReplicationRequest) {
+        try {
+            val allTasks: PersistentTasksCustomMetadata =
+                clusterService.state().metadata().custom(PersistentTasksCustomMetadata.TYPE)
+            for (singleTask in allTasks.tasks()) {
+                if (isReplicationTask(singleTask, request) && !singleTask.isAssigned){
+                    log.info("Removing task: ${singleTask.id} from cluster state")
+                    val removeRequest: RemovePersistentTaskAction.Request =
+                        RemovePersistentTaskAction.Request(singleTask.id)
+                    client.suspendExecute(RemovePersistentTaskAction.INSTANCE, removeRequest)
+                }
+            }
+        } catch (e: Exception) {
+            log.info("Could not update cluster state")
+        }
+    }
+
+    // Remove index replication task metadata, format replication:index:fruit-1
+    // Remove shard replication task metadata, format replication:[fruit-1][0]
+    private fun isReplicationTask(
+        singleTask: PersistentTasksCustomMetadata.PersistentTask<*>,
+        request: StopIndexReplicationRequest
+    ) = singleTask.id.startsWith("replication:") &&
+            (singleTask.id == "replication:index:${request.indexName}" || singleTask.id.split(":")[1].contains(request.indexName))
+
+
     private fun validateReplicationStateOfIndex(request: StopIndexReplicationRequest) {
         // If replication blocks/settings are present, Stop action should proceed with the clean-up
         // This can happen during settings of follower index are carried over in the snapshot and the restore is
@@ -151,6 +180,15 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
         if (clusterService.state().blocks.hasIndexBlock(request.indexName, INDEX_REPLICATION_BLOCK)
                 || clusterService.state().metadata.index(request.indexName)?.settings?.get(REPLICATED_INDEX_SETTING.key) != null) {
             return
+        }
+
+        //check for stale replication tasks
+        val allTasks: PersistentTasksCustomMetadata? =
+            clusterService.state()?.metadata()?.custom(PersistentTasksCustomMetadata.TYPE)
+        allTasks?.tasks()?.forEach{
+            if (isReplicationTask(it, request) && !it.isAssigned){
+                return
+            }
         }
 
         val replicationStateParams = getReplicationStateParamsForIndex(clusterService, request.indexName)

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRestoreLeaderService.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRestoreLeaderService.kt
@@ -114,8 +114,8 @@ class RemoteClusterRestoreLeaderService @Inject constructor(private val indicesS
         var fromSeqNo = RetentionLeaseActions.RETAIN_ALL
 
         // Adds the retention lease for fromSeqNo for the next stage of the replication.
-        retentionLeaseHelper.addRetentionLease(request.leaderShardId, fromSeqNo,
-                request.followerShardId, RemoteClusterRepository.REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC)
+        retentionLeaseHelper.addRetentionLease(request.leaderShardId, fromSeqNo, request.followerShardId,
+                RemoteClusterRepository.REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC)
 
         /**
          * At this point, it should be safe to release retention lock as the retention lease

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -22,6 +22,7 @@ import org.opensearch.index.seqno.RetentionLeaseActions
 import org.opensearch.index.seqno.RetentionLeaseAlreadyExistsException
 import org.opensearch.index.seqno.RetentionLeaseInvalidRetainingSeqNoException
 import org.opensearch.index.seqno.RetentionLeaseNotFoundException
+import org.opensearch.index.shard.IndexShard
 import org.opensearch.index.shard.ShardId
 import org.opensearch.replication.metadata.store.ReplicationMetadata
 import org.opensearch.replication.repository.RemoteClusterRepository
@@ -175,22 +176,47 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
         }
     }
 
+    public fun attemptRetentionLeaseRemoval(leaderShardId: ShardId, followerShardId: ShardId, timeout: Long) {
+        val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
+        val request = RetentionLeaseActions.RemoveRequest(leaderShardId, retentionLeaseId)
+        try {
+            client.execute(RetentionLeaseActions.Remove.INSTANCE, request).actionGet(timeout)
+            log.info("Removed retention lease with id - $retentionLeaseId")
+        } catch(e: RetentionLeaseNotFoundException) {
+            // log error and bail
+            log.error(e.stackTraceToString())
+        } catch (e: Exception) {
+            // We are not bubbling up the exception as the stop action/ task cleanup should succeed
+            // even if we fail to remove the retention lease from leader cluster
+            log.error("Exception in removing retention lease", e)
+        }
+    }
+
 
     /**
      * Remove these once the callers are moved to above APIs
      */
     public fun addRetentionLease(leaderShardId: ShardId, seqNo: Long,
-                                 followerShardId: ShardId, timeout: Long) {
+                                         followerShardId: ShardId, timeout: Long) {
         val retentionLeaseId = retentionLeaseIdForShard(followerClusterNameWithUUID, followerShardId)
         val request = RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
-        try {
-            client.execute(RetentionLeaseActions.Add.INSTANCE, request).actionGet(timeout)
-        } catch (e: RetentionLeaseAlreadyExistsException) {
-            log.error(e.stackTraceToString())
-            log.info("Renew retention lease as it already exists $retentionLeaseId with $seqNo")
-            // Only one retention lease should exists for the follower shard
-            // Ideally, this should have got cleaned-up
-            renewRetentionLease(leaderShardId, seqNo, followerShardId, timeout)
+        var canRetry = true
+        while (true) {
+            try {
+                log.info("Adding retention lease $retentionLeaseId")
+                client.execute(RetentionLeaseActions.Add.INSTANCE, request).actionGet(timeout)
+                break
+            } catch (e: RetentionLeaseAlreadyExistsException) {
+                log.info("Found a stale retention lease $retentionLeaseId on leader.")
+                if (canRetry) {
+                    canRetry = false
+                    attemptRetentionLeaseRemoval(leaderShardId, followerShardId, timeout)
+                    log.info("Cleared stale retention lease $retentionLeaseId on leader. Retrying...")
+                } else {
+                    log.error(e.stackTraceToString())
+                    throw e
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -290,7 +290,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     private suspend fun pollShardTaskStatus(): IndexReplicationState {
         val failedShardTasks = findAllReplicationFailedShardTasks(followerIndexName, clusterService.state())
         if (failedShardTasks.isNotEmpty()) {
-            log.info("Failed shard tasks - ", failedShardTasks)
+            log.info("Failed shard tasks - $failedShardTasks")
             var msg = ""
             for ((shard, task) in failedShardTasks) {
                 val taskState = task.state

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -828,7 +828,11 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
             }
         } catch(e: Exception) {
             val err = "Unable to initiate restore call for $followerIndexName from $leaderAlias:${leaderIndex.name}"
+            val aliasErrMsg = "cannot rename index [${leaderIndex.name}] into [$followerIndexName] because of conflict with an alias with the same name"
             log.error(err, e)
+            if (e.message!!.contains(aliasErrMsg)) {
+                return FailedState(Collections.emptyMap(), aliasErrMsg)
+            }
             return FailedState(Collections.emptyMap(), err)
         }
         cso.waitForNextChange("remote restore start") { inProgressRestore(it) != null }

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -218,6 +218,10 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
 
         val changeTracker = ShardReplicationChangesTracker(indexShard, replicationSettings)
         followerClusterStats.stats[followerShardId]!!.followerCheckpoint = indexShard.localCheckpoint
+        // In case the shard task starts on a new node and there are no active writes on the leader shard, leader checkpoint
+        // never gets initialized and defaults to 0. To get around this, we set the leaderCheckpoint to follower shard's
+        // localCheckpoint as the leader shard is guaranteed to equal or more.
+        followerClusterStats.stats[followerShardId]!!.leaderCheckpoint = indexShard.localCheckpoint
         coroutineScope {
             while (isActive) {
                 rateLimiter.acquire()

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ReplicationStopThenRestartIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ReplicationStopThenRestartIT.kt
@@ -1,0 +1,62 @@
+package org.opensearch.replication.integ.rest
+
+import org.opensearch.replication.MultiClusterRestTestCase
+import org.opensearch.replication.MultiClusterAnnotations
+import org.opensearch.replication.StartReplicationRequest
+import org.opensearch.replication.startReplication
+import org.opensearch.replication.stopReplication
+import org.assertj.core.api.Assertions
+import org.opensearch.client.RequestOptions
+import org.opensearch.client.indices.CreateIndexRequest
+import org.junit.Assert
+import java.util.concurrent.TimeUnit
+
+
+@MultiClusterAnnotations.ClusterConfigurations(
+        MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER),
+        MultiClusterAnnotations.ClusterConfiguration(clusterName = FOLLOWER)
+)
+
+class ReplicationStopThenRestartIT : MultiClusterRestTestCase() {
+    private val leaderIndexName = "leader_index"
+    private val followerIndexName = "follower_index"
+
+    fun `test replication works after unclean stop and start`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        changeTemplate(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+        insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
+        insertDocToIndex(LEADER, "2", "dummy data 1",leaderIndexName)
+
+        assertBusy ({
+            try {
+                Assert.assertEquals(2, docCount(followerClient, followerIndexName))
+            } catch (ex: Exception) {
+                ex.printStackTrace();
+                Assert.fail("Exception while querying follower cluster. Failing to retry again {}")
+            }
+        }, 1, TimeUnit.MINUTES)
+
+
+        deleteConnection(FOLLOWER)
+        followerClient.stopReplication(followerIndexName, shouldWait = true)
+        deleteIndex(followerClient, followerIndexName)
+
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        insertDocToIndex(LEADER, "3", "dummy data 1",leaderIndexName)
+        insertDocToIndex(LEADER, "4", "dummy data 1",leaderIndexName)
+        followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName))
+
+        assertBusy ({
+            try {
+                Assert.assertEquals(4, docCount(followerClient, followerIndexName))
+            } catch (ex: Exception) {
+                Assert.fail("Exception while querying follower cluster. Failing to retry again")
+            }
+        }, 1, TimeUnit.MINUTES)
+    }
+}

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityBase.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityBase.kt
@@ -18,6 +18,8 @@ import org.apache.hc.core5.http.io.entity.StringEntity
 import org.opensearch.client.Request
 import org.junit.BeforeClass
 
+const val INTEG_TEST_PASSWORD = "ccr-integ-test@123"
+
 abstract class SecurityBase : MultiClusterRestTestCase()   {
     companion object {
         var initialized : Boolean = false
@@ -282,17 +284,17 @@ abstract class SecurityBase : MultiClusterRestTestCase()   {
         }
 
         private fun addUsers(){
-            addUserToCluster("testUser1","password", FOLLOWER)
-            addUserToCluster("testUser1","password", LEADER)
-            addUserToCluster("testUser2","password", FOLLOWER)
-            addUserToCluster("testUser2","password", LEADER)
-            addUserToCluster("testUser3","password", FOLLOWER)
-            addUserToCluster("testUser4","password", FOLLOWER)
-            addUserToCluster("testUser5","password", FOLLOWER)
-            addUserToCluster("testUser6","password", LEADER)
-            addUserToCluster("testUser6","password", FOLLOWER)
-            addUserToCluster("testUser7","password", LEADER)
-            addUserToCluster("testUser7","password", FOLLOWER)
+            addUserToCluster("testUser1", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser1", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser2", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser2", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser3", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser4", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser5", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser6", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser6", INTEG_TEST_PASSWORD, FOLLOWER)
+            addUserToCluster("testUser7", INTEG_TEST_PASSWORD, LEADER)
+            addUserToCluster("testUser7", INTEG_TEST_PASSWORD, FOLLOWER)
         }
 
         private fun addUserToCluster(userName: String, password: String, clusterName: String) {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -60,7 +60,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD), waitForRestore = true)
         assertBusy {
             Assertions.assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
@@ -79,7 +79,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"))
 
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD)) }
                     .isInstanceOf(ResponseException::class.java)
                     .hasMessageContaining("403 Forbidden")
     }
@@ -89,7 +89,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         Assertions.assertThatThrownBy {
             followerClient.stopReplication("follower-index1",
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("No replication in progress for index:follower-index1")
     }
@@ -99,7 +99,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         Assertions.assertThatThrownBy {
             followerClient.stopReplication("follower-index1",
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -115,7 +115,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
-        var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")
+        var requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
                 requestOptions = requestOptions)
 
@@ -145,11 +145,11 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         Assertions.assertThatThrownBy {
             followerClient.pauseReplication(followerIndexName,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -167,11 +167,11 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest,  waitForRestore = true,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         assertBusy {
             `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
         }
     }
 
@@ -188,11 +188,11 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
 
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         Assertions.assertThatThrownBy {
             followerClient.replicationStatus(followerIndexName,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -215,7 +215,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
         followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
             useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
-            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         assertBusy {
             Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
@@ -234,7 +234,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 .put("index.shard.check_on_startup", "checksum")
                 .build()
         followerClient.updateReplication(followerIndexName, settings,
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
 
         // Wait for the settings to get updated at follower cluster.
         assertBusy ({
@@ -260,7 +260,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
-                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+                requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD), waitForRestore = true)
         assertBusy {
             Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
@@ -279,7 +279,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 .build()
         Assertions.assertThatThrownBy {
             followerClient.updateReplication(followerIndexName, settings,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -297,7 +297,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"),
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             // Verify that existing index matching the pattern are replicated.
             assertBusy ({
                 Assertions.assertThat(followerClient.indices()
@@ -326,7 +326,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
         Assertions.assertThatThrownBy {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleNoPerms"),
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser2",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining("403 Forbidden")
     }
@@ -358,7 +358,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
             //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
             assertBusy ({
@@ -370,7 +370,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
             }, 1, TimeUnit.MINUTES)
             assertBusy {
                 `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }
 
             updateRole(followerIndexName,"followerRoleValidPerms", false)
@@ -378,7 +378,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
 
             assertBusy ({
                 validatePausedState(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }, 100, TimeUnit.SECONDS)
         } finally {
             updateRole(followerIndexName,"followerRoleValidPerms", true)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesLeaderIT.kt
@@ -47,7 +47,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleNoPerms",followerClusterRole = "followerRoleValidPerms"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser6","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser6",INTEG_TEST_PASSWORD)) }
                 .isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining("403 Forbidden")
                 .hasMessageContaining("no permissions for [indices:admin/plugins/replication/index/setup/validate]")
@@ -64,7 +64,7 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
             var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             insertDocToIndex(LEADER, "1", "dummy data 1",leaderIndexName)
             //Querying ES cluster throws random exceptions like ClusterManagerNotDiscovered or ShardsFailed etc, so catching them and retrying
             assertBusy ({
@@ -76,13 +76,13 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
             }, 1, TimeUnit.MINUTES)
             assertBusy {
                 `validate status syncing response`(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }
             updateRole(followerIndexName,"leaderRoleValidPerms", false)
             insertDocToIndex(LEADER, "2", "dummy data 2",leaderIndexName)
             assertBusy ({
                 validatePausedState(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }, 100, TimeUnit.SECONDS)
         } finally {
             updateRole(followerIndexName,"leaderRoleValidPerms", true)
@@ -101,10 +101,10 @@ class SecurityCustomRolesLeaderIT: SecurityBase() {
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
             updateFileChunkPermissions("","leaderRoleValidPerms", false)
             followerClient.startReplication(startReplicationRequest,
-                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                    requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
             assertBusy ({
                 validateFailedState(followerClient.replicationStatus(followerIndexName,
-                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password")))
+                        requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD)))
             }, 60, TimeUnit.SECONDS)
         } catch (ex : Exception) {
             logger.info("Exception is", ex)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
@@ -49,7 +49,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                     useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerDlsRole"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password")) }
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD)) }
                 .isInstanceOf(ResponseException::class.java)
                 .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
                 .hasMessageContaining("403 Forbidden")
@@ -59,7 +59,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         val followerClient = getClientForCluster(FOLLOWER)
         Assertions.assertThatThrownBy {
             followerClient.stopReplication("follower-index1-stop-forbidden",
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -75,10 +75,10 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         Assertions.assertThatThrownBy {
             followerClient.pauseReplication(followerIndexName,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -94,10 +94,10 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms"))
         followerClient.startReplication(startReplicationRequest, waitForRestore = true,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"))
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD))
         Assertions.assertThatThrownBy {
             followerClient.replicationStatus(followerIndexName,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -116,7 +116,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         Assertions.assertThat(createIndexResponse.isAcknowledged).isTrue()
         followerClient.startReplication(StartReplicationRequest("source", leaderIndexName, followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerRoleValidPerms")),
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1","password"), waitForRestore = true)
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser1",INTEG_TEST_PASSWORD), waitForRestore = true)
         assertBusy {
             Assertions.assertThat(followerClient.indices()
                     .exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT))
@@ -135,7 +135,7 @@ class SecurityDlsFlsIT: SecurityBase() {
                 .build()
         Assertions.assertThatThrownBy {
             followerClient.updateReplication(followerIndexName, settings,
-                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3","password"))
+                    requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser3",INTEG_TEST_PASSWORD))
         }.isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -151,7 +151,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFlsRole"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser4","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser4",INTEG_TEST_PASSWORD)) }
         .isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -167,7 +167,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         var startReplicationRequest = StartReplicationRequest("source",leaderIndexName,followerIndexName,
                 useRoles = UseRoles(leaderClusterRole = "leaderRoleValidPerms",followerClusterRole = "followerFieldMaskRole"))
         Assertions.assertThatThrownBy { followerClient.startReplication(startReplicationRequest,
-                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser5","password")) }
+                requestOptions= RequestOptions.DEFAULT.addBasicAuthHeader("testUser5",INTEG_TEST_PASSWORD)) }
         .isInstanceOf(ResponseException::class.java)
         .hasMessageContaining(DLS_FLS_EXCEPTION_MESSAGE)
         .hasMessageContaining("403 Forbidden")
@@ -190,7 +190,7 @@ class SecurityDlsFlsIT: SecurityBase() {
         )
         followerClient.startReplication(
             startReplicationRequest,
-            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser7", "password"),
+            requestOptions = RequestOptions.DEFAULT.addBasicAuthHeader("testUser7", INTEG_TEST_PASSWORD),
             waitForRestore = true
         )
         OpenSearchTestCase.assertBusy {


### PR DESCRIPTION
### Description
This change will fix the generic error coming in case of replication failed in restore phase.
This change will also return the acknowledgement as 200 when replication failed in restore phase and put the failed reason in metadata store, which can be view via replication status API
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/707
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
