### PR TITLE
Added a override function for finalizeSnapshot

### DIFF
--- a/release-notes/opensearch-cross-cluster-replication.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-cross-cluster-replication.release-notes-2.17.0.0.md
@@ -1,0 +1,6 @@
+## Version 2.17.0.0 Release Notes
+
+Compatible with OpenSearch 2.17.0
+
+### Bug Fixes
+* Updating remote-migration IT with correct setting name ([#1412](https://github.com/opensearch-project/cross-cluster-replication/pull/1412))

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -74,7 +74,7 @@ import java.util.UUID
 import java.util.function.Consumer
 import java.util.function.Function
 import kotlin.collections.ArrayList
-import org.opensearch.common.Priority;
+import org.opensearch.common.Priority
 
 const val REMOTE_REPOSITORY_PREFIX = "replication-remote-repo-"
 const val REMOTE_REPOSITORY_TYPE = "replication-remote-repository"
@@ -117,17 +117,17 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
     }
 
     override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
-    snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
-    stateTransformer: Function<ClusterState, ClusterState>?,
-    listener: ActionListener<RepositoryData>?) {
-    throw UnsupportedOperationException("Operation not permitted")
+                                  snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
+                                  stateTransformer: Function<ClusterState, ClusterState>?,
+                                  listener: ActionListener<RepositoryData>?) {
+        throw UnsupportedOperationException("Operation not permitted")
     }
 
     override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
-    snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
-    stateTransformer: Function<ClusterState, ClusterState>?, repositoryUpdatePriority: Priority,
-    listener: ActionListener<RepositoryData>?) {
-    throw UnsupportedOperationException("Operation not permitted")
+                                  snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
+                                  stateTransformer: Function<ClusterState, ClusterState>?, repositoryUpdatePriority: Priority,
+                                  listener: ActionListener<RepositoryData>?) {
+        throw UnsupportedOperationException("Operation not permitted")
     }
     
     override fun deleteSnapshots(snapshotIds: MutableCollection<SnapshotId>?, repositoryStateId: Long,

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -74,6 +74,7 @@ import java.util.UUID
 import java.util.function.Consumer
 import java.util.function.Function
 import kotlin.collections.ArrayList
+import org.opensearch.common.Priority;
 
 const val REMOTE_REPOSITORY_PREFIX = "replication-remote-repo-"
 const val REMOTE_REPOSITORY_TYPE = "replication-remote-repository"
@@ -116,12 +117,19 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
     }
 
     override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
-                                  snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
-                                  stateTransformer: Function<ClusterState, ClusterState>?,
-                                  listener: ActionListener<RepositoryData>?) {
-        throw UnsupportedOperationException("Operation not permitted")
+    snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
+    stateTransformer: Function<ClusterState, ClusterState>?,
+    listener: ActionListener<RepositoryData>?) {
+    throw UnsupportedOperationException("Operation not permitted")
     }
 
+    override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
+    snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
+    stateTransformer: Function<ClusterState, ClusterState>?, repositoryUpdatePriority: Priority,
+    listener: ActionListener<RepositoryData>?) {
+    throw UnsupportedOperationException("Operation not permitted")
+    }
+    
     override fun deleteSnapshots(snapshotIds: MutableCollection<SnapshotId>?, repositoryStateId: Long,
                                  repositoryMetaVersion: Version?, listener: ActionListener<RepositoryData>?) {
         throw UnsupportedOperationException("Operation not permitted")


### PR DESCRIPTION
### Description
Added an Priority parameter in finalizeSnapshot method in  ( https://github.com/opensearch-project/cross-cluster-replication/blob/2.17/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt )

### Related Issues
CCR Build was getting failed due to change in finalizeSnapshot method in opensearch repo and hence needed to overridden.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
