### PR TITLE
Version bump to opensearch-3.0.0-alpha1 and replaced usage of deprecated classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
         // e.g. 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'

--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -74,7 +74,7 @@ import org.opensearch.replication.task.shard.ShardReplicationState
 import org.opensearch.replication.util.Injectables
 import org.opensearch.action.ActionRequest
 import org.opensearch.core.action.ActionResponse
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.NamedDiff
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.metadata.Metadata

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/AutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/AutoFollowClusterManagerNodeAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.autofollow
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class AutoFollowClusterManagerNodeAction: ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/AutoFollowClusterManagerNodeRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/AutoFollowClusterManagerNodeRequest.kt
@@ -13,14 +13,14 @@ package org.opensearch.replication.action.autofollow
 
 import org.opensearch.commons.authuser.User
 import org.opensearch.action.ActionRequestValidationException
-import org.opensearch.action.support.master.MasterNodeRequest
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentBuilder
 
-class AutoFollowClusterManagerNodeRequest: MasterNodeRequest<AutoFollowClusterManagerNodeRequest>, ToXContentObject {
+class AutoFollowClusterManagerNodeRequest: ClusterManagerNodeRequest<AutoFollowClusterManagerNodeRequest>, ToXContentObject {
     var user: User? = null
     var autofollowReq: UpdateAutoFollowPatternRequest
     var withSecurityContext: Boolean = false

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
@@ -30,9 +30,9 @@ import org.opensearch.ResourceAlreadyExistsException
 import org.opensearch.ResourceNotFoundException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
-import org.opensearch.client.node.NodeClient
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.block.ClusterBlockLevel
@@ -49,7 +49,7 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
                                                               actionFilters: ActionFilters, indexNameExpressionResolver: IndexNameExpressionResolver,
                                                               private val client: NodeClient, private val metadataManager: ReplicationMetadataManager,
                                                               val indexScopedSettings: IndexScopedSettings) :
-        TransportMasterNodeAction<AutoFollowClusterManagerNodeRequest, AcknowledgedResponse>(
+    TransportClusterManagerNodeAction<AutoFollowClusterManagerNodeRequest, AcknowledgedResponse>(
         AutoFollowClusterManagerNodeAction.NAME, true, transportService, clusterService, threadPool, actionFilters,
         ::AutoFollowClusterManagerNodeRequest, indexNameExpressionResolver), CoroutineScope by GlobalScope {
 
@@ -62,7 +62,7 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
     }
 
-    override fun masterOperation(clusterManagerNodeReq: AutoFollowClusterManagerNodeRequest, state: ClusterState, listener: ActionListener<AcknowledgedResponse>) {
+    override fun clusterManagerOperation(clusterManagerNodeReq: AutoFollowClusterManagerNodeRequest, state: ClusterState, listener: ActionListener<AcknowledgedResponse>) {
         val request = clusterManagerNodeReq.autofollowReq
         var user = clusterManagerNodeReq.user
         launch(threadPool.coroutineContext()) {

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportUpdateAutoFollowPatternAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportUpdateAutoFollowPatternAction.kt
@@ -27,8 +27,8 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.client.Client
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.transport.client.Client
 import org.opensearch.common.inject.Inject
 import org.opensearch.tasks.Task
 import org.opensearch.threadpool.ThreadPool

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.autofollow
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class UpdateAutoFollowPatternAction : ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
 

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
@@ -16,7 +16,7 @@ import org.opensearch.replication.metadata.store.KEY_SETTINGS
 import org.opensearch.replication.util.ValidationUtil.validateName
 import org.opensearch.replication.util.ValidationUtil.validatePattern
 import org.opensearch.action.ActionRequestValidationException
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.ParseField
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput

--- a/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexClusterManagerNodeAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.index
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class ReplicateIndexClusterManagerNodeAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexClusterManagerNodeRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexClusterManagerNodeRequest.kt
@@ -13,7 +13,7 @@ package org.opensearch.replication.action.index
 
 import org.opensearch.commons.authuser.User
 import org.opensearch.action.ActionRequestValidationException
-import org.opensearch.action.support.master.MasterNodeRequest
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.xcontent.ToXContent
@@ -21,7 +21,7 @@ import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentBuilder
 
 class ReplicateIndexClusterManagerNodeRequest:
-        MasterNodeRequest<ReplicateIndexClusterManagerNodeRequest>, ToXContentObject {
+    ClusterManagerNodeRequest<ReplicateIndexClusterManagerNodeRequest>, ToXContentObject {
 
     var user: User? = null
     var replicateIndexReq: ReplicateIndexRequest

--- a/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexRequest.kt
@@ -16,7 +16,7 @@ import org.opensearch.replication.util.ValidationUtil.validateName
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.ParseField
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput

--- a/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexResponse.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/ReplicateIndexResponse.kt
@@ -11,7 +11,7 @@
 
 package org.opensearch.replication.action.index
 
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -31,7 +31,7 @@ import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.metadata.MetadataCreateIndexService
 import org.opensearch.common.inject.Inject

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
@@ -30,9 +30,9 @@ import org.opensearch.OpenSearchStatusException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
-import org.opensearch.client.node.NodeClient
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.block.ClusterBlockLevel
@@ -62,7 +62,7 @@ class TransportReplicateIndexClusterManagerNodeAction @Inject constructor(transp
                                                                           private val nodeClient : NodeClient,
                                                                           private val repositoryService: RepositoriesService,
                                                                           private val replicationMetadataManager: ReplicationMetadataManager) :
-        TransportMasterNodeAction<ReplicateIndexClusterManagerNodeRequest, AcknowledgedResponse>(ReplicateIndexClusterManagerNodeAction.NAME,
+    TransportClusterManagerNodeAction<ReplicateIndexClusterManagerNodeRequest, AcknowledgedResponse>(ReplicateIndexClusterManagerNodeAction.NAME,
                 transportService, clusterService, threadPool, actionFilters, ::ReplicateIndexClusterManagerNodeRequest, indexNameExpressionResolver),
         CoroutineScope by GlobalScope {
 
@@ -80,7 +80,7 @@ class TransportReplicateIndexClusterManagerNodeAction @Inject constructor(transp
     }
 
     @Throws(Exception::class)
-    override fun masterOperation(request: ReplicateIndexClusterManagerNodeRequest, state: ClusterState,
+    override fun clusterManagerOperation(request: ReplicateIndexClusterManagerNodeRequest, state: ClusterState,
                                  listener: ActionListener<AcknowledgedResponse>) {
         val replicateIndexReq = request.replicateIndexReq
         val user = request.user

--- a/src/main/kotlin/org/opensearch/replication/action/index/block/TransportUpddateIndexBlockAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/block/TransportUpddateIndexBlockAction.kt
@@ -22,9 +22,9 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
-import org.opensearch.client.Client
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.block.ClusterBlockLevel
@@ -44,7 +44,7 @@ class TransportUpddateIndexBlockAction @Inject constructor(transportService: Tra
                                                            indexNameExpressionResolver:
                                                            IndexNameExpressionResolver,
                                                            val client: Client) :
-        TransportMasterNodeAction<UpdateIndexBlockRequest, AcknowledgedResponse>(UpdateIndexBlockAction.NAME,
+    TransportClusterManagerNodeAction<UpdateIndexBlockRequest, AcknowledgedResponse>(UpdateIndexBlockAction.NAME,
                 transportService, clusterService, threadPool, actionFilters, ::UpdateIndexBlockRequest,
                 indexNameExpressionResolver), CoroutineScope by GlobalScope {
 
@@ -57,7 +57,7 @@ class TransportUpddateIndexBlockAction @Inject constructor(transportService: Tra
     }
 
     @Throws(Exception::class)
-    override fun masterOperation(request: UpdateIndexBlockRequest?, state: ClusterState?, listener: ActionListener<AcknowledgedResponse>) {
+    override fun clusterManagerOperation(request: UpdateIndexBlockRequest?, state: ClusterState?, listener: ActionListener<AcknowledgedResponse>) {
         val followerIndexName = request!!.indexName
         log.debug("Adding index block for $followerIndexName")
         launch(threadPool.coroutineContext(ThreadPool.Names.MANAGEMENT)) {

--- a/src/main/kotlin/org/opensearch/replication/action/index/block/UpdateIndexBlockAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/block/UpdateIndexBlockAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.index.block
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class UpdateIndexBlockAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/index/block/UpdateIndexBlockRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/block/UpdateIndexBlockRequest.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.action.index.block
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.ParseField
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput

--- a/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.pause
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class PauseIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/pause/PauseIndexReplicationRequest.kt
@@ -15,7 +15,7 @@ import org.opensearch.replication.metadata.ReplicationMetadataManager
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.ParseField
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput

--- a/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/pause/TransportPauseIndexReplicationAction.kt
@@ -24,10 +24,9 @@ import org.opensearch.OpenSearchException
 import org.opensearch.ResourceAlreadyExistsException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
-import org.opensearch.action.support.master.AcknowledgedRequest
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
-import org.opensearch.client.Client
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.AckedClusterStateUpdateTask
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.ClusterStateTaskExecutor
@@ -50,7 +49,7 @@ class TransportPauseIndexReplicationAction @Inject constructor(transportService:
                                                                IndexNameExpressionResolver,
                                                                val client: Client,
                                                                val replicationMetadataManager: ReplicationMetadataManager) :
-    TransportMasterNodeAction<PauseIndexReplicationRequest, AcknowledgedResponse> (PauseIndexReplicationAction.NAME,
+    TransportClusterManagerNodeAction<PauseIndexReplicationRequest, AcknowledgedResponse> (PauseIndexReplicationAction.NAME,
             transportService, clusterService, threadPool, actionFilters, ::PauseIndexReplicationRequest,
             indexNameExpressionResolver), CoroutineScope by GlobalScope {
 
@@ -63,7 +62,7 @@ class TransportPauseIndexReplicationAction @Inject constructor(transportService:
     }
 
     @Throws(Exception::class)
-    override fun masterOperation(request: PauseIndexReplicationRequest, state: ClusterState,
+    override fun clusterManagerOperation(request: PauseIndexReplicationRequest, state: ClusterState,
                                  listener: ActionListener<AcknowledgedResponse>) {
         launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
             listener.completeWith {

--- a/src/main/kotlin/org/opensearch/replication/action/replay/TransportReplayChangesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/replay/TransportReplayChangesAction.kt
@@ -33,7 +33,7 @@ import org.opensearch.action.resync.TransportResyncReplicationAction
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.replication.TransportWriteAction
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterStateObserver
 import org.opensearch.cluster.action.index.MappingUpdatedAction
 import org.opensearch.cluster.action.shard.ShardStateAction

--- a/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/TransportUpdateReplicationStateDetails.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/TransportUpdateReplicationStateDetails.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
-import org.opensearch.action.support.master.AcknowledgedRequest
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.ClusterStateTaskExecutor
 import org.opensearch.cluster.block.ClusterBlockException
@@ -39,7 +39,7 @@ class TransportUpdateReplicationStateDetails @Inject constructor(transportServic
                                                                  threadPool: ThreadPool,
                                                                  actionFilters: ActionFilters,
                                                                  indexNameExpressionResolver: IndexNameExpressionResolver) :
-        TransportMasterNodeAction<UpdateReplicationStateDetailsRequest, AcknowledgedResponse>(UpdateReplicationStateAction.NAME,
+    TransportClusterManagerNodeAction<UpdateReplicationStateDetailsRequest, AcknowledgedResponse>(UpdateReplicationStateAction.NAME,
                 transportService, clusterService, threadPool, actionFilters, ::UpdateReplicationStateDetailsRequest, indexNameExpressionResolver),
         CoroutineScope by GlobalScope {
 
@@ -47,7 +47,7 @@ class TransportUpdateReplicationStateDetails @Inject constructor(transportServic
         return state.blocks.globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
     }
 
-    override fun masterOperation(request: UpdateReplicationStateDetailsRequest, state: ClusterState,
+    override fun clusterManagerOperation(request: UpdateReplicationStateDetailsRequest, state: ClusterState,
                                  listener: ActionListener<AcknowledgedResponse>) {
 
         launch(threadPool.coroutineContext(ThreadPool.Names.MANAGEMENT)) {

--- a/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.replicationstatedetails
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class UpdateReplicationStateAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateDetailsRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/replicationstatedetails/UpdateReplicationStateDetailsRequest.kt
@@ -13,7 +13,7 @@ package org.opensearch.replication.action.replicationstatedetails
 
 import org.opensearch.replication.metadata.state.ReplicationStateParams
 import org.opensearch.action.ActionRequestValidationException
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 

--- a/src/main/kotlin/org/opensearch/replication/action/repository/ReleaseLeaderResourcesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/repository/ReleaseLeaderResourcesAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.repository
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class ReleaseLeaderResourcesAction private constructor() : ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse)  {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/repository/TransportReleaseLeaderResourcesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/repository/TransportReleaseLeaderResourcesAction.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.action.repository
 import org.opensearch.replication.repository.RemoteClusterRestoreLeaderService
 import org.apache.logging.log4j.LogManager
 import org.opensearch.action.support.ActionFilters
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.action.support.single.shard.TransportSingleShardAction
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver

--- a/src/main/kotlin/org/opensearch/replication/action/resume/ResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/ResumeIndexReplicationAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.resume
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class ResumeIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/resume/ResumeIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/ResumeIndexReplicationRequest.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.action.resume
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.xcontent.*

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -39,9 +39,9 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
-import org.opensearch.client.Client
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.block.ClusterBlockLevel
@@ -67,7 +67,7 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
                                                                 val client: Client,
                                                                 val replicationMetadataManager: ReplicationMetadataManager,
                                                                 private val environment: Environment) :
-    TransportMasterNodeAction<ResumeIndexReplicationRequest, AcknowledgedResponse> (ResumeIndexReplicationAction.NAME,
+    TransportClusterManagerNodeAction<ResumeIndexReplicationRequest, AcknowledgedResponse> (ResumeIndexReplicationAction.NAME,
             transportService, clusterService, threadPool, actionFilters, ::ResumeIndexReplicationRequest,
             indexNameExpressionResolver), CoroutineScope by GlobalScope {
 
@@ -80,7 +80,7 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
     }
 
     @Throws(Exception::class)
-    override fun masterOperation(request: ResumeIndexReplicationRequest, state: ClusterState,
+    override fun clusterManagerOperation(request: ResumeIndexReplicationRequest, state: ClusterState,
                                  listener: ActionListener<AcknowledgedResponse>) {
         launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
             listener.completeWith {

--- a/src/main/kotlin/org/opensearch/replication/action/setup/SetupChecksAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/setup/SetupChecksAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.setup
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class SetupChecksAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/setup/SetupChecksRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/setup/SetupChecksRequest.kt
@@ -13,7 +13,7 @@ package org.opensearch.replication.action.setup
 
 import org.opensearch.replication.metadata.store.ReplicationContext
 import org.opensearch.action.ActionRequestValidationException
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.xcontent.ToXContent

--- a/src/main/kotlin/org/opensearch/replication/action/setup/TransportSetupChecksAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/setup/TransportSetupChecksAction.kt
@@ -20,8 +20,8 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.action.StepListener
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.client.Client
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.util.concurrent.ThreadContext

--- a/src/main/kotlin/org/opensearch/replication/action/setup/TransportValidatePermissionsAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/setup/TransportValidatePermissionsAction.kt
@@ -16,8 +16,8 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.client.Client
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.transport.client.Client
 import org.opensearch.common.inject.Inject
 import org.opensearch.tasks.Task
 import org.opensearch.threadpool.ThreadPool

--- a/src/main/kotlin/org/opensearch/replication/action/setup/ValidatePermissionsAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/setup/ValidatePermissionsAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.setup
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class ValidatePermissionsAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse){
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/setup/ValidatePermissionsRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/setup/ValidatePermissionsRequest.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.action.setup
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.xcontent.ToXContent

--- a/src/main/kotlin/org/opensearch/replication/action/stats/TransportFollowerStatsAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stats/TransportFollowerStatsAction.kt
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.action.FailedNodeException
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.nodes.TransportNodesAction
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.core.common.io.stream.StreamInput

--- a/src/main/kotlin/org/opensearch/replication/action/stats/TransportLeaderStatsAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stats/TransportLeaderStatsAction.kt
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.LogManager
 import org.opensearch.action.FailedNodeException
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.nodes.TransportNodesAction
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Inject
 import org.opensearch.core.common.io.stream.StreamInput

--- a/src/main/kotlin/org/opensearch/replication/action/status/TransportReplicationStatusAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/status/TransportReplicationStatusAction.kt
@@ -23,7 +23,7 @@ import org.opensearch.ResourceNotFoundException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.HandledTransportAction
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.common.inject.Inject
 import org.opensearch.tasks.Task
 import org.opensearch.threadpool.ThreadPool

--- a/src/main/kotlin/org/opensearch/replication/action/stop/StopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/StopIndexReplicationAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.stop
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class StopIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/stop/StopIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/StopIndexReplicationRequest.kt
@@ -14,8 +14,8 @@ package org.opensearch.replication.action.stop
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedRequest
 import org.opensearch.core.ParseField
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.xcontent.*

--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -36,10 +36,10 @@ import org.opensearch.OpenSearchException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.admin.indices.open.OpenIndexRequest
 import org.opensearch.action.support.ActionFilters
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
-import org.opensearch.client.Client
-import org.opensearch.client.Requests
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
+import org.opensearch.transport.client.Client
+import org.opensearch.transport.client.Requests
 import org.opensearch.cluster.AckedClusterStateUpdateTask
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.RestoreInProgress
@@ -68,7 +68,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                                                               IndexNameExpressionResolver,
                                                               val client: Client,
                                                               val replicationMetadataManager: ReplicationMetadataManager) :
-    TransportMasterNodeAction<StopIndexReplicationRequest, AcknowledgedResponse> (StopIndexReplicationAction.NAME,
+    TransportClusterManagerNodeAction<StopIndexReplicationRequest, AcknowledgedResponse> (StopIndexReplicationAction.NAME,
             transportService, clusterService, threadPool, actionFilters, ::StopIndexReplicationRequest,
             indexNameExpressionResolver), CoroutineScope by GlobalScope {
 
@@ -81,7 +81,7 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
     }
 
     @Throws(Exception::class)
-    override fun masterOperation(request: StopIndexReplicationRequest, state: ClusterState,
+    override fun clusterManagerOperation(request: StopIndexReplicationRequest, state: ClusterState,
                                  listener: ActionListener<AcknowledgedResponse>) {
         launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
             try {

--- a/src/main/kotlin/org/opensearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/update/TransportUpdateIndexReplicationAction.kt
@@ -24,9 +24,9 @@ import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.support.ActionFilters
-import org.opensearch.action.support.master.AcknowledgedResponse
-import org.opensearch.action.support.master.TransportMasterNodeAction
-import org.opensearch.client.Client
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlockException
 import org.opensearch.cluster.block.ClusterBlockLevel
@@ -48,7 +48,7 @@ class TransportUpdateIndexReplicationAction @Inject constructor(transportService
                                                               val indexScopedSettings: IndexScopedSettings,
                                                               val client: Client,
                                                               val replicationMetadataManager: ReplicationMetadataManager) :
-    TransportMasterNodeAction<UpdateIndexReplicationRequest, AcknowledgedResponse> (UpdateIndexReplicationAction.NAME,
+    TransportClusterManagerNodeAction<UpdateIndexReplicationRequest, AcknowledgedResponse> (UpdateIndexReplicationAction.NAME,
             transportService, clusterService, threadPool, actionFilters, ::UpdateIndexReplicationRequest,
             indexNameExpressionResolver), CoroutineScope by GlobalScope {
 
@@ -61,7 +61,7 @@ class TransportUpdateIndexReplicationAction @Inject constructor(transportService
     }
 
     @Throws(Exception::class)
-    override fun masterOperation(request: UpdateIndexReplicationRequest, state: ClusterState,
+    override fun clusterManagerOperation(request: UpdateIndexReplicationRequest, state: ClusterState,
                                  listener: ActionListener<AcknowledgedResponse>) {
         launch(Dispatchers.Unconfined + threadPool.coroutineContext()) {
             listener.completeWith {

--- a/src/main/kotlin/org/opensearch/replication/action/update/UpdateIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/update/UpdateIndexReplicationAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.action.update
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 class UpdateIndexReplicationAction private constructor(): ActionType<AcknowledgedResponse>(NAME, ::AcknowledgedResponse) {
     companion object {

--- a/src/main/kotlin/org/opensearch/replication/action/update/UpdateIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/update/UpdateIndexReplicationRequest.kt
@@ -14,7 +14,7 @@ import org.opensearch.replication.metadata.store.KEY_SETTINGS
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.IndicesRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.ParseField
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput

--- a/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger
 import org.opensearch.OpenSearchException
 import org.opensearch.ResourceNotFoundException
 import org.opensearch.action.DocWriteResponse
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.inject.Singleton
 import org.opensearch.common.settings.Settings

--- a/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/TransportUpdateMetadataAction.kt
@@ -30,7 +30,7 @@ import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.IndicesOptions
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.ack.ClusterStateUpdateResponse
 import org.opensearch.cluster.ack.OpenIndexClusterStateUpdateResponse
@@ -106,7 +106,7 @@ class TransportUpdateMetadataAction @Inject constructor(
                                  listener: ActionListener<AcknowledgedResponse>) {
         val openIndexRequest = request.request as OpenIndexRequest
         val updateRequest = OpenIndexClusterStateUpdateRequest()
-                .ackTimeout(openIndexRequest.timeout()).masterNodeTimeout(openIndexRequest.masterNodeTimeout())
+                .ackTimeout(openIndexRequest.timeout()).clusterManagerNodeTimeout(openIndexRequest.clusterManagerNodeTimeout())
                 .indices(concreteIndices).waitForActiveShards(openIndexRequest.waitForActiveShards())
 
         indexStateService.openIndex(updateRequest, object : ActionListener<OpenIndexClusterStateUpdateResponse> {
@@ -126,7 +126,7 @@ class TransportUpdateMetadataAction @Inject constructor(
         val openIndexRequest = request.request as CloseIndexRequest
         val closeRequest = CloseIndexClusterStateUpdateRequest(task.id)
                 .ackTimeout(openIndexRequest.timeout())
-                .masterNodeTimeout(openIndexRequest.masterNodeTimeout())
+                .clusterManagerNodeTimeout(openIndexRequest.clusterManagerNodeTimeout())
                 .waitForActiveShards(openIndexRequest.waitForActiveShards())
                 .indices(concreteIndices)
 
@@ -186,7 +186,7 @@ class TransportUpdateMetadataAction @Inject constructor(
 
         val updateRequest =
             IndicesAliasesClusterStateUpdateRequest(Collections.unmodifiableList(finalActions))
-                .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
+                .ackTimeout(request.timeout()).clusterManagerNodeTimeout(request.clusterManagerNodeTimeout())
 
         indexAliasService.indicesAliases(
             updateRequest,
@@ -211,7 +211,7 @@ class TransportUpdateMetadataAction @Inject constructor(
             .settings(updateSettingsRequest.settings())
             .setPreserveExisting(updateSettingsRequest.isPreserveExisting)
             .ackTimeout(request.timeout())
-            .masterNodeTimeout(request.masterNodeTimeout())
+            .clusterManagerNodeTimeout(request.clusterManagerNodeTimeout())
 
 
         updateSettingsService.updateSettings(clusterStateUpdateRequest,
@@ -250,7 +250,7 @@ class TransportUpdateMetadataAction @Inject constructor(
     ) {
         val mappingRequest = request.request as PutMappingRequest
         val updateRequest = PutMappingClusterStateUpdateRequest(mappingRequest.source())
-            .ackTimeout(mappingRequest.timeout()).masterNodeTimeout(mappingRequest.masterNodeTimeout())
+            .ackTimeout(mappingRequest.timeout()).clusterManagerNodeTimeout(mappingRequest.clusterManagerNodeTimeout())
             .indices(concreteIndices)
 
         metadataMappingService.putMapping(updateRequest,

--- a/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTask.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.metadata
 import org.opensearch.replication.action.index.block.IndexBlockUpdateType
 import org.opensearch.replication.action.index.block.UpdateIndexBlockRequest
 import org.opensearch.core.action.ActionListener
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.cluster.AckedClusterStateUpdateTask
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.block.ClusterBlock

--- a/src/main/kotlin/org/opensearch/replication/metadata/UpdateMetadataAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/UpdateMetadataAction.kt
@@ -12,7 +12,7 @@
 package org.opensearch.replication.metadata
 
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 
 
 class UpdateMetadataAction private constructor(): ActionType<AcknowledgedResponse>(

--- a/src/main/kotlin/org/opensearch/replication/metadata/UpdateMetadataRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/UpdateMetadataRequest.kt
@@ -17,7 +17,7 @@ import org.opensearch.action.admin.indices.close.CloseIndexRequest
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
 import org.opensearch.action.admin.indices.open.OpenIndexRequest
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
-import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 

--- a/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadataStore.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadataStore.kt
@@ -26,7 +26,7 @@ import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.delete.DeleteResponse
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.index.IndexResponse
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.health.ClusterHealthStatus
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.service.ClusterService

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterMultiChunkTransfer.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterMultiChunkTransfer.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.apache.logging.log4j.Logger
 import org.opensearch.core.action.ActionListener
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.node.DiscoveryNode
 import org.opensearch.core.common.unit.ByteSizeValue
 import org.opensearch.common.util.concurrent.ThreadContext

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -37,7 +37,7 @@ import org.opensearch.action.ActionType
 import org.opensearch.action.admin.indices.stats.IndicesStatsAction
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.ClusterStateUpdateTask
 import org.opensearch.cluster.metadata.IndexMetadata

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRestoreLeaderService.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRestoreLeaderService.kt
@@ -16,7 +16,7 @@ import org.opensearch.replication.seqno.RemoteClusterRetentionLeaseHelper
 import org.opensearch.replication.util.performOp
 import org.opensearch.OpenSearchException
 import org.opensearch.action.support.single.shard.SingleShardRequest
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent
 import org.opensearch.common.inject.Inject
 import org.opensearch.common.inject.Singleton

--- a/src/main/kotlin/org/opensearch/replication/rest/AutoFollowStatsHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/AutoFollowStatsHandler.kt
@@ -1,7 +1,7 @@
 package org.opensearch.replication.rest
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentFactory

--- a/src/main/kotlin/org/opensearch/replication/rest/FollowerStatsHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/FollowerStatsHandler.kt
@@ -1,7 +1,7 @@
 package org.opensearch.replication.rest
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentFactory

--- a/src/main/kotlin/org/opensearch/replication/rest/LeaderStatsHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/LeaderStatsHandler.kt
@@ -1,7 +1,7 @@
 package org.opensearch.replication.rest
 
 import org.apache.logging.log4j.LogManager
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentFactory

--- a/src/main/kotlin/org/opensearch/replication/rest/PauseIndexReplicationHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/PauseIndexReplicationHandler.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.rest
 import org.opensearch.replication.action.pause.PauseIndexReplicationAction
 import org.opensearch.replication.action.pause.PauseIndexReplicationRequest
 import org.apache.logging.log4j.LogManager
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.RestChannel
 import org.opensearch.rest.RestHandler

--- a/src/main/kotlin/org/opensearch/replication/rest/ReplicateIndexHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/ReplicateIndexHandler.kt
@@ -13,7 +13,7 @@ package org.opensearch.replication.rest
 
 import org.opensearch.replication.action.index.ReplicateIndexAction
 import org.opensearch.replication.action.index.ReplicateIndexRequest
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestChannel

--- a/src/main/kotlin/org/opensearch/replication/rest/ReplicationStatusHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/ReplicationStatusHandler.kt
@@ -15,7 +15,7 @@ package org.opensearch.replication.rest
 import org.opensearch.replication.action.status.ReplicationStatusAction
 import org.opensearch.replication.action.status.ShardInfoRequest
 import org.apache.logging.log4j.LogManager
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler

--- a/src/main/kotlin/org/opensearch/replication/rest/ResumeIndexReplicationHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/ResumeIndexReplicationHandler.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.rest
 import org.opensearch.replication.action.resume.ResumeIndexReplicationAction
 import org.opensearch.replication.action.resume.ResumeIndexReplicationRequest
 import org.apache.logging.log4j.LogManager
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.RestChannel
 import org.opensearch.rest.RestHandler

--- a/src/main/kotlin/org/opensearch/replication/rest/StopIndexReplicationHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/StopIndexReplicationHandler.kt
@@ -13,7 +13,7 @@ package org.opensearch.replication.rest
 
 import org.opensearch.replication.action.stop.StopIndexReplicationAction
 import org.opensearch.replication.action.stop.StopIndexReplicationRequest
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.RestChannel
 import org.opensearch.rest.RestHandler

--- a/src/main/kotlin/org/opensearch/replication/rest/UpdateAutoFollowPatternsHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/UpdateAutoFollowPatternsHandler.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.rest
 import org.opensearch.replication.action.autofollow.UpdateAutoFollowPatternAction
 import org.opensearch.replication.action.autofollow.UpdateAutoFollowPatternRequest
 import org.opensearch.OpenSearchStatusException
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
 import org.opensearch.rest.RestHandler

--- a/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt
+++ b/src/main/kotlin/org/opensearch/replication/rest/UpdateIndexHandler.kt
@@ -15,8 +15,8 @@ import org.opensearch.replication.action.update.UpdateIndexReplicationAction
 import org.opensearch.replication.action.update.UpdateIndexReplicationRequest
 import org.opensearch.replication.task.index.IndexReplicationExecutor.Companion.log
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.client.Requests
-import org.opensearch.client.node.NodeClient
+import org.opensearch.transport.client.Requests
+import org.opensearch.transport.client.node.NodeClient
 import org.opensearch.core.common.Strings
 import org.opensearch.rest.BaseRestHandler
 import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
@@ -42,7 +42,7 @@ class UpdateIndexHandler : BaseRestHandler() {
         log.info("Update Setting requested for $followIndex")
         val updateSettingsRequest = Requests.updateSettingsRequest(*Strings.splitStringByCommaToArray(request.param("index")))
         updateSettingsRequest.timeout(request.paramAsTime("timeout", updateSettingsRequest.timeout()))
-        updateSettingsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", updateSettingsRequest.masterNodeTimeout()))
+        updateSettingsRequest.clusterManagerNodeTimeout(request.paramAsTime("master_timeout", updateSettingsRequest.clusterManagerNodeTimeout()))
         updateSettingsRequest.indicesOptions(IndicesOptions.fromRequest(request, updateSettingsRequest.indicesOptions()))
         updateSettingsRequest.fromXContent(request.contentParser())
         val updateIndexReplicationRequest = UpdateIndexReplicationRequest(followIndex, updateSettingsRequest.settings() )

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -14,7 +14,7 @@ package org.opensearch.replication.seqno
 import org.opensearch.replication.util.suspendExecute
 import org.apache.logging.log4j.LogManager
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.metadata.IndexMetadata
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.index.IndexNotFoundException

--- a/src/main/kotlin/org/opensearch/replication/task/CrossClusterReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/CrossClusterReplicationTask.kt
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.Logger
 import org.opensearch.OpenSearchException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.core.action.ActionResponse
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.common.settings.Settings

--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowExecutor.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowExecutor.kt
@@ -13,7 +13,7 @@ package org.opensearch.replication.task.autofollow
 
 import org.opensearch.replication.ReplicationSettings
 import org.opensearch.replication.metadata.ReplicationMetadataManager
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.persistent.AllocatedPersistentTask
 import org.opensearch.persistent.PersistentTaskState

--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -27,7 +27,7 @@ import org.opensearch.OpenSearchException
 import org.opensearch.OpenSearchSecurityException
 import org.opensearch.action.admin.indices.get.GetIndexRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationExecutor.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationExecutor.kt
@@ -18,7 +18,7 @@ import org.opensearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_
 import org.opensearch.replication.metadata.state.getReplicationStateParamsForIndex
 import org.opensearch.replication.util.persistentTasksService
 import org.apache.logging.log4j.LogManager
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.ClusterStateObserver
 import org.opensearch.cluster.service.ClusterService

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -58,8 +58,8 @@ import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest
 import org.opensearch.action.support.IndicesOptions
-import org.opensearch.client.Client
-import org.opensearch.client.Requests
+import org.opensearch.transport.client.Client
+import org.opensearch.transport.client.Requests
 import org.opensearch.cluster.ClusterChangedEvent
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.ClusterStateListener

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationExecutor.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationExecutor.kt
@@ -18,7 +18,7 @@ import org.opensearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_
 import org.opensearch.replication.metadata.state.getReplicationStateParamsForIndex
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchException
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterState
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.persistent.AllocatedPersistentTask

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withContext
 import org.opensearch.OpenSearchException
 import org.opensearch.OpenSearchTimeoutException
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterChangedEvent
 import org.opensearch.cluster.ClusterStateListener
 import org.opensearch.cluster.service.ClusterService

--- a/src/main/kotlin/org/opensearch/replication/task/shard/TranslogSequencer.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/TranslogSequencer.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.OpenSearchException
 import org.opensearch.action.support.TransportActions
 import org.opensearch.common.logging.Loggers

--- a/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/Coroutines.kt
@@ -19,10 +19,10 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.action.ActionRequest
 import org.opensearch.core.action.ActionResponse
 import org.opensearch.action.ActionType
-import org.opensearch.action.support.master.AcknowledgedRequest
-import org.opensearch.action.support.master.MasterNodeRequest
-import org.opensearch.client.Client
-import org.opensearch.client.OpenSearchClient
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest
+import org.opensearch.transport.client.Client
+import org.opensearch.transport.client.OpenSearchClient
 import org.opensearch.cluster.*
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.Priority
@@ -251,7 +251,7 @@ fun ThreadPool.coroutineContext(replicationMetadata: ReplicationMetadata?, actio
 fun ThreadPool.coroutineContext(executorName: String) : CoroutineContext =
     executor(executorName).asCoroutineDispatcher() + coroutineContext()
 
-suspend fun <T : MasterNodeRequest<T>> submitClusterStateUpdateTask(request: AcknowledgedRequest<T>,
+suspend fun <T : ClusterManagerNodeRequest<T>> submitClusterStateUpdateTask(request: AcknowledgedRequest<T>,
                                                                     taskExecutor: ClusterStateTaskExecutor<AcknowledgedRequest<T>>,
                                                                     clusterService: ClusterService,
                                                                     source: String): ClusterState {

--- a/src/main/kotlin/org/opensearch/replication/util/Extensions.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/Extensions.kt
@@ -27,7 +27,7 @@ import org.opensearch.action.ActionType
 import org.opensearch.action.index.IndexRequestBuilder
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.support.TransportActions
-import org.opensearch.client.Client
+import org.opensearch.transport.client.Client
 import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException
 import org.opensearch.index.IndexNotFoundException

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -16,7 +16,7 @@ import org.opensearch.replication.task.shard.ShardReplicationExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response

--- a/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/NoOpClient.kt
@@ -27,7 +27,7 @@ import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsAction
 import org.opensearch.action.get.GetAction
 import org.opensearch.action.get.GetResponse
-import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.common.UUIDs
 import org.opensearch.core.common.bytes.BytesReference
 import org.opensearch.common.settings.Settings


### PR DESCRIPTION
### Description
Updated to opensearch-3.0.0-alpha1 and fixed usage of classes that are refactored/replaced in latest opensearch.

Changes:
- Fixed imports for classes moved from org.opensearch.action.support.master to  org.opensearch.action.support.clustermanager
- Fixed imports for classes moved from org.opensearch.client to org.opensearch.transport.client
- Replaced usage of deprecated classes (MasterNodeRequest, TransportMasterNodeAction) and methods (masterOperation()) etc by their alternatives (ClusterManagerNodeRequest, TransportClusterManagerNodeAction, clusterManagerOperation()).

### Related Issues
Resolves #1503 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
