### PR TITLE
Consume numNodes sent during integTestRemote

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -931,9 +931,8 @@ task integTestRemote (type: RestIntegTestTask) {
 
         nonInputProperties.systemProperty('tests.integTestRemote', "true")
         var numberOfNodes = findProperty('numNodes') as Integer
-        systemProperty "tests.cluster.followCluster.total_nodes", "${-> _numNodes.toString()}"
-        systemProperty "tests.cluster.leaderCluster.total_nodes", "${-> _numNodes.toString()}"
-        nonInputProperties.systemProperty('tests.numNodes', "${-> numberOfNodes.toString()}")
+        systemProperty "tests.cluster.followCluster.total_nodes", "${-> numberOfNodes.toString()}"
+        systemProperty "tests.cluster.leaderCluster.total_nodes", "${-> numberOfNodes.toString()}"
         systemProperty "build.dir", "${buildDir}"
 
     }

--- a/build.gradle
+++ b/build.gradle
@@ -930,6 +930,10 @@ task integTestRemote (type: RestIntegTestTask) {
         systemProperty "tests.cluster.leaderCluster.security_enabled", System.getProperty("security_enabled")
 
         nonInputProperties.systemProperty('tests.integTestRemote', "true")
+        var numberOfNodes = findProperty('numNodes') as Integer
+        systemProperty "tests.cluster.followCluster.total_nodes", "${-> _numNodes.toString()}"
+        systemProperty "tests.cluster.leaderCluster.total_nodes", "${-> _numNodes.toString()}"
+        nonInputProperties.systemProperty('tests.numNodes', "${-> numberOfNodes.toString()}")
         systemProperty "build.dir", "${buildDir}"
 
     }

--- a/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
@@ -118,7 +118,6 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
         lateinit var testClusters : Map<String, TestCluster>
         var isSecurityPropertyEnabled = false
         var forceInitSecurityConfiguration = false
-        var isMultiNodeClusterConfiguration = true
 
         internal fun createTestCluster(configuration: ClusterConfiguration) : TestCluster {
             return createTestCluster(configuration.clusterName, configuration.preserveSnapshots, configuration.preserveIndices,
@@ -131,7 +130,6 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
             val httpHostsProp = systemProperties.get("tests.cluster.${cluster}.http_hosts") as String?
             val transportHostsProp = systemProperties.get("tests.cluster.${cluster}.transport_hosts") as String?
             val securityEnabled = systemProperties.get("tests.cluster.${cluster}.security_enabled") as String?
-            val totalNodes = systemProperties.get("tests.cluster.${cluster}.total_nodes") as String?
 
             requireNotNull(httpHostsProp) { "Missing http hosts property for cluster: $cluster."}
             requireNotNull(transportHostsProp) { "Missing transport hosts property for cluster: $cluster."}
@@ -143,9 +141,6 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
                 isSecurityPropertyEnabled = true
             }
 
-            if(totalNodes != null && totalNodes < "2") {
-                isMultiNodeClusterConfiguration = false
-            }
 
             forceInitSecurityConfiguration = isSecurityPropertyEnabled && initSecurityConfiguration
 
@@ -662,6 +657,16 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
         val systemProperties = BootstrapInfo.getSystemProperties()
         val integTestRemote = systemProperties.get("tests.integTestRemote") as String?
         return integTestRemote.equals("true")
+    }
+
+    protected fun isMultiNodeClusterConfiguration(leaderCluster: String, followerCluster: String): Boolean{
+        val systemProperties = BootstrapInfo.getSystemProperties()
+        val totalLeaderNodes = systemProperties.get("tests.cluster.${leaderCluster}.total_nodes") as String?
+        val totalFollowerNodes = systemProperties.get("tests.cluster.${followerCluster}.total_nodes") as String?
+        if(totalLeaderNodes != null && totalFollowerNodes !=null && totalLeaderNodes < "2" && totalFollowerNodes < "2" ) {
+            return false
+        }
+        return true
     }
 
     protected fun docCount(cluster: RestHighLevelClient, indexName: String) : Int {

--- a/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
@@ -661,9 +661,12 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
 
     protected fun isMultiNodeClusterConfiguration(leaderCluster: String, followerCluster: String): Boolean{
         val systemProperties = BootstrapInfo.getSystemProperties()
-        val totalLeaderNodes = systemProperties.get("tests.cluster.${leaderCluster}.total_nodes") as String?
-        val totalFollowerNodes = systemProperties.get("tests.cluster.${followerCluster}.total_nodes") as String?
-        if(totalLeaderNodes != null && totalFollowerNodes !=null && totalLeaderNodes < "2" && totalFollowerNodes < "2" ) {
+        val totalLeaderNodes = systemProperties.get("tests.cluster.${leaderCluster}.total_nodes") as String
+        val totalFollowerNodes = systemProperties.get("tests.cluster.${followerCluster}.total_nodes") as String
+
+        assertNotNull(totalLeaderNodes)
+        assertNotNull(totalFollowerNodes)
+        if(totalLeaderNodes < "2" ||  totalFollowerNodes < "2" ) {
             return false
         }
         return true

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteFollowerIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteFollowerIT.kt
@@ -30,7 +30,7 @@ class ClusterRerouteFollowerIT : MultiClusterRestTestCase() {
 
     @Before
     fun beforeTest() {
-        Assume.assumeTrue(isMultiNodeClusterConfiguration)
+        Assume.assumeTrue(isMultiNodeClusterConfiguration(LEADER, FOLLOWER))
     }
 
     fun `test replication works after rerouting a shard from one node to another in follower cluster`() {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteLeaderIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteLeaderIT.kt
@@ -30,7 +30,7 @@ class ClusterRerouteLeaderIT : MultiClusterRestTestCase() {
 
     @Before
     fun beforeTest() {
-        Assume.assumeTrue(isMultiNodeClusterConfiguration)
+        Assume.assumeTrue(isMultiNodeClusterConfiguration(LEADER, FOLLOWER))
     }
 
     fun `test replication works after rerouting a shard from one node to another in leader cluster`() {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -1223,7 +1223,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     fun `test that wait_for_active_shards setting is updated on follower through start replication api`() {
 
         //Ignore this test if clusters dont have multiple nodes
-        if(!isMultiNodeClusterConfiguration){
+        if(!isMultiNodeClusterConfiguration(LEADER, FOLLOWER)){
             return
         }
 


### PR DESCRIPTION
### Description
numNodes parameter was not getting consumed by the integTestRemote gradle task.
numNodes param is used to set `isMultiNodeClusterConfiguration` which is used to skip tests like reroute.

This change allows numNodes param to be used.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
