### PR TITLE
Updates integTest behavior to accept the version and set the password accordingly, and force HTTP1 policy for local clusters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        System.setProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "myStrongPassword123!")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
@@ -429,7 +428,7 @@ def configureCluster(OpenSearchCluster cluster, Boolean securityEnabled) {
         }
         CrossClusterWaitForHttpResource wait = new CrossClusterWaitForHttpResource(protocol, cluster.getFirstNode().getHttpSocketURI(), cluster.nodes.size())
         wait.setUsername("admin")
-        wait.setPassword(System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD"))
+        wait.setPassword("admin")
         return wait.wait(500)
     }
 

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -75,8 +75,11 @@ OPENSEARCH_REQUIRED_VERSION="2.12.0"
 if [ -z "$CREDENTIAL" ]
 then
   # Starting in 2.12.0, security demo configuration script requires an initial admin password
-  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-  if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
+  # Pick the minimum of two versions
+  VERSION_TO_COMPARE=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+  # Check if the compared version is not equal to the required version.
+  # If it is not equal, it means the current version is older.
+  if [ "$VERSION_TO_COMPARE" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
     CREDENTIAL="admin:admin"
   else
     CREDENTIAL="admin:myStrongPassword123!"

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -70,9 +70,17 @@ then
   SECURITY_ENABLED="true"
 fi
 
+OPENSEARCH_REQUIRED_VERSION="2.12.0"
+
 if [ -z "$CREDENTIAL" ]
 then
-  CREDENTIAL="admin:admin" # CCR uses custom setup and hence doesn't require custom password
+  # Starting in 2.12.0, security demo configuration script requires an initial admin password
+  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+  if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
+    CREDENTIAL="admin:admin"
+  else
+    CREDENTIAL="admin:myStrongPassword123!"
+  fi
 fi
 
 USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -70,17 +70,9 @@ then
   SECURITY_ENABLED="true"
 fi
 
-OPENSEARCH_REQUIRED_VERSION="2.12.0"
-
 if [ -z "$CREDENTIAL" ]
 then
-  # Starting in 2.12.0, security demo configuration script requires an initial admin password
-  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-  if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
-    CREDENTIAL="admin:admin"
-  else
-    CREDENTIAL="admin:myStrongPassword123!"
-  fi
+  CREDENTIAL="admin:admin" # CCR uses custom setup and hence doesn't require custom password
 fi
 
 USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -50,7 +50,7 @@ while getopts ":h:b:p:t:e:s:c:v:" arg; do
             CREDENTIAL=$OPTARG
             ;;
         v)
-            # Do nothing as we're not consuming this param.
+            OPENSEARCH_VERSION=$OPTARG
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -70,15 +70,16 @@ then
   SECURITY_ENABLED="true"
 fi
 
-IFS='.' read -ra version_array <<< "$OPENSEARCH_VERSION"
+OPENSEARCH_REQUIRED_VERSION="2.12.0"
 
 if [ -z "$CREDENTIAL" ]
 then
   # Starting in 2.12.0, security demo configuration script requires an initial admin password
-  if (( ${version_array[0]} > 2 || (${version_array[0]} == 2 && ${version_array[1]} >= 12) )); then
-    CREDENTIAL="admin:myStrongPassword123!"
-  else
+  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+  if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
     CREDENTIAL="admin:admin"
+  else
+    CREDENTIAL="admin:myStrongPassword123!"
   fi
 fi
 

--- a/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/replication/MultiClusterRestTestCase.kt
@@ -27,6 +27,7 @@ import org.apache.hc.core5.http.message.BasicHeader
 import org.apache.hc.core5.http.io.entity.StringEntity
 import org.apache.hc.core5.ssl.SSLContexts
 import org.apache.hc.core5.http.io.entity.EntityUtils
+import org.apache.hc.core5.http2.HttpVersionPolicy
 import org.apache.hc.core5.util.Timeout
 import org.apache.lucene.util.SetOnce
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest
@@ -102,6 +103,7 @@ abstract class MultiClusterRestTestCase : OpenSearchTestCase() {
 
             val builder = RestClient.builder(*httpHosts.toTypedArray()).setHttpClientConfigCallback { httpAsyncClientBuilder ->
                 httpAsyncClientBuilder.setConnectionManager(connManager)
+                httpAsyncClientBuilder.setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1)
             }
             configureClient(builder, getClusterSettings(clusterName), securityEnabled)
             builder.setStrictDeprecationMode(false)


### PR DESCRIPTION
### Description
integtest.sh run by opensearch-build passes `-v` to supply opensearch version however it was not being consumed on CCR side. This PR consumes that version to conditionally set the password correctly and fixes:
```
2024-02-05 13:17:41 INFO     /tmp/tmpp1sdta5m/cross-cluster-replication/scripts/integtest.sh: line 78: ((: > 2 || ( == 2 &&  >= 12) : syntax error: operand expected (error token is "> 2 || ( == 2 &&  >= 12) ")
```
https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/integ-test/runs/7592/nodes/98/steps/579/log/?start=0
 
### Issues Resolved
- related to https://github.com/opensearch-project/cross-cluster-replication/issues/1317
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
