### PR TITLE
Update TranslogSequencer.kt

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/shard/TranslogSequencer.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/TranslogSequencer.kt
@@ -70,13 +70,13 @@ class TranslogSequencer(scope: CoroutineScope, private val replicationMetadata: 
         // raise the same exception.  See [SendChannel.close] method for details.
         val rateLimiter = Semaphore(writersPerShard)
         var highWatermark = initialSeqNo
-        for (m in channel) {
-            rateLimiter.acquire()
+        for (m in channel) {            
             while (unAppliedChanges.containsKey(highWatermark + 1)) {
                 val next = unAppliedChanges.remove(highWatermark + 1)!!
                 val replayRequest = ReplayChangesRequest(followerShardId, next.changes, next.maxSeqNoOfUpdatesOrDeletes,
                                                          leaderAlias, leaderIndexName)
                 replayRequest.parentTask = parentTaskId
+                rateLimiter.acquire()
                 launch {
                     var relativeStartNanos  = System.nanoTime()
                     val retryOnExceptions = ArrayList<Class<*>>()


### PR DESCRIPTION
Correct the flow for rateLimiter.acquire()
The change makes sure that lock is aquired only when a change is going to be processed

### Description
Currently, rateLimiter.acquire() acquires the lock before the condition 
```
  while (unAppliedChanges.containsKey(highWatermark + 1))
```

This results in lock being acquired in cases when change is not going to be replayed, this results in taking locks which which are never released as the release happen only inside the while -> launch.

This change makes sure the lock is taken only when needed and ensures the locks are release.

This change also fixed failing test `TranslogSequencerTests.test sequencer out of order` when batch size is more than 1

```
REPRODUCE WITH: ./gradlew ':test' --tests "org.opensearch.replication.task.shard.TranslogSequencerTests.test sequencer out of order" -Dtests.seed=C4EDF5240EBB1EFA -Dtests.security.manager=false -Dtests.locale=el -Dtests.timezone=Etc/GMT -Druntime.java=17

This job has not completed yet
java.lang.IllegalStateException: This job has not completed yet
	at __randomizedtesting.SeedInfo.seed([C4EDF5240EBB1EFA:7D5CC772A8F5E5AB]:0)
	at kotlinx.coroutines.JobSupport.getCompletionExceptionOrNull(JobSupport.kt:1190)
	at kotlinx.coroutines.test.TestBuildersKt__TestBuildersDeprecatedKt.runBlockingTest(TestBuildersDeprecated.kt:67)
	at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest(Unknown Source)
	at kotlinx.coroutines.test.TestBuildersKt__TestBuildersDeprecatedKt.runBlockingTest$default(TestBuildersDeprecated.kt:57)
	at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest$default(Unknown Source)
	at org.opensearch.replication.task.shard.TranslogSequencerTests.test sequencer out of order(TranslogSequencerTests.kt:87)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1750)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:938)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:974)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:988)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:817)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:468)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:947)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:832)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:883)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:894)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at java.base/java.lang.Thread.run(Thread.java:833)

NOTE: leaving temporary files on disk at: /Users/msnghgw/main/ccr-dev/build/testrun/test/temp/org.opensearch.replication.task.shard.TranslogSequencerTests_C4EDF5240EBB1EFA-001
NOTE: test params are: codec=Asserting(Lucene95): {}, docValues:{}, maxPointsInLeafNode=1068, maxMBSortInHeap=7.804259309177127, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=el, timezone=Etc/GMT
NOTE: Mac OS X 12.6.6 aarch64/Amazon.com Inc. 17.0.7 (64-bit)/cpus=10,threads=2,free=424950208,total=536870912
NOTE: All tests run in this JVM: [TranslogSequencerTests]

REPRODUCE WITH: ./gradlew ':test' --tests "org.opensearch.replication.task.shard.TranslogSequencerTests.test sequencer out of order" -Dtests.seed=C4EDF5240EBB1EFA -Dtests.security.manager=false -Dtests.locale=el -Dtests.timezone=Etc/GMT -Druntime.java=17
org.opensearch.replication.task.shard.TranslogSequencerTests > test sequencer out of order FAILED
    java.lang.IllegalStateException: This job has not completed yet
        at __randomizedtesting.SeedInfo.seed([C4EDF5240EBB1EFA:7D5CC772A8F5E5AB]:0)
        at kotlinx.coroutines.JobSupport.getCompletionExceptionOrNull(JobSupport.kt:1190)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersDeprecatedKt.runBlockingTest(TestBuildersDeprecated.kt:67)
        at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersDeprecatedKt.runBlockingTest$default(TestBuildersDeprecated.kt:57)
        at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest$default(Unknown Source)
        at org.opensearch.replication.task.shard.TranslogSequencerTests.test sequencer out of order(TranslogSequencerTests.kt:87)
Suite: Test class org.opensearch.replication.task.shard.TranslogSequencerTests
  1> [2023-07-10T03:23:14,678][INFO ][o.o.r.t.s.TranslogSequencerTests] [test sequencer out of order] before test
  1> [2023-07-10T03:23:15,460][INFO ][o.o.r.t.s.TranslogSequencerTests] [test sequencer out of order] after test
  2> REPRODUCE WITH: ./gradlew ':test' --tests "org.opensearch.replication.task.shard.TranslogSequencerTests.test sequencer out of order" -Dtests.seed=C4EDF5240EBB1EFA -Dtests.security.manager=false -Dtests.locale=el -Dtests.timezone=Etc/GMT -Druntime.java=17
  2> java.lang.IllegalStateException: This job has not completed yet
        at __randomizedtesting.SeedInfo.seed([C4EDF5240EBB1EFA:7D5CC772A8F5E5AB]:0)
        at kotlinx.coroutines.JobSupport.getCompletionExceptionOrNull(JobSupport.kt:1190)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersDeprecatedKt.runBlockingTest(TestBuildersDeprecated.kt:67)
        at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersDeprecatedKt.runBlockingTest$default(TestBuildersDeprecated.kt:57)
        at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest$default(Unknown Source)
        at org.opensearch.replication.task.shard.TranslogSequencerTests.test sequencer out of order(TranslogSequencerTests.kt:87)
  2> NOTE: leaving temporary files on disk at: /Users/msnghgw/main/ccr-dev/build/testrun/test/temp/org.opensearch.replication.task.shard.TranslogSequencerTests_C4EDF5240EBB1EFA-001
  2> NOTE: test params are: codec=Asserting(Lucene95): {}, docValues:{}, maxPointsInLeafNode=1068, maxMBSortInHeap=7.804259309177127, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=el, timezone=Etc/GMT
  2> NOTE: Mac OS X 12.6.6 aarch64/Amazon.com Inc. 17.0.7 (64-bit)/cpus=10,threads=2,free=424950208,total=536870912
  2> NOTE: All tests run in this JVM: [TranslogSequencerTests]
Tests with failures:
 - org.opensearch.replication.task.shard.TranslogSequencerTests.test sequencer out of order
1 test completed, 1 failed
> Task :test FAILED
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
