### PR TITLE
Set cross-cluster-replication plugin 3.0.0 baseline JDK version to JDK 21

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
   build-test-linux:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [21]
 
     name: Build CCR Plugin on Linux using Container Image
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         java:
-          - 17
+          - 21
         os:
           - windows-latest
           - macos-latest

--- a/.github/workflows/bwc.yml
+++ b/.github/workflows/bwc.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
+      - name: Set Up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 21
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4

--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -65,10 +65,10 @@ jobs:
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4
@@ -110,10 +110,10 @@ jobs:
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The replication machinery is implemented as an OpenSearch plugin that exposes AP
 The project in this package uses the [Gradle](https://docs.gradle.org/current/userguide/userguide.html) build system. Gradle comes with excellent documentation that should be your first stop when trying to figure out how to operate or modify the build.
 
 ### Building from the command line
-Set JAVA_HOME to JDK-11 or above  
+Set JAVA_HOME to JDK-21 or above  
 
 1. `./gradlew build` builds and tests project.
 2. `./gradlew clean release` cleans previous builds, creates new build and tests project.

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ buildscript {
         plugin_previous_version = opensearch_previous_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
-        kotlin_version = System.getProperty("kotlin.version", "1.8.21")
+        kotlin_version = System.getProperty("kotlin.version", "1.9.25")
 
         security_plugin_version = opensearch_build
         if (!isSnapshot) {
@@ -89,6 +89,10 @@ plugins {
 allprojects {
     group = "org.opensearch"
     version = "${opensearch_build}"
+    plugins.withId('org.jetbrains.kotlin.jvm') {
+        compileJava.sourceCompatibility = compileJava.targetCompatibility = JavaVersion.VERSION_21
+        compileTestJava.sourceCompatibility = compileTestJava.targetCompatibility = JavaVersion.VERSION_21
+    }
 }
 
 apply plugin: 'java'
@@ -165,14 +169,14 @@ repositories {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "21"
         freeCompilerArgs = ['-Xjsr305=strict'] // Handle OpenSearch @Nullable annotation correctly
     }
 }
 
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "21"
         freeCompilerArgs = ['-Xjsr305=strict']
     }
 }


### PR DESCRIPTION

### Description
Set cross-cluster-replication plugin 3.0.0 baseline JDK version to JDK 21

### Related Issues
Resolves #1393
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
