### PR TITLE
 Update http5client and httpcore version to sync with OS core + 3.0.0.0 release notes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,10 +126,10 @@ configurations.all {
         force 'commons-codec:commons-codec:1.13'
         force 'org.apache.httpcomponents:httpclient:4.5.13'
         force 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
-        force 'org.apache.httpcomponents.core5:httpcore5:5.1.4'
-        force 'org.apache.httpcomponents.core5:httpcore5-h2:5.1.4'
-        force 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
-        force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
+        force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
+        force "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
+        force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+        force "org.apache.httpcomponents.client5:httpclient5-osgi:${versions.httpclient5}"
         force 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
         force 'org.yaml:snakeyaml:2.0'
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
@@ -151,9 +151,9 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.4.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0" // Moving away from kotlin_version
     implementation "org.opensearch:common-utils:${common_utils_version}"
-    implementation "org.apache.httpcomponents.client5:httpclient5:5.1.3"
-    implementation "org.apache.httpcomponents.core5:httpcore5:5.1.4"
-    implementation "org.apache.httpcomponents.core5:httpcore5-h2:5.1.4"
+    implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+    implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
+    implementation "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.assertj:assertj-core:3.17.2"

--- a/release-notes/opensearch-cross-cluster-replication.release-notes-3.0.0.0.md
+++ b/release-notes/opensearch-cross-cluster-replication.release-notes-3.0.0.0.md
@@ -1,0 +1,11 @@
+## Version 3.0.0.0 Release Notes
+
+Compatible with OpenSearch 3.0.0.0
+
+### Maintenance
+* Version bump to opensearch-3.0.0-alpha1 and replaced usage of deprecated classes
+* Version bump to opensearch-3.0.0-beta1 and replaced usage of deprecated classes
+* Update CCR with gradle 8.10.2 and support JDK23 ([#1496](https://github.com/opensearch-project/cross-cluster-replication/pull/1496))
+
+### Bug Fixes
+* Disabling knn validation checks ([#1515](https://github.com/opensearch-project/cross-cluster-replication/pull/1515))


### PR DESCRIPTION
### Description
 Update http5client and httpcore version to sync with OS core + 3.0.0.0 release notes

### Related Issues
opensearch-projects/opensearch-build#3747

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
