### PR TITLE
Disabling knn validation checks

### DIFF
--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: logs
+          name: logs-build-${{ matrix.java }}
           path: |
             build/testclusters/integTest-*/logs/*
             build/testclusters/leaderCluster-*/logs/*
@@ -137,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: logs
+          name: logs-knnbuild-${{ matrix.java }}
           path: |
             build/testclusters/integTest-*/logs/*
             build/testclusters/leaderCluster-*/logs/*

--- a/release-notes/opensearch-cross-cluster-replication.release-notes-3.0.0.0-alpha1.md
+++ b/release-notes/opensearch-cross-cluster-replication.release-notes-3.0.0.0-alpha1.md
@@ -1,3 +1,8 @@
 ## Version 3.0.0.0-alpha1 Release Notes
 
 Compatible with OpenSearch 3.0.0.0-alpha1
+
+### Bug Fixes
+* Disabling knn validation checks
+
+

--- a/release-notes/opensearch-cross-cluster-replication.release-notes-3.0.0.0-alpha1.md
+++ b/release-notes/opensearch-cross-cluster-replication.release-notes-3.0.0.0-alpha1.md
@@ -2,7 +2,11 @@
 
 Compatible with OpenSearch 3.0.0.0-alpha1
 
+### Maintenance
+* Version bump to opensearch-3.0.0-alpha1 and replaced usage of deprecated classes
+* Update CCR with gradle 8.10.2 and support JDK23 ([#1496](https://github.com/opensearch-project/cross-cluster-replication/pull/1496))
+
 ### Bug Fixes
-* Disabling knn validation checks
+* Disabling knn validation checks ([#1515](https://github.com/opensearch-project/cross-cluster-replication/pull/1515))
 
 

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexAction.kt
@@ -103,8 +103,9 @@ class TransportReplicateIndexAction @Inject constructor(transportService: Transp
                 if (!leaderSettings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.key, false)) {
                     throw IllegalArgumentException("Cannot Replicate an index where the setting ${IndexSettings.INDEX_SOFT_DELETES_SETTING.key} is disabled")
                 }
-                //Not starting replication if leader index is knn as knn plugin is not installed on follower.
-                ValidationUtil.checkKNNEligibility(getNodesInfoForPlugin(request.leaderAlias), request.leaderIndex)
+
+                // Disabling knn checks as new api call will require us add roles in security index which will be a breaking call.
+//                ValidationUtil.checkKNNEligibility(getNodesInfoForPlugin(request.leaderAlias), request.leaderIndex)
 
                 ValidationUtil.validateIndexSettings(
                     environment,

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -98,15 +98,10 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
                     injectSecurityContext = true
                 )(getSettingsRequest)
 
-                var nodesInfoRequest = NodesInfoRequest().addMetric(NodesInfoRequest.Metric.PLUGINS.metricName())
-                val nodesInfoResponse = remoteClient.suspending(
-                    remoteClient.admin().cluster()::nodesInfo
-                )(nodesInfoRequest)
-
                 val leaderSettings = settingsResponse.indexToSettings.get(params.leaderIndex.name) ?: throw IndexNotFoundException(params.leaderIndex.name)
 
-                /// Not starting replication if leader index is knn as knn plugin is not installed on follower.
-                ValidationUtil.checkKNNEligibility(nodesInfoResponse, params.leaderIndex.name)
+                // Disabling knn checks as new api call will require us add roles in security index which will be a breaking call.
+//                ValidationUtil.checkKNNEligibility(nodesInfoResponse, params.leaderIndex.name)
 
                 ValidationUtil.validateAnalyzerSettings(environment, leaderSettings, replMetdata.settings)
 


### PR DESCRIPTION
### Description
Since knn team removed setting ```knn.plugin.enabled```  for 3.0 release, we can no longer depend on this setting to validate if knn is enabled or not. Making any other call will require us to add a role in security plugin setting, which will be a breaking change.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
