### PR TITLE
Added validations for indexPattern in autofollow API

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
@@ -14,6 +14,7 @@ package org.opensearch.replication.action.autofollow
 import org.opensearch.replication.action.index.ReplicateIndexRequest
 import org.opensearch.replication.metadata.store.KEY_SETTINGS
 import org.opensearch.replication.util.ValidationUtil.validateName
+import org.opensearch.replication.util.ValidationUtil.validatePattern
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.support.master.AcknowledgedRequest
 import org.opensearch.core.ParseField
@@ -113,8 +114,11 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
             if(pattern != null) {
                 validationException.addValidationError("Unexpected pattern")
             }
-        } else if(pattern == null) {
-            validationException.addValidationError("Missing pattern")
+        } else {
+            if(pattern == null)
+               validationException.addValidationError("Missing pattern")
+            else
+               validatePattern(pattern, validationException)
         }
 
         return if(validationException.validationErrors().isEmpty()) return null else validationException

--- a/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
@@ -122,6 +122,7 @@ object ValidationUtil {
 
         if ((pattern?.startsWith('_') ?: false) || (pattern?.startsWith('-') ?: false))
             validationException.addValidationError("Autofollow pattern: $pattern must not start with '_' or '-'")
+
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
@@ -106,6 +106,25 @@ object ValidationUtil {
     }
 
     /**
+     * Validate the pattern against the rules that we have for indexPattern name.
+     */
+
+    fun validatePattern(pattern: String?, validationException: ValidationException) {
+
+        if (!Strings.validFileNameExcludingAstrix(pattern))
+            validationException.addValidationError("Autofollow pattern: $pattern must not contain the following characters ${Strings.INVALID_FILENAME_CHARS}")
+
+        if (pattern.isNullOrEmpty() == true)
+            validationException.addValidationError("Autofollow pattern: $pattern must not be empty")
+
+        if ((pattern?.contains("#") ?: false)|| (pattern?.contains(":") ?: false))
+            validationException.addValidationError("Autofollow pattern: $pattern must not contain '#' or ':'")
+
+        if ((pattern?.startsWith('_') ?: false) || (pattern?.startsWith('-') ?: false))
+            validationException.addValidationError("Autofollow pattern: $pattern must not start with '_' or '-'")
+    }
+
+    /**
      * validate leader index version for compatibility
      * If on higher version - Replication will not be allowed
      *  - Upgrade path - Upgrade Follower cluster to higher version


### PR DESCRIPTION
### Description

Opening a new PR since old PR got closed by mistake. 

This PR adds validations for the indexPattern configured in autofollow API
 
 Existing behavior of the autofollow API with invalid indexPattern: 
 
```
  curl -Method POST -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Typ
e' = 'application/json'} -body '{"leader_alias":"leader", "name": "test", "pattern": "test/abcd"}'                   


StatusCode        : 200
StatusDescription : OK
Content           : {
                      "acknowledged" : true
                    }
```


 
 Behaviour after adding validations on indexPattern: 
 
```
curl -Method POST -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Typ
e' = 'application/json'} -body '{"leader_alias":"leader_sanjay", "name": "test", "pattern": "test/adfas"}'

curl : { "error" : { "root_cause" : [ { "type" : "action_request_validation_exception", "reason" : "Validation Failed: 1: Autofollow pattern: 
test/adfas must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?];" } ], "type" : "action_request_validation_exception", 
"reason" : "Validation Failed: 1: Autofollow pattern: test/adfas must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?];" },    
"status" : 400 }
```

 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/1034
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
