### PR TITLE
Upgrade the jacoco to 0.8.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC15"
-        classpath "org.jacoco:org.jacoco.agent:0.8.5"
+        classpath "org.jacoco:org.jacoco.agent:0.8.12"
     }
 }
 


### PR DESCRIPTION
### Description
Upgrade the jacoco to 0.8.12 as older version is not compatible with JDK 21

