### PR TITLE
Adding fix for test knn index replication integ test failure

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
@@ -94,11 +94,14 @@ class BasicReplicationIT : MultiClusterRestTestCase() {
         val leaderIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexNameInitial = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
-        val KNN_INDEX_MAPPING = "{\"settings\":{\"index\":{\"knn\":true}},\"mappings\":{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}}"
+        val settings: Settings = Settings.builder()
+            .put("index.knn", true)
+            .build()
+        val KNN_INDEX_MAPPING = "{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}"
         // create knn-index on leader cluster
         try {
             val createIndexResponse = leaderClient.indices().create(
-                CreateIndexRequest(leaderIndexName)
+                CreateIndexRequest(leaderIndexName).settings(settings)
                     .mapping(KNN_INDEX_MAPPING, XContentType.JSON), RequestOptions.DEFAULT
             )
             assertThat(createIndexResponse.isAcknowledged).isTrue()

--- a/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
@@ -26,6 +26,10 @@ import org.opensearch.client.indices.CreateIndexRequest
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.CheckedRunnable
 import org.opensearch.test.OpenSearchTestCase.assertBusy
+import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.opensearch.index.IndexSettings
+import org.opensearch.common.settings.Settings
 import org.opensearch.client.indices.PutMappingRequest
 import org.junit.Assert
 import java.util.Locale

--- a/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
@@ -94,7 +94,7 @@ class BasicReplicationIT : MultiClusterRestTestCase() {
         val leaderIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexNameInitial = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
-        val KNN_INDEX_MAPPING = "{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}"
+        val KNN_INDEX_MAPPING = "{\"settings\":{\"index\":{\"knn\":true}},\"mappings\":{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}}"
         // create knn-index on leader cluster
         try {
             val createIndexResponse = leaderClient.indices().create(


### PR DESCRIPTION
### Description
Description

Added index level setting for specifying knn index
```
curl -k -X PUT -u 'admin:admin' "http://localhost:9200/mohit-2" -H "Content-Type: application/json" -d '{                                                                                                                        "settings": {
    "index": {
      "knn": true
    }
  },
  "mappings": {
    "properties": {
      "my_vector1": {
        "type": "knn_vector",
        "dimension": 2
      },
      "my_vector2": {
        "type": "knn_vector",
        "dimension": 4
      }
    }
  }
}'
{"acknowledged":true,"shards_acknowledged":true,"index":"mohit-2"}%
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
