### PR TITLE
Update Lucene snapshot location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ buildscript {
         mavenCentral()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/" }
+        maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
     }
 
     dependencies {
@@ -161,7 +161,7 @@ repositories {
     mavenCentral()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     maven { url "https://plugins.gradle.org/m2/" }
-    maven { url "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/" }
+    maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
 }
 
 compileKotlin {


### PR DESCRIPTION
### Description
Update Lucene snapshot location to https://artifacts.opensearch.org/snapshots/lucene/

This will prevent builds to fail between file deletion and re-upload when snapshots are updated.
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/1308

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
