### PR TITLE
Handle exception for the updation of a replication rule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -528,7 +528,7 @@ integTest {
         }
     }
     filter {
-        setExcludePatterns("org.opensearch.replication.integ.rest.StartReplicationIT.test operations are fetched from lucene when leader is in mixed mode")
+        setExcludePatterns("org.opensearch.replication.bwc.BackwardsCompatibilityIT","org.opensearch.replication.singleCluster.SingleClusterSanityIT","org.opensearch.replication.integ.rest.StartReplicationIT.test operations are fetched from lucene when leader is in mixed mode")
     }
     systemProperty "build.dir", "${buildDir}"
     systemProperty "java.security.policy", "file://${projectDir}/src/test/resources/plugin-security.policy"

--- a/build.gradle
+++ b/build.gradle
@@ -527,7 +527,9 @@ integTest {
             }
         }
     }
-
+    filter {
+        setExcludePatterns("org.opensearch.replication.integ.rest.StartReplicationIT.test operations are fetched from lucene when leader is in mixed mode")
+    }
     systemProperty "build.dir", "${buildDir}"
     systemProperty "java.security.policy", "file://${projectDir}/src/test/resources/plugin-security.policy"
     finalizedBy jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -527,9 +527,7 @@ integTest {
             }
         }
     }
-    filter {
-        setExcludePatterns("org.opensearch.replication.bwc.BackwardsCompatibilityIT","org.opensearch.replication.singleCluster.SingleClusterSanityIT","org.opensearch.replication.integ.rest.StartReplicationIT.test operations are fetched from lucene when leader is in mixed mode")
-    }
+
     systemProperty "build.dir", "${buildDir}"
     systemProperty "java.security.policy", "file://${projectDir}/src/test/resources/plugin-security.policy"
     finalizedBy jacocoTestReport

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
@@ -111,6 +111,7 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
         } catch(e: ResourceAlreadyExistsException) {
             // Log and bail as task is already running
             log.warn("Task already started for '$clusterAlias:$patternName'", e)
+            throw OpenSearchException("Exisiting autofollow replication rule cannot be recreated/updated", e)
         } catch (e: Exception) {
             log.error("Failed to start auto follow task for cluster '$clusterAlias:$patternName'", e)
             throw OpenSearchException(AUTOFOLLOW_EXCEPTION_GENERIC_STRING)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -115,7 +115,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         try {
             // Set poll duration to 30sec from 60sec (default)
             val settings = Settings.builder().put(ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL.key,
-                    TimeValue.timeValueSeconds(30))
+                TimeValue.timeValueSeconds(30))
             val clusterUpdateSetttingsReq = ClusterUpdateSettingsRequest().persistentSettings(settings)
             val clusterUpdateResponse = followerClient.cluster().putSettings(clusterUpdateSetttingsReq, RequestOptions.DEFAULT)
             var lastExecutionTime = 0L
@@ -138,12 +138,12 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
                 }
             }, 30, TimeUnit.SECONDS)
             assertBusy({
-                var af_stats = stats.get("autofollow_stats")!! as ArrayList<HashMap<String, Any>>
-                for (key in af_stats) {
-                    if(key["name"] == indexPatternName) {
-                        Assertions.assertThat(key["last_execution_time"]!! as Long).isNotEqualTo(lastExecutionTime)
-                    }
+            var af_stats = stats.get("autofollow_stats")!! as ArrayList<HashMap<String, Any>>
+            for (key in af_stats) {
+                if(key["name"] == indexPatternName) {
+                    Assertions.assertThat(key["last_execution_time"]!! as Long).isNotEqualTo(lastExecutionTime)
                 }
+            }
             }, 40, TimeUnit.SECONDS)
         } finally {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
@@ -263,35 +263,35 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
         assertPatternNameValidation(followerClient, "testPattern",
-                "Value testPattern must be lowercase")
+            "Value testPattern must be lowercase")
         assertPatternNameValidation(followerClient, "testPattern*",
-                "Value testPattern* must not contain the following characters")
+            "Value testPattern* must not contain the following characters")
         assertPatternNameValidation(followerClient, "test#",
-                "Value test# must not contain '#' or ':'")
+            "Value test# must not contain '#' or ':'")
         assertPatternNameValidation(followerClient, "test:",
-                "Value test: must not contain '#' or ':'")
+            "Value test: must not contain '#' or ':'")
         assertPatternNameValidation(followerClient, ".",
-                "Value . must not be '.' or '..'")
+            "Value . must not be '.' or '..'")
         assertPatternNameValidation(followerClient, "..",
-                "Value .. must not be '.' or '..'")
+            "Value .. must not be '.' or '..'")
         assertPatternNameValidation(followerClient, "_leader",
-                "Value _leader must not start with '_' or '-' or '+'")
+            "Value _leader must not start with '_' or '-' or '+'")
         assertPatternNameValidation(followerClient, "-leader",
-                "Value -leader must not start with '_' or '-' or '+'")
+            "Value -leader must not start with '_' or '-' or '+'")
         assertPatternNameValidation(followerClient, "+leader",
-                "Value +leader must not start with '_' or '-' or '+'")
+            "Value +leader must not start with '_' or '-' or '+'")
         assertPatternNameValidation(followerClient, longIndexPatternName,
-                "Value $longIndexPatternName must not be longer than ${MetadataCreateIndexService.MAX_INDEX_NAME_BYTES} bytes")
+            "Value $longIndexPatternName must not be longer than ${MetadataCreateIndexService.MAX_INDEX_NAME_BYTES} bytes")
         assertPatternNameValidation(followerClient, ".leaderIndex",
-                "Value .leaderIndex must not start with '.'")
+            "Value .leaderIndex must not start with '.'")
     }
 
     private fun assertPatternNameValidation(followerClient: RestHighLevelClient, patternName: String,
-                                            errorMsg: String) {
+        errorMsg: String) {
         Assertions.assertThatThrownBy {
             followerClient.updateAutoFollowPattern(connectionAlias, patternName, indexPattern)
         }.isInstanceOf(ResponseException::class.java)
-                .hasMessageContaining(errorMsg)
+            .hasMessageContaining(errorMsg)
     }
 
     fun `test deletion of auto follow pattern`() {
@@ -418,13 +418,13 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             // Verify that existing index matching the pattern are replicated.
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(leaderIndexName1), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
+                    .exists(GetIndexRequest(leaderIndexName1), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
             }
             assertBusy {
                 Assertions.assertThat(followerClient.indices()
-                        .exists(GetIndexRequest(leaderIndexName2), RequestOptions.DEFAULT))
-                        .isEqualTo(true)
+                    .exists(GetIndexRequest(leaderIndexName2), RequestOptions.DEFAULT))
+                    .isEqualTo(true)
             }
             sleep(30000) // Default poll for auto follow in worst case
             Assertions.assertThat(getAutoFollowTasks(FOLLOWER).size).isEqualTo(1)


### PR DESCRIPTION
### Description
This PR handles the exception handling for updation of a replication rule. 

**Earlier behavior:** 

**First hit of the replication rule:** 
```
curl -Method POST -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Type' = 'application/json'} -body '{"leader_alias":"leader", "name": "test3", "
pattern":"test*"}'


StatusCode        : 200
StatusDescription : OK
Content           : {
                      "acknowledged" : true
                    }

```
**Second hit of the same Replication rule:** 
```
curl -Method POST -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Type' = 'application/json'} -body '{"leader_alias":"leader", "name": "test3", "
pattern":"test*"}'


StatusCode        : 200
StatusDescription : OK
Content           : {
                      "acknowledged" : true
                    }

```



**New behavior: 
First hit of the replication rule:** 
```
curl -Method POST -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Type' = 'application/json'} -body '{"leader_alias":"leader", "name": "test3", "
pattern":"test*"}'


StatusCode        : 200
StatusDescription : OK
Content           : {
                      "acknowledged" : true
                    }

```
**Second hit of the Replication rule:** 
```
curl -Method POST -Uri "http://localhost:9201/_plugins/_replication/_autofollow?pretty"  -H @{'Content-Type' = 'application/json'} -body '{"leader_alias":"leader", "name": "test3", "
pattern":"log*"}' 

curl : { "error" : { "root_cause" : [ { "type" : "resource_already_exists_exception", "reason" : "task with id {autofollow:leader:test3} already exist" } ], "type" : "exception", "reason" : "Exisiting Autofollow replication     
    rule cannot be updated", "caused_by" : { "type" : "resource_already_exists_exception", "reason" : "task with id {autofollow:leader:test3} already exist" } }, "status" : 500 }
```

 
### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/1394
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
