### PR TITLE
Fix test for single node

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -1221,6 +1221,12 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     }
 
     fun `test that wait_for_active_shards setting is updated on follower through start replication api`() {
+
+        //Ignore this test if clusters dont have multiple nodes
+        if(!isMultiNodeClusterConfiguration){
+            return
+        }
+
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
 


### PR DESCRIPTION
### Description
Skip test when single node clusters are used.
wait_for_active_shards setting will not allow the index to close as more than 1 shard will not be active.
This causes the test to fail.


```
{"acknowledged":false,"shards_acknowledged":false,"indices":{"remote-index":{"closed":false,"failedShards":{"0":{"failures":[{"shard":0,"index":"remote-index","status":"SERVICE_UNAVAILABLE","reason":{"type":"unavailable_shards_exception","reason":"[remote-index][0] Not enough active copies to meet shard count of [2] (have 1, needed 2). Timeout: [30s], request: [verify shard [remote-index][0] before close with block 4,RRq3_-4RRi2uSs03x15Odw,index preparing to close. Reopen the index to allow writes again or retry closing the index to fully close the index., blocks WRITE]"}}]}}}}}%
```
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
