### PR TITLE
ratelimiter acquiring after getting unAppliedChanges in TranslogSequncer

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/shard/TranslogSequencer.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/TranslogSequencer.kt
@@ -71,12 +71,12 @@ class TranslogSequencer(scope: CoroutineScope, private val replicationMetadata: 
         val rateLimiter = Semaphore(writersPerShard)
         var highWatermark = initialSeqNo
         for (m in channel) {
-            rateLimiter.acquire()
             while (unAppliedChanges.containsKey(highWatermark + 1)) {
                 val next = unAppliedChanges.remove(highWatermark + 1)!!
                 val replayRequest = ReplayChangesRequest(followerShardId, next.changes, next.maxSeqNoOfUpdatesOrDeletes,
                                                          leaderAlias, leaderIndexName)
                 replayRequest.parentTask = parentTaskId
+                rateLimiter.acquire()
                 launch {
                     var relativeStartNanos  = System.nanoTime()
                     val retryOnExceptions = ArrayList<Class<*>>()


### PR DESCRIPTION

### Description
ratelimiter acquiring after getting unAppliedChanges in TranslogSequncer, Corrects Translog tests failures
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
