### PR TITLE
Ignoring update of final type settings in updateSettings function

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -461,7 +461,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                             continue
                         }
                         val setting = indexScopedSettings[key]
-                        if (!setting.isPrivateIndex) {
+                        if (!setting.isPrivateIndex && !setting.isFinal) {
                             desiredSettingsBuilder.copy(key, settings);
                         }
                     }
@@ -473,7 +473,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     if (desiredSettings.get(key) != followerSettings.get(key)) {
                         //Not intended setting on follower side.
                         val setting = indexScopedSettings[key]
-                        if (indexScopedSettings.isPrivateSetting(key)) {
+                        if (indexScopedSettings.isPrivateSetting(key) || setting.isFinal) {
                             continue
                         }
                         if (!setting.isDynamic()) {
@@ -486,7 +486,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
                 for (key in followerSettings.keySet()) {
                     val setting = indexScopedSettings[key]
-                    if (setting == null || setting.isPrivateIndex) {
+                    if (setting == null || setting.isPrivateIndex || setting.isFinal) {
                         continue
                     }
 


### PR DESCRIPTION
### Description
Ignoring all the final settings to copy from leader to follower as those settings won't be able to apply as those are not updatable.
 
### Issues Resolved
[(https://github.com/opensearch-project/cross-cluster-replication/issues/1300)]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
