### PR TITLE
Support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/.github/workflows/security-knn-tests.yml
+++ b/.github/workflows/security-knn-tests.yml
@@ -25,11 +25,16 @@ jobs:
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
       - id: plugin-availability-check
         name: "plugin check"
         run: |
-          opensearch_version=$(grep "System.getProperty(\"opensearch.version\", \"" build.gradle | grep '\([0-9]\|[.]\)\{5\}' -o)
-          opensearch_version=$opensearch_version".0-SNAPSHOT"
+          opensearch_version=$(./gradlew properties | grep -E '^version:' | awk '{print $2}')
           # we publish build artifacts to the below url 
           sec_plugin_url="https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-security/"$opensearch_version"/"
           sec_st=$(curl -s -o /dev/null -w "%{http_code}" $sec_plugin_url)

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ apply plugin: 'opensearch.rest-test'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 apply plugin: 'opensearch.pluginzip'
-
+apply plugin: 'opensearch.java-agent'
 
 forbiddenApisTest.ignoreFailures = true
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,6 @@ buildscript {
 
         opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT","")
         security_no_snapshot = opensearch_build.replace("-SNAPSHOT","")
-        knn_plugin_path = "build/dependencies/knn"
-        knn_plugin_download_url = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot +
-                '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-knn-' + security_no_snapshot + '.zip'
 
     }
 
@@ -163,6 +160,7 @@ dependencies {
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
 
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${security_plugin_version}@zip"
+    opensearchPlugin "org.opensearch.plugin:opensearch-knn:${security_plugin_version}@zip"
 }
 
 repositories {
@@ -253,14 +251,9 @@ def knnPluginFile = new Callable<RegularFile>() {
         return new RegularFile() {
             @Override
             File getAsFile() {
-                if (new File("$project.rootDir/$knn_plugin_path").exists()) {
-                    project.delete(files("$project.rootDir/$knn_plugin_path"))
-                }
-                project.mkdir knn_plugin_path
-                ant.get(src: knn_plugin_download_url,
-                        dest: knn_plugin_path,
-                        httpusecaches: false)
-                return fileTree(knn_plugin_path).getSingleFile()
+                return configurations.opensearchPlugin.resolvedConfiguration.resolvedArtifacts
+                        .find { ResolvedArtifact f -> f.name.contains('opensearch-knn') }
+                        .file
             }
         }
     }


### PR DESCRIPTION
### Description

WIP on fixing build issues related to java agent (replacement for JSM)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
