### PR TITLE
Change use of XContentType.fromMediaType to MediaType.fromMediaType

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -25,7 +25,7 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.core.xcontent.DeprecationHandler
 import org.opensearch.core.xcontent.NamedXContentRegistry
-import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.xcontent.MediaType
 import org.opensearch.test.OpenSearchTestCase.assertBusy
 import org.opensearch.test.rest.OpenSearchRestTestCase
 import org.junit.Assert
@@ -96,7 +96,7 @@ fun RestHighLevelClient.startReplication(request: StartReplicationRequest,
         waitForNoInitializingShards()
 }
 fun getAckResponse(lowLevelResponse: Response): AcknowledgedResponse {
-    val xContentType = XContentType.fromMediaType(lowLevelResponse.entity.contentType)
+    val xContentType = MediaType.fromMediaType(lowLevelResponse.entity.contentType)
     val xcp = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS,
             lowLevelResponse.entity.content)
     return AcknowledgedResponse.fromXContent(xcp)


### PR DESCRIPTION
### Description
Refactor to use MediaType.fromMediaType due to upstream change https://github.com/opensearch-project/OpenSearch/pull/8636 
 
### Issues Resolved
```

e: file:///Users/msnghgw/main/ccr-dev/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt:99:37 Unresolved reference: fromMediaType

> Task :compileTestKotlin FAILED

FAILURE: Build failed with an exception.

```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
