### PR TITLE
Fixing integTestRemote for windows setup

### DIFF
--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -103,24 +103,48 @@ then
     exit 1
   fi
 
-  data=$(python3 -c "import json; cluster=$ENDPOINT_LIST ; data_nodes=cluster; print(data_nodes[0][\"data_nodes\"][0][\"endpoint\"],':',data_nodes[0][\"data_nodes\"][0][\"port\"],':',data_nodes[0][\"data_nodes\"][0][\"transport\"],',',data_nodes[1][\"data_nodes\"][0][\"endpoint\"],':',data_nodes[1][\"data_nodes\"][0][\"port\"],':',data_nodes[1][\"data_nodes\"][0][\"transport\"])" | tr -d "[:blank:]")
+  extract_values() {
+      local cluster_name="$1"
+      local field="$2"
 
+      echo "$ENDPOINT_LIST" | awk -v cluster="$cluster_name" -v field="$field" '
+          BEGIN { RS=","; FS=":" }
+          $1 ~ "\"cluster_name\"" && $2 ~ "\"" cluster "\"" {
+              while (getline) {
+                  if ($1 ~ "\"" field "\"") {
+                      gsub(/"/, "", $2)
+                      gsub(/ /, "", $2)
+                      print $2
+                      exit
+                  }
+              }
+          }
+      ' | tr -d '{}'
+  }
 
-  leader=$(echo  $data | cut -d ',' -f1 | cut -d ':' -f1,2 )
-  follower=$(echo $data  |  cut -d ',' -f2 | cut -d ':' -f1,2 )
-  echo "leader: $leader"
-  echo "follower: $follower"
-  
+  # Extract values for leader cluster
+  leader_endpoint=$(extract_values "leader" "endpoint")
+  leader_port=$(extract_values "leader" "port")
+  leader_transport=$(extract_values "leader" "transport")
+
+  # Extract values for follower cluster
+  follower_endpoint=$(extract_values "follower" "endpoint")
+  follower_port=$(extract_values "follower" "port")
+  follower_transport=$(extract_values "follower" "transport")
+
+  # Print extracted data
+  echo "Leader Endpoint: $leader_endpoint"
+  echo "Leader Port: $leader_port"
+  echo "Leader Transport: $leader_transport"
+  echo "Follower Endpoint: $follower_endpoint"
+  echo "Follower Port: $follower_port"
+  echo "Follower Transport: $follower_transport"
+
   # Get number of nodes, assuming both leader and follower have same number of nodes
-  numNodes=$((${follower##*:} - ${leader##*:}))
+  numNodes=$((${follower_port} - ${leader_port}))
   echo "numNodes: $numNodes"
-  
-  LTRANSPORT_PORT=$(echo  $data | cut -d ',' -f1 | cut -d ':' -f1,3 )
-  FTRANSPORT_PORT=$(echo $data  |  cut -d ',' -f2 | cut -d ':' -f1,3 )
-  echo "LTRANSPORT_PORT: $LTRANSPORT_PORT"
-  echo "FTRANSPORT_PORT: $FTRANSPORT_PORT"
-  
-  eval "./gradlew integTestRemote -Dleader.http_host=\"$leader\" -Dfollower.http_host=\"$follower\" -Dfollower.transport_host=\"$FTRANSPORT_PORT\"  -Dleader.transport_host=\"$LTRANSPORT_PORT\"  -Dsecurity_enabled=\"$SECURITY_ENABLED\" -Duser=\"$USERNAME\" -Dpassword=\"$PASSWORD\" -PnumNodes=$numNodes --console=plain "
+  echo './gradlew integTestRemote -Dleader.http_host='"$leader_endpoint:$leader_port"' -Dfollower.http_host='"$follower_endpoint:$follower_port"' -Dfollower.transport_host='"$follower_endpoint:$follower_transport"'  -Dleader.transport_host='"$leader_endpoint:$leader_transport"'  -Dsecurity_enabled='"$SECURITY_ENABLED"' -Duser='"$USERNAME"' -Dpassword='"$PASSWORD"' -PnumNodes='"$numNodes"' --console=plain'
+  ./gradlew integTestRemote -Dleader.http_host=$leader_endpoint:$leader_port -Dfollower.http_host=$follower_endpoint:$follower_port -Dfollower.transport_host=$follower_endpoint:$follower_transport  -Dleader.transport_host=$leader_endpoint:$leader_transport  -Dsecurity_enabled=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD -PnumNodes=$numNodes --console=plain
 
 else
   # Single cluster


### PR DESCRIPTION
### Description
bash script is failing due to python dependency on windows which ran by opensearch-build package at the time of version release.
 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/1361
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
