### PR TITLE
Add support to ignore updates on autofollow pattern

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c 'whoami && java -version && ./gradlew --refresh-dependencies clean release -D"build.snapshot=true"'
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout CCR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build and run Replication tests
         run: |
           ./gradlew --refresh-dependencies clean release -D"build.snapshot=true" -x test -x IntegTest

--- a/.github/workflows/bwc.yml
+++ b/.github/workflows/bwc.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 11
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build and run Replication tests
         run: |
           echo "Running backwards compatibility tests ..."

--- a/.github/workflows/bwc.yml
+++ b/.github/workflows/bwc.yml
@@ -28,7 +28,7 @@ jobs:
           ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -x test -x IntegTest
           ./gradlew fullRestartClusterTask --stacktrace
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -78,7 +78,7 @@ jobs:
           ls -al src/test/resources/security/plugin
           su `id -un 1000` -c "whoami && java -version && ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -Psecurity=true"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs
@@ -122,7 +122,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c 'whoami && java -version && ./gradlew --refresh-dependencies clean release -Dbuild.snapshot=true -PnumNodes=1  -Dtests.class=org.opensearch.replication.BasicReplicationIT   -Dtests.method="test knn index replication"  -Pknn=true'
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - id: plugin-availability-check
         name: "plugin check"
         run: |
@@ -71,7 +71,7 @@ jobs:
           java-version: 17
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build and run Replication tests
         run: |
           chown -R 1000:1000 `pwd`
@@ -116,7 +116,7 @@ jobs:
           java-version: 17
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build and run Replication tests
         run: |
           chown -R 1000:1000 `pwd`

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -523,7 +523,11 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
 
     private fun assertValidPatternValidation(followerClient: RestHighLevelClient, pattern: String) {
         Assertions.assertThatCode {
-            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, pattern)
+            try {
+                followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, pattern)
+            } finally {
+                followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+            }
         }.doesNotThrowAnyException()
     }
 


### PR DESCRIPTION
### Description
- Exception handling was added for Autofollow update in the change below but tests weren't handling it gracefully. Added a flag to ignore ResourceAlreadyExists exception.
- Also updated Github action to use upload-artifact@v4 and checkout action.

### Related Issues
https://github.com/opensearch-project/cross-cluster-replication/issues/1433

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
