### PR TITLE
Fix test in StartReplicationIT

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -878,7 +878,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             assertThat(stats.containsKey("index_stats"))
         }, 60L, TimeUnit.SECONDS)
     }
-
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/176")
     fun `test follower stats`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)


### PR DESCRIPTION
### Description
The test "test follower stats" fails intermittently due to https://github.com/opensearch-project/cross-cluster-replication/issues/176



Added 
```
 @AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/176")
```
This change was missed only in 1.1 branch.
Ref https://github.com/opensearch-project/cross-cluster-replication/pull/236

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
