### PR TITLE
[Backport 2.x] Handle exception for the updation of a replication rule

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
@@ -111,6 +111,7 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
         } catch(e: ResourceAlreadyExistsException) {
             // Log and bail as task is already running
             log.warn("Task already started for '$clusterAlias:$patternName'", e)
+            throw OpenSearchException("Exisiting autofollow replication rule cannot be recreated/updated", e)
         } catch (e: Exception) {
             log.error("Failed to start auto follow task for cluster '$clusterAlias:$patternName'", e)
             throw OpenSearchException(AUTOFOLLOW_EXCEPTION_GENERIC_STRING)


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/cross-cluster-replication/commit/2da20341107bfe707487d93d271df70aed31356d from https://github.com/opensearch-project/cross-cluster-replication/pull/1405

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
