### PR TITLE
Fix for CVE-2023-50570(Bumping up to latest version of ipaddress library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile "org.jetbrains:annotations:13.0"
-    compile "com.github.seancfoley:ipaddress:5.3.3"
+    compile "com.github.seancfoley:ipaddress:5.4.1"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5"
     compile "org.opensearch:common-utils:${common_utils_version}"
 


### PR DESCRIPTION
### Description
Bumping up to latest version of ipaddress library to fix https://github.com/advisories/GHSA-qphf-w3cq-jpmx mentioned below
 
### Issues Resolved
Fixes this CVE (https://nvd.nist.gov/vuln/detail/CVE-2023-50570)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
