### PR TITLE
Revert "Add setting to use document replication for system indices. (…

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadataStore.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadataStore.kt
@@ -40,7 +40,6 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentParser
-import org.opensearch.indices.replication.common.ReplicationType
 import org.opensearch.replication.util.suspendExecuteWithRetries
 
 class ReplicationMetadataStore constructor(val client: Client, val clusterService: ClusterService,
@@ -266,7 +265,6 @@ class ReplicationMetadataStore constructor(val client: Client, val clusterServic
                 .put(IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.key, "0-1")
                 .put(IndexMetadata.INDEX_PRIORITY_SETTING.key, Int.MAX_VALUE)
                 .put(IndexMetadata.INDEX_HIDDEN_SETTING.key, true)
-                .put(IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.key, ReplicationType.DOCUMENT) // System Indices should use Document Replication strategy
                 .build()
     }
 


### PR DESCRIPTION
…#802)"

This reverts commit 55b6968af90d739d8448c5d88ed5204a240d0f86.

Reverting https://github.com/opensearch-project/cross-cluster-replication/pull/802 to remove document replication enforcement.

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
