### PR TITLE
[Backport 2.19]feat: change IOContext strategy to DEFAULT, Use performOp block when opening an IndexInput file

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
@@ -94,11 +94,14 @@ class BasicReplicationIT : MultiClusterRestTestCase() {
         val leaderIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexNameInitial = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
-        val KNN_INDEX_MAPPING = "{\"settings\":{\"index\":{\"knn\":true}},\"mappings\":{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}}"
+        val settings: Settings = Settings.builder()
+            .put("index.knn", true)
+            .build()
+        val KNN_INDEX_MAPPING = "{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}"
         // create knn-index on leader cluster
         try {
             val createIndexResponse = leaderClient.indices().create(
-                CreateIndexRequest(leaderIndexName)
+                CreateIndexRequest(leaderIndexName).settings(settings)
                     .mapping(KNN_INDEX_MAPPING, XContentType.JSON), RequestOptions.DEFAULT
             )
             assertThat(createIndexResponse.isAcknowledged).isTrue()

--- a/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
@@ -26,6 +26,10 @@ import org.opensearch.client.indices.CreateIndexRequest
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.CheckedRunnable
 import org.opensearch.test.OpenSearchTestCase.assertBusy
+import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.opensearch.index.IndexSettings
+import org.opensearch.common.settings.Settings
 import org.opensearch.client.indices.PutMappingRequest
 import org.junit.Assert
 import java.util.Locale

--- a/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/BasicReplicationIT.kt
@@ -94,7 +94,7 @@ class BasicReplicationIT : MultiClusterRestTestCase() {
         val leaderIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexNameInitial = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
         val followerIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT)
-        val KNN_INDEX_MAPPING = "{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}"
+        val KNN_INDEX_MAPPING = "{\"settings\":{\"index\":{\"knn\":true}},\"mappings\":{\"properties\":{\"my_vector1\":{\"type\":\"knn_vector\",\"dimension\":2},\"my_vector2\":{\"type\":\"knn_vector\",\"dimension\":4}}}}"
         // create knn-index on leader cluster
         try {
             val createIndexResponse = leaderClient.indices().create(

--- a/src/test/kotlin/org/opensearch/replication/repository/RestoreContextTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/repository/RestoreContextTests.kt
@@ -1,0 +1,74 @@
+package org.opensearch.replication.repository
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.apache.lucene.index.IndexCommit
+import org.apache.lucene.store.Directory
+import org.apache.lucene.store.IndexInput
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.*
+import org.opensearch.common.concurrent.GatedCloseable
+import org.opensearch.index.shard.IndexShard
+import org.opensearch.index.store.Store
+import org.opensearch.test.OpenSearchTestCase
+import java.util.UUID
+
+class RestoreContextTests : OpenSearchTestCase() {
+
+    fun `test openInput returns cloned IndexInput from cache`() {
+        // given
+        val fileName = "test_file"
+
+        val mockShard = mock<IndexShard>()
+        val mockIndexCommit = mock<GatedCloseable<IndexCommit>>()
+        val mockDirectory = mock<Directory>()
+        val mockBaseInput = mock<IndexInput>()
+        val mockClonedInput = mock<IndexInput>()
+        val mockStore = mock<Store> {
+            on { directory() } doReturn mockDirectory
+        }
+
+        whenever(mockDirectory.openInput(eq(fileName), any())).thenReturn(mockBaseInput)
+        whenever(mockBaseInput.clone()).thenReturn(mockClonedInput)
+
+        val sut = object : RestoreContext(
+            restoreUUID = UUID.randomUUID().toString(),
+            shard = mockShard,
+            indexCommitRef = mockIndexCommit,
+            metadataSnapshot = Store.MetadataSnapshot.EMPTY,
+            replayOperationsFrom = 0L,
+        ) {
+            override fun withStoreReference(store: Store, block: () -> Unit) {
+                block()
+            }
+        }
+
+        val threads = mutableListOf<Thread>()
+        val results = mutableListOf<IndexInput>()
+        val lock = Object()
+
+        // when
+        repeat(10) {
+            val thread = Thread {
+                val input = sut.openInput(mockStore, fileName)
+                synchronized(lock) {
+                    results.add(input)
+                }
+            }
+            threads.add(thread)
+        }
+
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        // then
+        assertEquals(threads.size, results.size)
+        results.forEach {
+            assertSame(mockClonedInput, it)
+        }
+        verify(mockDirectory, times(1)).openInput(eq(fileName), any())
+        verify(mockBaseInput, times(threads.size)).clone()
+    }
+}


### PR DESCRIPTION
### Description

Main PRs:-
https://github.com/opensearch-project/cross-cluster-replication/pull/1520
https://github.com/opensearch-project/cross-cluster-replication/pull/1521

this backport PR consists of these changes
```
198f9851ea8d57bca0b7e8c470982a0b111bf5ac
40b73a1ee41457c80241aee8f0054445602ebae6
05e62e992d90921fa4b675b8ba0ff33fce1581f3
0eabd309ab04ba7c6aa71aa601f132c2dbb2be29
8fd8ebee272f08bf851779cc4d758e25d9e38ce7
fd879471e7d93fb0c24e8e7ae429607533d2b7fa
```

https://github.com/opensearch-project/cross-cluster-replication/commits/main/



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
