### PR TITLE
Fix for CVE-2023-50570(Bumping up to latest version of ipaddress library)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.jetbrains:annotations:13.0"
-    implementation "com.github.seancfoley:ipaddress:5.4.0"
+    implementation "com.github.seancfoley:ipaddress:5.4.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0" // Moving away from kotlin_version
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation "org.apache.httpcomponents.client5:httpclient5:5.1.3"


### PR DESCRIPTION
### Description
Bumping up to latest version of ipaddress library to fix CVE-2023-50570 mentioned below
 
### Issues Resolved
Fixes this CVE (https://nvd.nist.gov/vuln/detail/CVE-2023-50570)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
