### PR TITLE
Support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -25,11 +25,16 @@ jobs:
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
       - id: plugin-availability-check
         name: "plugin check"
         run: |
-          opensearch_version=$(grep "System.getProperty(\"opensearch.version\", \"" build.gradle | grep '\([0-9]\|[.]\)\{5\}' -o)
-          opensearch_version=$opensearch_version".0-SNAPSHOT"
+          opensearch_version=$(./gradlew properties | grep -E '^version:' | awk '{print $2}')
           # we publish build artifacts to the below url 
           sec_plugin_url="https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-security/"$opensearch_version"/"
           sec_st=$(curl -s -o /dev/null -w "%{http_code}" $sec_plugin_url)

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ apply plugin: 'opensearch.rest-test'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 apply plugin: 'opensearch.pluginzip'
-
+apply plugin: 'opensearch.java-agent'
 
 forbiddenApisTest.ignoreFailures = true
 


### PR DESCRIPTION
### Description
Support phasing off SecurityManager usage in favor of Java Agent

This commit allows passing a JVM argument to allow plugins test execute under Java Agent.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
