### PR TITLE
[Backport 2.x] Updates integTest behavior to accept the version and set the password accordingly and removes admin:admin reference from the Handbook

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -66,7 +66,7 @@ plugins.security.nodes_dn_dynamic_config_enabled: true
 Allow connections from follower cluster on the leader as follows
 
 ```bash
-curl -k -u admin:admin -XPUT "https://${LEADER}/_plugins/_security/api/nodesdn/follower" \
+curl -k -u admin:<admin password> -XPUT "https://${LEADER}/_plugins/_security/api/nodesdn/follower" \
 -H 'Content-type: application/json' \
 -d'{"nodes_dn": ["CN=follower.example.com"]}'
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        System.setProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "myStrongPassword123!")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "2.12.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
@@ -430,7 +429,7 @@ def configureCluster(OpenSearchCluster cluster, Boolean securityEnabled) {
         }
         CrossClusterWaitForHttpResource wait = new CrossClusterWaitForHttpResource(protocol, cluster.getFirstNode().getHttpSocketURI(), cluster.nodes.size())
         wait.setUsername("admin")
-        wait.setPassword(System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD"))
+        wait.setPassword("admin")
         return wait.wait(500)
     }
 
@@ -683,7 +682,6 @@ clusters.each { name ->
             if (securityEnabled) {
                 plugin(provider(securityPluginOld))
                 cliSetup("opensearch-security/install_demo_configuration.sh", "-y")
-
             }
             // Currently fetching the ARCHIVE distribution fails on mac as it tries to fetch the Mac specific "DARWIN" distribution
             // for Opensearch which is not publish yet. Changing this to INTEG_TEST to make it work on mac.

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
+        System.setProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "myStrongPassword123!")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "2.12.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
@@ -429,7 +430,7 @@ def configureCluster(OpenSearchCluster cluster, Boolean securityEnabled) {
         }
         CrossClusterWaitForHttpResource wait = new CrossClusterWaitForHttpResource(protocol, cluster.getFirstNode().getHttpSocketURI(), cluster.nodes.size())
         wait.setUsername("admin")
-        wait.setPassword("admin")
+        wait.setPassword(System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD"))
         return wait.wait(500)
     }
 
@@ -682,6 +683,7 @@ clusters.each { name ->
             if (securityEnabled) {
                 plugin(provider(securityPluginOld))
                 cliSetup("opensearch-security/install_demo_configuration.sh", "-y")
+
             }
             // Currently fetching the ARCHIVE distribution fails on mac as it tries to fetch the Mac specific "DARWIN" distribution
             // for Opensearch which is not publish yet. Changing this to INTEG_TEST to make it work on mac.

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -70,9 +70,16 @@ then
   SECURITY_ENABLED="true"
 fi
 
+IFS='.' read -ra version_array <<< "$OPENSEARCH_VERSION"
+
 if [ -z "$CREDENTIAL" ]
 then
-  CREDENTIAL="admin:admin"
+  # Starting in 2.12.0, security demo configuration script requires an initial admin password
+  if (( ${version_array[0]} > 2 || (${version_array[0]} == 2 && ${version_array[1]} >= 12) )); then
+    CREDENTIAL="admin:myStrongPassword123!"
+  else
+    CREDENTIAL="admin:admin"
+  fi
 fi
 
 USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -50,7 +50,7 @@ while getopts ":h:b:p:t:e:s:c:v:" arg; do
             CREDENTIAL=$OPTARG
             ;;
         v)
-            # Do nothing as we're not consuming this param.
+            OPENSEARCH_VERSION=$OPTARG
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -70,15 +70,19 @@ then
   SECURITY_ENABLED="true"
 fi
 
-IFS='.' read -ra version_array <<< "$OPENSEARCH_VERSION"
+OPENSEARCH_REQUIRED_VERSION="2.12.0"
 
 if [ -z "$CREDENTIAL" ]
 then
   # Starting in 2.12.0, security demo configuration script requires an initial admin password
-  if (( ${version_array[0]} > 2 || (${version_array[0]} == 2 && ${version_array[1]} >= 12) )); then
-    CREDENTIAL="admin:myStrongPassword123!"
-  else
+  # Pick the minimum of two versions
+  VERSION_TO_COMPARE=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+  # Check if the compared version is not equal to the required version.
+  # If it is not equal, it means the current version is older.
+  if [ "$VERSION_TO_COMPARE" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
     CREDENTIAL="admin:admin"
+  else
+    CREDENTIAL="admin:myStrongPassword123!"
   fi
 fi
 


### PR DESCRIPTION
Backports https://github.com/opensearch-project/cross-cluster-replication/commit/3ea239b5b308b8c053511fb2da79ac37f12b2340 from https://github.com/opensearch-project/cross-cluster-replication/pull/1298

Backports d703887f88f24c444e0513ebeca21e30b93354f8 from #1318 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
