### PR TITLE
[Backport 2.x ]Fix test for single node and consume numNodes (#1091)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -930,6 +930,9 @@ task integTestRemote (type: RestIntegTestTask) {
         systemProperty "tests.cluster.leaderCluster.security_enabled", System.getProperty("security_enabled")
 
         nonInputProperties.systemProperty('tests.integTestRemote', "true")
+        var numberOfNodes = findProperty('numNodes') as Integer
+        systemProperty "tests.cluster.followCluster.total_nodes", "${-> numberOfNodes.toString()}"
+        systemProperty "tests.cluster.leaderCluster.total_nodes", "${-> numberOfNodes.toString()}"
         systemProperty "build.dir", "${buildDir}"
 
     }

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -55,6 +55,9 @@ const val INDEX_TASK_CANCELLATION_REASON = "AutoPaused: Index replication task w
 const val STATUS_REASON_USER_INITIATED = "User initiated"
 const val STATUS_REASON_SHARD_TASK_CANCELLED = "Shard task killed or cancelled."
 const val STATUS_REASON_INDEX_NOT_FOUND = "no such index"
+const val ANALYZERS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS = "Analysers are not accessible when run on remote clusters."
+const val SNAPSHOTS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS = "Snapshots are not accessible when run on remote clusters."
+const val REROUTE_TESTS_NOT_ELIGIBLE_FOR_SINGLE_NODE_CLUSTER = "Reroute not eligible for single node clusters"
 
 
 fun RestHighLevelClient.startReplication(request: StartReplicationRequest,

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteFollowerIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteFollowerIT.kt
@@ -7,6 +7,7 @@ import org.opensearch.replication.startReplication
 import org.opensearch.replication.stopReplication
 import org.apache.http.entity.ContentType
 import org.apache.http.nio.entity.NStringEntity
+import org.opensearch.replication.REROUTE_TESTS_NOT_ELIGIBLE_FOR_SINGLE_NODE_CLUSTER
 import org.assertj.core.api.Assertions
 import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
@@ -30,7 +31,7 @@ class ClusterRerouteFollowerIT : MultiClusterRestTestCase() {
 
     @Before
     fun beforeTest() {
-        Assume.assumeTrue(isMultiNodeClusterConfiguration)
+        Assume.assumeTrue(REROUTE_TESTS_NOT_ELIGIBLE_FOR_SINGLE_NODE_CLUSTER, isMultiNodeClusterConfiguration(LEADER, FOLLOWER))
     }
 
     fun `test replication works after rerouting a shard from one node to another in follower cluster`() {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteLeaderIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ClusterRerouteLeaderIT.kt
@@ -17,6 +17,7 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Ignore
+import org.opensearch.replication.REROUTE_TESTS_NOT_ELIGIBLE_FOR_SINGLE_NODE_CLUSTER
 import java.util.concurrent.TimeUnit
 
 @MultiClusterAnnotations.ClusterConfigurations(
@@ -30,7 +31,7 @@ class ClusterRerouteLeaderIT : MultiClusterRestTestCase() {
 
     @Before
     fun beforeTest() {
-        Assume.assumeTrue(isMultiNodeClusterConfiguration)
+        Assume.assumeTrue(REROUTE_TESTS_NOT_ELIGIBLE_FOR_SINGLE_NODE_CLUSTER, isMultiNodeClusterConfiguration(LEADER, FOLLOWER),)
     }
 
     fun `test replication works after rerouting a shard from one node to another in leader cluster`() {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/ResumeReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/ResumeReplicationIT.kt
@@ -40,9 +40,10 @@ import org.opensearch.client.indices.GetMappingsRequest
 import org.opensearch.common.io.PathUtils
 import org.opensearch.common.settings.Settings
 import org.junit.Assert
+import org.junit.Assume
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
-import org.opensearch.bootstrap.BootstrapInfo
+import org.opensearch.replication.ANALYZERS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS
 
 @MultiClusterAnnotations.ClusterConfigurations(
         MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER),
@@ -165,9 +166,7 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
 
     fun `test that replication fails to resume when custom analyser is not present in follower`() {
 
-        if(checkifIntegTestRemote()){
-            return;
-        }
+        Assume.assumeFalse(ANALYZERS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS, checkifIntegTestRemote())
 
         val synonyms = javaClass.getResourceAsStream("/analyzers/synonyms.txt")
         val config = PathUtils.get(buildDir, leaderClusterPath, "config")
@@ -202,9 +201,7 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
 
     fun `test that replication resumes when custom analyser is present in follower`() {
 
-        if(checkifIntegTestRemote()){
-            return;
-        }
+        Assume.assumeFalse(ANALYZERS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS, checkifIntegTestRemote())
 
         val synonyms = javaClass.getResourceAsStream("/analyzers/synonyms.txt")
         val config = PathUtils.get(buildDir, leaderClusterPath, "config")
@@ -246,9 +243,7 @@ class ResumeReplicationIT: MultiClusterRestTestCase() {
 
     fun `test that replication resumes when custom analyser is overridden and present in follower`() {
 
-        if(checkifIntegTestRemote()){
-            return;
-        }
+        Assume.assumeFalse(ANALYZERS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS, checkifIntegTestRemote())
 
         val synonyms = javaClass.getResourceAsStream("/analyzers/synonyms.txt")
         val config = PathUtils.get(buildDir, leaderClusterPath, "config")

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StopReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StopReplicationIT.kt
@@ -24,6 +24,7 @@ import org.apache.http.util.EntityUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Assert
+import org.junit.Assume
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest
@@ -40,6 +41,7 @@ import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.index.mapper.MapperService
+import org.opensearch.replication.SNAPSHOTS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS
 import java.util.Random
 import java.util.concurrent.TimeUnit
 
@@ -243,9 +245,7 @@ class StopReplicationIT: MultiClusterRestTestCase() {
 
     fun `test stop replication with stale replication settings at leader cluster`() {
 
-        if(checkifIntegTestRemote()){
-            return;
-        }
+        Assume.assumeFalse(SNAPSHOTS_NOT_ACCESSIBLE_FOR_REMOTE_CLUSTERS, checkifIntegTestRemote())
         
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)


### PR DESCRIPTION
### Description
backport https://github.com/opensearch-project/cross-cluster-replication/pull/1091 to 2.x branch.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
