### PR TITLE
[Remote Store] Updating remote-migration IT with correct setting name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -380,8 +380,6 @@ testClusters {
             testDistribution = "ARCHIVE"
         }
         int debugPort = 5005
-        //adding it to test migration
-        systemProperty('opensearch.experimental.feature.remote_store.migration.enabled','true')
 
         if (_numNodes > 1) numberOfNodes = _numNodes
         //numberOfNodes = 3
@@ -940,8 +938,7 @@ task integTestRemote (type: RestIntegTestTask) {
 
     }
     filter {
-            setExcludePatterns("org.opensearch.replication.bwc.BackwardsCompatibilityIT","org.opensearch.replication.singleCluster.SingleClusterSanityIT",
-                    "org.opensearch.replication.integ.rest.StartReplicationIT.test operations are fetched from lucene when leader is in mixed mode")
+            setExcludePatterns("org.opensearch.replication.bwc.BackwardsCompatibilityIT","org.opensearch.replication.singleCluster.SingleClusterSanityIT")
     }
 }
 

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -1278,8 +1278,8 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         val entityAsString = """
                         {
                           "persistent": {
-                             "remote_store.compatibility_mode": "mixed",
-                             "migration.direction" : "remote_store"
+                             "cluster.remote_store.compatibility_mode": "mixed",
+                             "cluster.migration.direction" : "remote_store"
                           }
                         }""".trimMargin()
 


### PR DESCRIPTION
### Description
Modified cluster setting name in IT `test operations are fetched from lucene when leader is in mixed mode`.  This is modified as part of  [PR](https://github.com/opensearch-project/OpenSearch/pull/14100). We also don't need feature flag now to enable migration.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] ~New functionality includes testing.~
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
