### PR TITLE
feat: change IOContext strategy to DEFAULT 

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/repository/RestoreContext.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RestoreContext.kt
@@ -12,47 +12,47 @@
 package org.opensearch.replication.repository
 
 import org.apache.lucene.index.IndexCommit
-import org.opensearch.replication.util.performOp
 import org.apache.lucene.store.IOContext
 import org.apache.lucene.store.IndexInput
-import org.opensearch.OpenSearchException
 import org.opensearch.common.concurrent.GatedCloseable
-import org.opensearch.index.engine.Engine
 import org.opensearch.index.shard.IndexShard
 import org.opensearch.index.store.Store
 import java.io.Closeable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
-class RestoreContext(val restoreUUID: String,
-                     val shard: IndexShard,
-                     val indexCommitRef: GatedCloseable<IndexCommit>,
-                     val metadataSnapshot: Store.MetadataSnapshot,
-                     val replayOperationsFrom: Long): Closeable {
+class RestoreContext(
+    val restoreUUID: String,
+    val shard: IndexShard,
+    val indexCommitRef: GatedCloseable<IndexCommit>,
+    val metadataSnapshot: Store.MetadataSnapshot,
+    val replayOperationsFrom: Long,
+) : Closeable {
+
+    private val currentFiles = ConcurrentHashMap<String, IndexInput>(INITIAL_FILE_CACHE_CAPACITY)
+
+    private val fileLocks = ConcurrentHashMap<String, ReentrantLock>()
+
+    fun openInput(store: Store, fileName: String): IndexInput {
+        val lock = fileLocks.computeIfAbsent(fileName) { ReentrantLock() }
+
+        lock.withLock {
+            val baseInput = currentFiles.computeIfAbsent(fileName) {
+                store.directory().openInput(fileName, IOContext.DEFAULT)
+            }
+            return baseInput.clone()
+        }
+    }
+
+    override fun close() {
+        currentFiles.values.forEach { it.close() }
+        currentFiles.clear()
+        fileLocks.clear()
+        indexCommitRef.close()
+    }
 
     companion object {
         private const val INITIAL_FILE_CACHE_CAPACITY = 20
     }
-    private val currentFiles = LinkedHashMap<String, IndexInput>(INITIAL_FILE_CACHE_CAPACITY)
-
-    fun openInput(store: Store, fileName: String): IndexInput {
-        var currentIndexInput = currentFiles.getOrDefault(fileName, null)
-        if(currentIndexInput != null) {
-            return currentIndexInput.clone()
-        }
-        store.performOp({
-            currentIndexInput = store.directory().openInput(fileName, IOContext.DEFAULT)
-        })
-
-        currentFiles[fileName] = currentIndexInput!!
-        return currentIndexInput!!.clone()
-    }
-
-    override fun close() {
-        // Close all the open index input obj
-        currentFiles.entries.forEach {
-            it.value.close()
-        }
-        currentFiles.clear()
-        indexCommitRef.close()
-    }
-
 }

--- a/src/main/kotlin/org/opensearch/replication/repository/RestoreContext.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RestoreContext.kt
@@ -39,7 +39,7 @@ class RestoreContext(val restoreUUID: String,
             return currentIndexInput.clone()
         }
         store.performOp({
-            currentIndexInput = store.directory().openInput(fileName, IOContext.READONCE)
+            currentIndexInput = store.directory().openInput(fileName, IOContext.DEFAULT)
         })
 
         currentFiles[fileName] = currentIndexInput!!

--- a/src/test/kotlin/org/opensearch/replication/repository/RestoreContextTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/repository/RestoreContextTests.kt
@@ -1,0 +1,49 @@
+package org.opensearch.replication.repository
+
+import org.apache.lucene.index.IndexCommit
+import org.apache.lucene.store.IOContext
+import org.apache.lucene.store.IndexInput
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.*
+import org.opensearch.common.concurrent.GatedCloseable
+import org.opensearch.index.shard.IndexShard
+import org.opensearch.index.store.Store
+import org.opensearch.test.OpenSearchTestCase
+import java.util.UUID
+
+class RestoreContextTests : OpenSearchTestCase() {
+
+    fun `test openInput returns cloned IndexInput from cache`() {
+        // given
+        val fileName = "test_file"
+
+        val mockShard = mock(IndexShard::class.java)
+        val mockIndexCommit = mock(GatedCloseable::class.java) as GatedCloseable<IndexCommit>
+        val mockStore = mock(Store::class.java)
+        val mockDirectory = mock(org.apache.lucene.store.Directory::class.java)
+        val mockBaseInput = mock(IndexInput::class.java)
+        val mockClonedInput = mock(IndexInput::class.java)
+
+        // when
+        `when`(mockStore.directory()).thenReturn(mockDirectory)
+        `when`(mockDirectory.openInput(eq(fileName), any(IOContext::class.java))).thenReturn(mockBaseInput)
+        `when`(mockBaseInput.clone()).thenReturn(mockClonedInput)
+        val sut = RestoreContext(
+            restoreUUID = UUID.randomUUID().toString(),
+            shard = mockShard,
+            indexCommitRef = mockIndexCommit,
+            metadataSnapshot = Store.MetadataSnapshot.EMPTY,
+            replayOperationsFrom = 0L,
+        )
+
+        val result1 = sut.openInput(mockStore, fileName)
+        val result2 = sut.openInput(mockStore, fileName)
+
+        // then
+        assertSame(mockClonedInput, result1)
+        assertSame(mockClonedInput, result2)
+        verify(mockDirectory, times(1)).openInput(eq(fileName), any(IOContext::class.java))
+        verify(mockBaseInput, times(2)).clone()
+    }
+}


### PR DESCRIPTION
### Description
When using the `READONCE` option in Apache Lucene to read index files via `IndexInput`, it is not suitable for use cases where multiple threads access the file concurrently. This is because `READONCE` is optimized for single-use I/O and assumes the input will be read only once.

Therefore, I have changed it to use the `READ` (or `DEFAULT`) option, which is more appropriate for multi-threaded access scenarios.

### Related Issues
Resolves #1482
Resolves #1465


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
