### PR TITLE
Adding github action in ccr to publish snapshots to maven

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,32 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
+jobs:
+  build-and-publish-snapshots:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 21
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+      - name: publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -980,6 +980,16 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
 }
 
 // updateVersion: Task to auto increment to the next development iteration


### PR DESCRIPTION
### Description
Added a github action to publish plugin snapshots to maven. Followed guidelines as documented [here](https://github.com/opensearch-project/opensearch-plugins/blob/e874ef7c8dd3e81214b167c6ee0164322fbc3c9e/WORKFLOWS.md?plain=1#L112)
As this old https://github.com/opensearch-project/cross-cluster-replication/pull/711 was closed without merging in main branch, trying to make similar changes now.

### Related Issues
Resolves #1508 
<!-- List any other related issues here -->

**Tested by publishing to the local filesystem**

```
ls -l snapshots/org/opensearch/plugin/opensearch-cross-cluster-replication/3.0.0.0-alpha1-SNAPSHOT/  | awk '{print $1, $9}'
total
-rw-r--r-- maven-metadata.xml
-rw-r--r-- maven-metadata.xml.md5
-rw-r--r-- maven-metadata.xml.sha1
-rw-r--r-- maven-metadata.xml.sha256
-rw-r--r-- maven-metadata.xml.sha512
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.pom
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.pom.md5
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.pom.sha1
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.pom.sha256
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.pom.sha512
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.zip
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.zip.md5
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.zip.sha1
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.zip.sha256
-rw-r--r-- opensearch-cross-cluster-replication-3.0.0.0-alpha1-20250228.120739-1.zip.sha512
```



### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
