### PR TITLE
Corrects the usage of admin credentials in integTest task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        System.setProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "myStrongPassword123!")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
@@ -430,7 +429,7 @@ def configureCluster(OpenSearchCluster cluster, Boolean securityEnabled) {
         }
         CrossClusterWaitForHttpResource wait = new CrossClusterWaitForHttpResource(protocol, cluster.getFirstNode().getHttpSocketURI(), cluster.nodes.size())
         wait.setUsername("admin")
-        wait.setPassword(System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD"))
+        wait.setPassword("admin")
         return wait.wait(500)
     }
 

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -74,12 +74,14 @@ IFS='.' read -ra version_array <<< "$OPENSEARCH_VERSION"
 
 if [ -z "$CREDENTIAL" ]
 then
+  CREDENTIAL="admin:admin"
   # Starting in 2.12.0, security demo configuration script requires an initial admin password
+  # That same password must be supplied here, else 401 Unauthorized may be seen when running this task
   if (( ${version_array[0]} > 2 || (${version_array[0]} == 2 && ${version_array[1]} >= 12) )); then
-    CREDENTIAL="admin:myStrongPassword123!"
-  else
-    CREDENTIAL="admin:admin"
-  fi
+    if [ "$SECURITY_ENABLED" == true]; then
+      CREDENTIAL="admin:myStrongPassword123!"
+      echo "A password is required to execute the integTest. This must the same as the password used to setup admin user."
+    fi
 fi
 
 USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`


### PR DESCRIPTION
### Description
Some changes introduced in https://github.com/opensearch-project/cross-cluster-replication/pull/1298 are incorrect as the CCR repo doesn't use `install_demo_configuration.sh` tool to [setup security config](https://github.com/opensearch-project/cross-cluster-replication/blob/main/build.gradle#L544-L574) in its CI runs. Hence, the credentials are reverted to admin:admin. 
The documentation changes from that PR are left unchanged since they don't relate with `integTest` task.
 
### Issues Resolved
- Resolves #1310 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
