### PR TITLE
[Backport 2.x] Added validations for indexPattern in autofollow API

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
@@ -14,6 +14,7 @@ package org.opensearch.replication.action.autofollow
 import org.opensearch.replication.action.index.ReplicateIndexRequest
 import org.opensearch.replication.metadata.store.KEY_SETTINGS
 import org.opensearch.replication.util.ValidationUtil.validateName
+import org.opensearch.replication.util.ValidationUtil.validatePattern
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.support.master.AcknowledgedRequest
 import org.opensearch.core.ParseField
@@ -113,8 +114,11 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
             if(pattern != null) {
                 validationException.addValidationError("Unexpected pattern")
             }
-        } else if(pattern == null) {
-            validationException.addValidationError("Missing pattern")
+        } else {
+            if(pattern == null)
+                validationException.addValidationError("Missing pattern")
+            else
+                validatePattern(pattern, validationException)
         }
 
         return if(validationException.validationErrors().isEmpty()) return null else validationException

--- a/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
@@ -106,6 +106,26 @@ object ValidationUtil {
     }
 
     /**
+     * Validate the pattern against the rules that we have for indexPattern name.
+     */
+
+    fun validatePattern(pattern: String?, validationException: ValidationException) {
+
+        if (!Strings.validFileNameExcludingAstrix(pattern))
+            validationException.addValidationError("Autofollow pattern: $pattern must not contain the following characters ${Strings.INVALID_FILENAME_CHARS}")
+
+        if (pattern.isNullOrEmpty() == true)
+            validationException.addValidationError("Autofollow pattern: $pattern must not be empty")
+
+        if ((pattern?.contains("#") ?: false)|| (pattern?.contains(":") ?: false))
+            validationException.addValidationError("Autofollow pattern: $pattern must not contain '#' or ':'")
+
+        if ((pattern?.startsWith('_') ?: false) || (pattern?.startsWith('-') ?: false))
+            validationException.addValidationError("Autofollow pattern: $pattern must not start with '_' or '-'")
+
+    }
+
+    /**
      * validate leader index version for compatibility
      * If on higher version - Replication will not be allowed
      *  - Upgrade path - Upgrade Follower cluster to higher version

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -484,6 +484,51 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         return getReplicationTaskList(clusterName, IndexReplicationExecutor.TASK_NAME + "*")
     }
 
+    fun `test auto follow should fail on indexPattern validation failure`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+        assertPatternValidation(followerClient, "testPattern,",
+                "Autofollow pattern: testPattern, must not contain the following characters")
+        assertPatternValidation(followerClient, "testPat?",
+                "Autofollow pattern: testPat? must not contain the following characters")
+        assertPatternValidation(followerClient, "test#",
+                "Autofollow pattern: test# must not contain '#' or ':'")
+        assertPatternValidation(followerClient, "test:",
+                "Autofollow pattern: test: must not contain '#' or ':'")
+        assertPatternValidation(followerClient, "_test",
+                "Autofollow pattern: _test must not start with '_' or '-'")
+        assertPatternValidation(followerClient, "-leader",
+                "Autofollow pattern: -leader must not start with '_' or '-'")
+        assertPatternValidation(followerClient, "",
+                "Autofollow pattern:  must not be empty")
+
+    }
+    private fun assertPatternValidation(followerClient: RestHighLevelClient, pattern: String,
+                                        errorMsg: String) {
+        Assertions.assertThatThrownBy {
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, pattern)
+        }.isInstanceOf(ResponseException::class.java)
+                .hasMessageContaining(errorMsg)
+    }
+
+    fun `test auto follow should succeed on valid indexPatterns`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+        assertValidPatternValidation(followerClient, "test-leader")
+        assertValidPatternValidation(followerClient, "test*")
+        assertValidPatternValidation(followerClient, "leader-*")
+        assertValidPatternValidation(followerClient, "leader_test")
+        assertValidPatternValidation(followerClient, "Leader_Test-*")
+        assertValidPatternValidation(followerClient, "Leader_*")
+
+    }
+
+    private fun assertValidPatternValidation(followerClient: RestHighLevelClient, pattern: String) {
+        Assertions.assertThatCode {
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, pattern)
+        }.doesNotThrowAnyException()
+    }
+
     fun createDummyConnection(fromClusterName: String, connectionName: String="source") {
         val fromCluster = getNamedCluster(fromClusterName)
         val persistentConnectionRequest = Request("PUT", "_cluster/settings")


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/cross-cluster-replication/commit/6022720794ec37f7770d36d7a9909b61ecc056c6 from https://github.com/opensearch-project/cross-cluster-replication/pull/1373

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
