### PR TITLE
Implement abstract methods of Repository

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -107,6 +107,14 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         return restoreRateLimitingTimeInNanos.count()
     }
 
+    override fun getRemoteUploadThrottleTimeInNanos(): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRemoteDownloadThrottleTimeInNanos(): Long {
+        TODO("Not yet implemented")
+    }
+
     override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
                                   snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
                                   stateTransformer: Function<ClusterState, ClusterState>?,

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -108,11 +108,11 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
     }
 
     override fun getRemoteUploadThrottleTimeInNanos(): Long {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException("Operation not permitted")
     }
 
     override fun getRemoteDownloadThrottleTimeInNanos(): Long {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException("Operation not permitted")
     }
 
     override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,


### PR DESCRIPTION
### Description



Current builds failing
```
e: file:///Users/user/main/ccr-dev/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt:82:1 Class 'RemoteClusterRepository' is not abstract and does not implement abstract member public abstract fun getRemoteUploadThrottleTimeInNanos(): Long defined in org.opensearch.repositories.Repository
```

Implemented abstract methods
getRemoteUploadThrottleTimeInNanos
getRemoteDownloadThrottleTimeInNanos


caused by https://github.com/opensearch-project/OpenSearch/commit/334b15a0910ad7d0e3e0b3defc30cd037ca5a5e1#diff-15dd2c1859d8b3091b1b702af9c5bbdd680224671444870daf9f392d4e838fa1R201
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
