### PR TITLE
Fix to handle the exception for deletion of non-existing autofollow replication rule 

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
@@ -123,6 +123,7 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
         } catch(e: ResourceNotFoundException) {
             // Log warn as the task is already removed
             log.warn("Task already stopped for '$clusterAlias:$patternName'", e)
+            throw OpenSearchException("Autofollow replication rule $clusterAlias:$patternName does not exist")
         } catch (e: Exception) {
            log.error("Failed to stop auto follow task for cluster '$clusterAlias:$patternName'", e)
             throw OpenSearchException(AUTOFOLLOW_EXCEPTION_GENERIC_STRING)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -294,6 +294,22 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             .hasMessageContaining(errorMsg)
     }
 
+    fun `test deletion of auto follow pattern`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+        followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
+        //Delete a replication rule which does not exist
+        Assertions.assertThatThrownBy {
+            followerClient.deleteAutoFollowPattern(connectionAlias, "dummy_conn")
+        }.isInstanceOf(ResponseException::class.java)
+                .hasMessageContaining("does not exist")
+        //Delete a replication rule which exists
+        Assertions.assertThatCode {
+            followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+        }.doesNotThrowAnyException()
+
+    }
+
     fun `test removing autofollow pattern stop autofollow task`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)


### PR DESCRIPTION
### Description
This PR handles the exception for deletion of any non-existing replication rule. 

Earlier behaviour: 

If any replication rule is tried to be deleted before creation of the first replication rule, it throws ResourceNotFoundException.

ex:

Directly delete the autofollow replication rule before creation of any autofollow rule.

```
curl -Method DELETE -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Type' = 'application/json'} -body '{"leader_alias":"leader", "name": "dummy"}'

curl : { "error" : { "root_cause" : [ { "type" : "resource_not_found_exception", "reason" : "Metadata for leader:dummy doesn't exist" } ],     
"type" : "resource_not_found_exception", "reason" : "Metadata for leader:dummy doesn't exist" }, "status" : 404 } 
```

Now, create a new replication rule 'A' and try to delete replication rule 'B'. Here we could see that there is a successful response in deleting a non-existing replication rule.

```
curl -Method POST -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Typ
e' = 'application/json'} -body '{"leader_alias":"leader", "name": "test", "pattern": "test-*"}'                   

StatusCode        : 200
StatusDescription : OK
Content           : {
                      "acknowledged" : true
                    }

curl -Method DELETE -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-T
ype' = 'application/json'} -body '{"leader_alias":"leader", "name": "dummy"}'                             


StatusCode        : 200
StatusDescription : OK
Content           : {
                      "acknowledged" : true
                    }
```

 Behaviour now: 
 
 Deletion of any non existing replication rule. 
 
 ```
curl -Method DELETE -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-T
ype' = 'application/json'} -body '{"leader_alias":"leader", "name": "test"}'       
curl : { "error" : { "root_cause" : [ { "type" : "exception", "reason" : "Autofollow replication rule :leader:test does not exist" } ], "type" : "exception", 
"reason" : "Autofollow replication rule :leader:test does not exist" }, "status" : 500 }

```
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/1370
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
