### PR TITLE
Correct error message when field are not passed when starting replication

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexRequest.kt
@@ -102,7 +102,6 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
         if (!this::followerIndex.isInitialized){
             missingFields.add("follower_index")
         }
-        missingFields.add("follower_index")
         if(missingFields.isNotEmpty()){
             validationException.addValidationError("Mandatory params $missingFields are missing for the request")
             return validationException

--- a/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexRequest.kt
@@ -92,10 +92,20 @@ class ReplicateIndexRequest : AcknowledgedRequest<ReplicateIndexRequest>, Indice
     override fun validate(): ActionRequestValidationException? {
 
         var validationException = ActionRequestValidationException()
-        if (!this::leaderAlias.isInitialized ||
-            !this::leaderIndex.isInitialized ||
-            !this::followerIndex.isInitialized) {
-            validationException.addValidationError("Mandatory params are missing for the request")
+        val missingFields: MutableList<String> = mutableListOf()
+        if (!this::leaderAlias.isInitialized){
+            missingFields.add("leader_alias")
+        }
+        if(!this::leaderIndex.isInitialized){
+            missingFields.add("leader_index")
+        }
+        if (!this::followerIndex.isInitialized){
+            missingFields.add("follower_index")
+        }
+        missingFields.add("follower_index")
+        if(missingFields.isNotEmpty()){
+            validationException.addValidationError("Mandatory params $missingFields are missing for the request")
+            return validationException
         }
 
         validateName(leaderIndex, validationException)


### PR DESCRIPTION
### Description
When replication is started an an important param is missed the Exception is directly returned to the user like 
```
{"_index":"fruit-1","_id":"1","_version":5,"result":"updated","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}{
  "error" : {
    "root_cause" : [
      {
        "type" : "uninitialized_property_access_exception",
        "reason" : "lateinit property leaderIndex has not been initialized"
      }
    ],
    "type" : "uninitialized_property_access_exception",
    "reason" : "lateinit property leaderIndex has not been initialized"
  },
  "status" : 500
}
```

The fix will list down the params that are missing and return useful message to the user.
```
{"_index":"fruit-1","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}{
  "error" : {
    "root_cause" : [
      {
        "type" : "action_request_validation_exception",
        "reason" : "Validation Failed: 1: Mandatory params [leader_index, follower_index] are missing for the request;"
      }
    ],
    "type" : "action_request_validation_exception",
    "reason" : "Validation Failed: 1: Mandatory params [leader_index, leader_alias] are missing for the request;"
  },
  "status" : 400
}
```

 
### Issues Resolved
(https://github.com/opensearch-project/cross-cluster-replication/issues/320)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
