### PR TITLE
Increment version to 2.9 and refactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.8.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.9.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // e.g. 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -130,9 +130,9 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
     private suspend fun isResumable(params :IndexReplicationParams): Boolean {
         var isResumable = true
         val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
-        val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName).shards()
+        val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName)?.shards()
         val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
-        shards.forEach {
+        shards?.forEach {
             val followerShardId = it.value.shardId
 
             if  (!retentionLeaseHelper.verifyRetentionLeaseExist(ShardId(params.leaderIndex, followerShardId.id), followerShardId)) {
@@ -146,7 +146,7 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
 
         // clean up all retention leases we may have accidentally took while doing verifyRetentionLeaseExist .
         // Idempotent Op which does no harm
-        shards.forEach {
+        shards?.forEach {
             val followerShardId = it.value.shardId
             log.debug("Removing lease for $followerShardId.id ")
             retentionLeaseHelper.attemptRetentionLeaseRemoval(ShardId(params.leaderIndex, followerShardId.id), followerShardId)

--- a/src/main/kotlin/org/opensearch/replication/action/status/TranportShardsInfoAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/status/TranportShardsInfoAction.kt
@@ -28,7 +28,6 @@ import org.opensearch.indices.IndicesService
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 import java.io.IOException
-import java.util.*
 
 class TranportShardsInfoAction  @Inject constructor(clusterService: ClusterService,
                                                     transportService: TransportService,

--- a/src/main/kotlin/org/opensearch/replication/action/update/UpdateIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/update/UpdateIndexReplicationRequest.kt
@@ -22,7 +22,7 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.settings.Settings.readSettingsFromStream
 import org.opensearch.core.xcontent.*
 import java.io.IOException
-import java.util.*
+import java.util.Collections
 
 
 class UpdateIndexReplicationRequest : AcknowledgedRequest<UpdateIndexReplicationRequest>, IndicesRequest.Replaceable, ToXContentObject {

--- a/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
@@ -274,8 +274,8 @@ class TransportUpdateMetadataAction @Inject constructor(
             val indexAsArray = arrayOf(concreteIndex)
             val aliasMetadata = metadata.findAliases(action, indexAsArray)
             val finalAliases: MutableList<String> = ArrayList()
-            for (curAliases in aliasMetadata.values()) {
-                for (aliasMeta in curAliases.value) {
+            for (curAliases in aliasMetadata.values) {
+                for (aliasMeta in curAliases) {
                     finalAliases.add(aliasMeta.alias())
                 }
             }

--- a/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
@@ -48,7 +48,7 @@ import org.opensearch.rest.action.admin.indices.AliasesNotFoundException
 import org.opensearch.tasks.Task
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
-import java.util.*
+import java.util.Collections
 
 /*
  This action allows the replication plugin to update the index metadata(mapping, setting & aliases) on the follower index

--- a/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTask.kt
@@ -22,10 +22,10 @@ import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.block.ClusterBlockLevel
 import org.opensearch.cluster.block.ClusterBlocks
 import org.opensearch.cluster.service.ClusterService
-import org.opensearch.common.collect.ImmutableOpenMap
 import org.opensearch.index.IndexNotFoundException
 import org.opensearch.rest.RestStatus
-import java.util.*
+import java.util.Collections
+import java.util.EnumSet
 
 
 /* This is our custom index block to prevent changes to follower
@@ -49,11 +49,11 @@ fun checkIfIndexBlockedWithLevel(clusterService: ClusterService,
                                  clusterBlockLevel: ClusterBlockLevel) {
     clusterService.state().routingTable.index(indexName) ?:
     throw IndexNotFoundException("Index with name:$indexName doesn't exist")
-    val writeIndexBlockMap : ImmutableOpenMap<String, Set<ClusterBlock>> = clusterService.state().blocks()
+    val writeIndexBlockMap : Map<String, Set<ClusterBlock>> = clusterService.state().blocks()
             .indices(clusterBlockLevel)
     if (!writeIndexBlockMap.containsKey(indexName))
         return
-    val clusterBlocksSet : Set<ClusterBlock> = writeIndexBlockMap.get(indexName)
+    val clusterBlocksSet : Set<ClusterBlock> = writeIndexBlockMap.getOrDefault(indexName, Collections.emptySet())
     if (clusterBlocksSet.contains(INDEX_REPLICATION_BLOCK)
             && clusterBlocksSet.size > 1)
         throw ClusterBlockException(clusterBlocksSet)

--- a/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadata.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadata.kt
@@ -22,9 +22,8 @@ import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.core.xcontent.XContentParser
 import java.io.IOException
-import java.util.*
 import java.util.function.BiConsumer
-import java.util.function.BiFunction
+import java.util.Collections
 
 const val KEY_SETTINGS = "settings"
 

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -244,7 +244,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         builder.remove(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key)
 
         val indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder)
-        indexMetadata.aliases.valuesIt().forEach {
+        indexMetadata.aliases.values.forEach {
             indexMdBuilder.putAlias(it)
         }
         return indexMdBuilder.build()

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -193,8 +193,8 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
     override fun getRepositoryData(listener: ActionListener<RepositoryData>) {
         val clusterState = getLeaderClusterState(false, false)
         val shardGenerations = ShardGenerations.builder()
-        clusterState.metadata.indices.values()
-                .map { it.value }
+        clusterState.metadata.indices.values
+                .map { it }
                 .forEach { indexMetadata ->
                     val indexId = IndexId(indexMetadata.index.name, indexMetadata.indexUUID)
                     for (i in 0 until indexMetadata.numberOfShards) {
@@ -215,7 +215,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
     override fun getSnapshotInfo(snapshotId: SnapshotId): SnapshotInfo {
         val leaderClusterState = getLeaderClusterState(false, false)
         assert(REMOTE_SNAPSHOT_NAME.equals(snapshotId.name), { "SnapshotName differs" })
-        val indices = leaderClusterState.metadata().indices().keys().map { x -> x.value }
+        val indices = leaderClusterState.metadata().indices().keys.map { x -> x }
         return SnapshotInfo(snapshotId, indices, emptyList(), SnapshotState.SUCCESS, Version.CURRENT)
     }
 

--- a/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt
@@ -17,7 +17,7 @@ import org.opensearch.replication.task.index.IndexReplicationExecutor.Companion.
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.client.Requests
 import org.opensearch.client.node.NodeClient
-import org.opensearch.common.Strings
+import org.opensearch.core.common.Strings
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestChannel

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -136,9 +136,9 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
             val remoteMetadata = getLeaderIndexMetadata(replMetadata.connectionName, replMetadata.leaderContext.resource)
             val params = IndexReplicationParams(replMetadata.connectionName, remoteMetadata.index, followerIndexName)
             val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
-            val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName).shards()
+            val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName)?.shards()
             val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), followerClusterUUID, remoteClient)
-            shards.forEach {
+            shards?.forEach {
                 val followerShardId = it.value.shardId
                 log.debug("Removing lease for $followerShardId.id ")
                 retentionLeaseHelper.attemptRetentionLeaseRemoval(ShardId(params.leaderIndex, followerShardId.id), followerShardId)

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -346,9 +346,9 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         val clusterState = clusterService.state()
         val persistentTasks = clusterState.metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
 
-        val followerShardIds = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
-            .map {  shard -> shard.value.shardId }
-            .stream().collect(Collectors.toSet())
+        val followerShardIds = clusterService.state().routingTable.indicesRouting().get(followerIndexName)?.shards()
+            ?.map { shard -> shard.value.shardId }
+            ?.stream()?.collect(Collectors.toSet()).orEmpty()
         val runningShardTasksForIndex = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
                 .map { task -> task.params as ShardReplicationParams }
                 .filter {taskParam -> followerShardIds.contains(taskParam.followerShardId) }
@@ -434,16 +434,16 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 // If we we want to retrieve just the version of settings and alias versions, there are two options
                 // 1. Include this in GetChanges and communicate it to IndexTask via Metadata
                 // 2. Add another API to retrieve version of settings & aliases. Persist current version in Metadata
-                var leaderSettings = settingsResponse.indexToSettings.get(this.leaderIndex.name)
-                leaderSettings = leaderSettings.filter { k: String? ->
+                var leaderSettings = settingsResponse.indexToSettings.getOrDefault(this.leaderIndex.name, Settings.EMPTY)
+                leaderSettings = leaderSettings.filter { k: String ->
                     !blockListedSettings.contains(k)
                 }
 
                 gsr = GetSettingsRequest().includeDefaults(false).indices(this.followerIndexName)
                 settingsResponse = client.suspending(client.admin().indices()::getSettings, injectSecurityContext = true)(gsr)
-                var followerSettings = settingsResponse.indexToSettings.get(this.followerIndexName)
+                var followerSettings = settingsResponse.indexToSettings.getOrDefault(this.followerIndexName, Settings.EMPTY)
 
-                followerSettings = followerSettings.filter { k: String? ->
+                followerSettings = followerSettings.filter { k: String ->
                     k != REPLICATED_INDEX_SETTING.key
                 }
 
@@ -516,11 +516,11 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 //Alias
                 var getAliasesRequest = GetAliasesRequest().indices(this.leaderIndex.name)
                 var getAliasesRes = remoteClient.suspending(remoteClient.admin().indices()::getAliases, injectSecurityContext = true)(getAliasesRequest)
-                var leaderAliases = getAliasesRes.aliases.get(this.leaderIndex.name)
+                var leaderAliases = getAliasesRes.aliases.getOrDefault(this.leaderIndex.name, Collections.emptyList())
 
                 getAliasesRequest = GetAliasesRequest().indices(followerIndexName)
                 getAliasesRes = client.suspending(client.admin().indices()::getAliases, injectSecurityContext = true)(getAliasesRequest)
-                var followerAliases = getAliasesRes.aliases.get(followerIndexName)
+                var followerAliases = getAliasesRes.aliases.getOrDefault(followerIndexName, Collections.emptyList())
 
                 var request  :IndicesAliasesRequest?
 
@@ -606,8 +606,8 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
             try {
                 //Step 1 : Remove the tasks
-                val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
-                shards.forEach {
+                val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName)?.shards()
+                shards?.forEach {
                     persistentTasksService.removeTask(ShardReplicationTask.taskIdForShard(it.value.shardId))
                 }
 
@@ -748,7 +748,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
     suspend fun startNewOrMissingShardTasks():  Map<ShardId, PersistentTask<ShardReplicationParams>> {
         assert(clusterService.state().routingTable.hasIndex(followerIndexName)) { "Can't find index $followerIndexName" }
-        val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName).shards()
+        val shards = clusterService.state().routingTable.indicesRouting().get(followerIndexName)?.shards()
         val persistentTasks = clusterService.state().metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
         val runningShardTasks = persistentTasks.findTasks(ShardReplicationExecutor.TASK_NAME, Predicate { true }).stream()
             .map { task -> task as PersistentTask<ShardReplicationParams> }
@@ -757,14 +757,14 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 {t: PersistentTask<ShardReplicationParams> -> t.params!!.followerShardId},
                 {t: PersistentTask<ShardReplicationParams> -> t}))
 
-        val tasks = shards.map {
+        val tasks = shards?.map {
             it.value.shardId
-        }.associate { shardId ->
+        }?.associate { shardId ->
             val task = runningShardTasks.getOrElse(shardId) {
                 startReplicationTask(ShardReplicationParams(leaderAlias, ShardId(leaderIndex, shardId.id), shardId))
             }
             return@associate shardId to task
-        }
+        }.orEmpty()
 
         return tasks
     }
@@ -865,9 +865,9 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     This can happen if there was a badly timed cluster manager node failure.""".trimIndent())
             }
         } else if (restore.state() == RestoreInProgress.State.FAILURE) {
-            val failureReason = restore.shards().values().find {
-                it.value.state() == RestoreInProgress.State.FAILURE
-            }!!.value.reason()
+            val failureReason = restore.shards().values.find {
+                it.state() == RestoreInProgress.State.FAILURE
+            }!!.reason()
             return FailedState(Collections.emptyMap(), failureReason)
         } else {
             return InitFollowState

--- a/src/test/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicyTests.kt
+++ b/src/test/kotlin/org/opensearch/index/translog/ReplicationTranslogDeletionPolicyTests.kt
@@ -28,8 +28,8 @@ import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.OpenOption
 import java.nio.file.Path
-import java.util.*
 import java.util.function.Supplier
+import java.util.LinkedList
 
 
 class ReplicationTranslogDeletionPolicyTests : OpenSearchTestCase() {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -228,7 +228,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
 
         settings = Settings.builder()
@@ -243,7 +243,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                     "checksum",
                     followerClient.indices()
                             .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
+                            .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.shard.check_on_startup"]
             )
         }, 30L, TimeUnit.SECONDS)
     }
@@ -273,7 +273,7 @@ class SecurityCustomRolesIT: SecurityBase()  {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put("index.shard.check_on_startup", "checksum")

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityCustomRolesIT.kt
@@ -29,11 +29,11 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.test.OpenSearchTestCase
 import org.junit.Assert
 import org.junit.Assume
-import java.util.*
 import java.util.concurrent.TimeUnit
 import org.opensearch.replication.task.autofollow.AutoFollowExecutor
 import org.opensearch.tasks.TaskInfo
 import org.junit.Before
+import java.util.Locale
 
 @MultiClusterAnnotations.ClusterConfigurations(
         MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER),

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/SecurityDlsFlsIT.kt
@@ -128,7 +128,7 @@ class SecurityDlsFlsIT: SecurityBase() {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put("index.shard.check_on_startup", "checksum")

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -74,8 +74,8 @@ import org.opensearch.replication.followerStats
 import org.opensearch.replication.leaderStats
 import org.opensearch.replication.updateReplicationStartBlockSetting
 import java.nio.file.Files
-import java.util.*
 import java.util.concurrent.TimeUnit
+import java.util.Locale
 import org.opensearch.bootstrap.BootstrapInfo
 
 

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -130,7 +130,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                     "3",
                     followerClient.indices()
                             .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                            .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                            .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
         }, 15, TimeUnit.SECONDS)
     }
@@ -289,7 +289,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "0",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
         }, 30L, TimeUnit.SECONDS)
     }
@@ -448,7 +448,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "0",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
@@ -469,14 +469,14 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "2",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
             assertEqualAliases()
         }, 30L, TimeUnit.SECONDS)
         // Case 2 :  Blocklisted  setting are not copied
         Assert.assertNull(followerClient.indices()
                 .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                .indexToSettings[followerIndexName].get("index.routing.allocation.enable"))
+                .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY).get("index.routing.allocation.enable"))
         //Alias test case 2: Update existing alias
         aliasAction = IndicesAliasesRequest.AliasActions.add()
                 .index(leaderIndexName)
@@ -500,19 +500,19 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "3",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
             )
             Assert.assertEquals(
                 "10s",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.search.idle.after"]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.search.idle.after"]
             )
             Assert.assertEquals(
                 "none",
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.routing.allocation.enable"]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.routing.allocation.enable"]
             )
             assertEqualAliases()
         }, 30L, TimeUnit.SECONDS)
@@ -539,7 +539,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 null,
                 followerClient.indices()
                     .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                    .indexToSettings[followerIndexName]["index.search.idle.after"]
+                    .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.search.idle.after"]
             )
             assertEqualAliases()
         }, 30L, TimeUnit.SECONDS)
@@ -568,7 +568,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "1",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
         )
         settings = Settings.builder()
                 .put("index.shard.check_on_startup", "checksum")
@@ -579,7 +579,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                 "checksum",
                 followerClient.indices()
                         .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                        .indexToSettings[followerIndexName]["index.shard.check_on_startup"]
+                        .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)["index.shard.check_on_startup"]
         )
     }
 
@@ -1138,7 +1138,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                         "2",
                         leaderClient.indices()
                                 .getSettings(getLeaderSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                                .indexToSettings.getOrDefault(leaderIndexName, Settings.EMPTY)[IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
                 )
             }, 15, TimeUnit.SECONDS)
 
@@ -1198,7 +1198,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                         "2",
                         leaderClient.indices()
                                 .getSettings(getLeaderSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                                .indexToSettings.getOrDefault(leaderIndexName, Settings.EMPTY)[IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
                 )
             }, 15, TimeUnit.SECONDS)
 
@@ -1250,7 +1250,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
                         "2",
                         followerClient.indices()
                                 .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[followerIndexName][IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
+                                .indexToSettings.getOrDefault(followerIndexName, Settings.EMPTY)[IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey()]
                 )
             }, 15, TimeUnit.SECONDS)
         } finally {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -177,7 +177,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                         "3",
                         followerClient.indices()
                                 .getSettings(getSettingsRequest, RequestOptions.DEFAULT)
-                                .indexToSettings[leaderIndexName][IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
+                                .indexToSettings.getOrDefault(leaderIndexName, Settings.EMPTY)[IndexMetadata.SETTING_NUMBER_OF_REPLICAS]
                 )
                 followerClient.waitForShardTaskStart(leaderIndexName, waitForShardTask)
             }, 15, TimeUnit.SECONDS)

--- a/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
@@ -58,8 +58,8 @@ import org.opensearch.test.ClusterServiceUtils
 import org.opensearch.test.ClusterServiceUtils.setState
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.threadpool.TestThreadPool
-import java.util.*
 import java.util.concurrent.TimeUnit
+import java.util.Collections
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 class IndexReplicationTaskTests : OpenSearchTestCase()  {

--- a/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
@@ -30,7 +30,6 @@ import org.opensearch.action.get.GetResponse
 import org.opensearch.action.support.master.AcknowledgedResponse
 import org.opensearch.common.UUIDs
 import org.opensearch.common.bytes.BytesReference
-import org.opensearch.common.collect.ImmutableOpenMap
 import org.opensearch.common.settings.Settings
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentFactory
@@ -55,8 +54,7 @@ import org.opensearch.snapshots.RestoreInfo
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.test.client.NoOpNodeClient
 import java.lang.reflect.Field
-import java.util.ArrayList
-import java.util.HashMap
+import java.util.*
 
 open class NoOpClient(testName :String) : NoOpNodeClient(testName) {
     @Override
@@ -109,9 +107,7 @@ open class NoOpClient(testName :String) : NoOpNodeClient(testName) {
 
             val indexToSettings = HashMap<String, Settings>()
             indexToSettings[IndexReplicationTaskTests.followerIndex] =  desiredSettingsBuilder.build()
-
-            val settingsMap = ImmutableOpenMap.builder<String, Settings>().putAll(indexToSettings).build()
-            var settingResponse = GetSettingsResponse(settingsMap, settingsMap)
+            var settingResponse = GetSettingsResponse(indexToSettings, indexToSettings)
             listener.onResponse(settingResponse as Response)
         } else if (action == RecoveryAction.INSTANCE) {
             val shardRecoveryStates: MutableMap<String, List<RecoveryState>> = HashMap()

--- a/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
@@ -54,7 +54,6 @@ import org.opensearch.snapshots.RestoreInfo
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.test.client.NoOpNodeClient
 import java.lang.reflect.Field
-import java.util.*
 
 open class NoOpClient(testName :String) : NoOpNodeClient(testName) {
     @Override


### PR DESCRIPTION
### Description
commit on 2.x https://github.com/opensearch-project/OpenSearch/pull/8316
commit on main https://github.com/opensearch-project/OpenSearch/pull/7309
Fix build failures from upstream changes

    Replaced existing uses of import java.util.* to relevant imports
    Removed uses of ImmutableOpenMap and changed to Map
    Added Null safety


Opensearch removed the remaining uses of ImmutableOpenMap to Map.
the get() of ImmutableOpenMap return non-null empty set however the get() method of Map can return null. To avoid this we changed the uses of get() to getOrDefault() to handle null cases gracefully.


Ref https://github.com/opensearch-project/cross-cluster-replication/pull/814, https://github.com/opensearch-project/cross-cluster-replication/pull/837




 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
