### PR TITLE
Removed timeout excessive logging in case of index is idle in replication

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/util/Extensions.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/Extensions.kt
@@ -137,10 +137,10 @@ suspend fun <Req: ActionRequest, Resp: ActionResponse> Client.suspendExecuteWith
                 throw ReplicationException(e, RestStatus.TOO_MANY_REQUESTS)
             }
         }
-        log.warn(
-            "Encountered a failure while executing in $req. Retrying in ${currentBackoff / 1000} seconds" +
-                    ".", retryException
-        )
+//        log.warn(
+//            "Encountered a failure while executing in $req. Retrying in ${currentBackoff / 1000} seconds" +
+//                    ".", retryException
+//        )
         delay(currentBackoff)
         currentBackoff = (currentBackoff * factor).toLong().coerceAtMost(maxTimeOut)
 

--- a/src/main/kotlin/org/opensearch/replication/util/Extensions.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/Extensions.kt
@@ -137,10 +137,6 @@ suspend fun <Req: ActionRequest, Resp: ActionResponse> Client.suspendExecuteWith
                 throw ReplicationException(e, RestStatus.TOO_MANY_REQUESTS)
             }
         }
-//        log.warn(
-//            "Encountered a failure while executing in $req. Retrying in ${currentBackoff / 1000} seconds" +
-//                    ".", retryException
-//        )
         delay(currentBackoff)
         currentBackoff = (currentBackoff * factor).toLong().coerceAtMost(maxTimeOut)
 


### PR DESCRIPTION

### Description
Relevant exceptions(5xx) are retried under the common module and during this time whole stack trace is logged under "WARN".
For certain operations, this can create excessive logging and creates noise.
Removed this log.warn message
 
### Issues Resolved
Resolved #267 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
