### PR TITLE
Indices deletion in leader cluster do not get replicated in follower cluster

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -203,6 +203,8 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
                 Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.autofollow.concurrent_replication_jobs_trigger_size", 3, 1, 10,
             Setting.Property.Dynamic, Setting.Property.NodeScope)
+        val REPLICATION_REPLICATE_INDEX_DELETION: Setting<Boolean> = Setting.boolSetting("plugins.replication.replicate.delete_index", false,
+            Setting.Property.Dynamic, Setting.Property.NodeScope)
     }
 
     override fun createComponents(client: Client, clusterService: ClusterService, threadPool: ThreadPool,
@@ -363,7 +365,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
             REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL, REPLICATION_METADATA_SYNC_INTERVAL,
             REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION, REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING,
             REPLICATION_INDEX_TRANSLOG_RETENTION_SIZE, REPLICATION_FOLLOWER_BLOCK_START, REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE,
-            REPLICATION_FOLLOWER_CONCURRENT_WRITERS_PER_SHARD)
+            REPLICATION_FOLLOWER_CONCURRENT_WRITERS_PER_SHARD, REPLICATION_REPLICATE_INDEX_DELETION)
     }
     override fun getInternalRepositories(env: Environment, namedXContentRegistry: NamedXContentRegistry,
                                          clusterService: ClusterService, recoverySettings: RecoverySettings): Map<String, Repository.Factory> {

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -52,6 +52,7 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest
+import org.opensearch.action.admin.indices.delete.DeleteIndexAction
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
@@ -104,6 +105,9 @@ import java.util.stream.Collectors
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import org.opensearch.commons.replication.action.ReplicationActions.INTERNAL_STOP_REPLICATION_ACTION_TYPE
+import org.opensearch.commons.replication.action.StopIndexReplicationRequest
+import org.opensearch.replication.ReplicationPlugin
 import kotlin.streams.toList
 import org.opensearch.cluster.DiffableUtils
 
@@ -222,8 +226,13 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                                     updateMetadata()
                                 }
                                 is FailedState -> {
-                                    // Try pausing first if we get Failed state. This returns failed state if pause failed
-                                    pauseReplication(state)
+                                    // Try pausing or stopping if we get Failed state based on settings.
+                                    // This returns failed state if pause or stop failed
+                                    if (clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_REPLICATE_INDEX_DELETION)) {
+                                        stopReplication(state)
+                                    } else {
+                                        pauseReplication(state)
+                                    }
                                 }
                                 else -> {
                                     state
@@ -682,6 +691,50 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         return MonitoringState
     }
 
+    private suspend fun stopReplication(state: FailedState): IndexReplicationState {
+        try {
+            log.info("Going to initiate stop of $followerIndexName due to deletion of leader index")
+            val stopReplicationResponse = client.suspendExecute(
+                replicationMetadata,
+                INTERNAL_STOP_REPLICATION_ACTION_TYPE, StopIndexReplicationRequest(followerIndexName),
+                defaultContext = true
+            )
+            if (!stopReplicationResponse.isAcknowledged) {
+                throw ReplicationException(
+                    "Failed to gracefully stop replication after deletion of leader index. " +
+                            "Replication tasks may need to be stopped manually and deleted follower index."
+                )
+            }
+        } catch (e: CancellationException) {
+            log.error("Encountered CancellationException while stopping $followerIndexName, ignoring it", e)
+        } catch (e: Exception) {
+            log.error("Encountered exception while stopping $followerIndexName", e)
+            return FailedState(state.failedShards,
+                "Stop failed with \"${e.message}\". Original failure for initiating stop - ${state.errorMsg}")
+        }
+        return CompletedState
+    }
+
+    private suspend fun deleteIndex() {
+        try {
+            log.info("Deleting the index $followerIndexName due to deletion of leader index")
+            val deleteIndexResponse = client.suspendExecute(
+                replicationMetadata,
+                DeleteIndexAction.INSTANCE, DeleteIndexRequest(followerIndexName),
+                defaultContext = true
+            )
+            if (!deleteIndexResponse.isAcknowledged) {
+                throw ReplicationException(
+                    "Failed to gracefully delete the follower index after deletion of the leader index. " +
+                            "Follower index may need to be deleted manually."
+                )
+            }
+        } catch (e: Exception) {
+            log.error("Encountered exception while deleting $followerIndexName", e)
+            throw e
+        }
+    }
+
     private fun findAllReplicationFailedShardTasks(followerIndexName: String, clusterState: ClusterState)
             :Map<ShardId, PersistentTask<ShardReplicationParams>> {
         val persistentTasks = clusterState.metadata.custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
@@ -717,6 +770,12 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 log.info("Task is cancelled. Moving the index to auto-pause state")
                 client.execute(PauseIndexReplicationAction.INSTANCE,
                         PauseIndexReplicationRequest(followerIndexName, TASK_CANCELLATION_REASON))
+            }
+
+            // Deleting the follower index if replication is stopped because of leader index deletion
+            if (clusterService.clusterSettings.get(ReplicationPlugin.REPLICATION_REPLICATE_INDEX_DELETION)
+                && currentTaskState.state == ReplicationState.COMPLETED)  {
+                deleteIndex()
             }
         }
 


### PR DESCRIPTION
### Description
Introduced a new setting parameter 'plugins.replication.replicate.delete_index'. If this property's value is set to true, it will replicate the deletion of leader index to follower. That means, the corresponding follower index will get deleted automatically.  The default behavior is just pause the replication(existing behavior).
The property 'plugins.replication.replicate.delete_index' is follower level. It has to set to each follower to delete index from that follower.

Automated Testing:
 - Added test case to test the deletion of follower index by setting the property 'plugins.replication.replicate.delete_index' to  true.
 - There is already a test case to test auto pause scenario in PauseReplicationIT.`test auto pause of index replication when leader index is unavailable`
Manual Testing:
 - Tested the default scenario - without setting the property
 - Tested by setting property to true with single follower (single index and multiple indices)
 - Tested by setting property to false with single follower (single index and multiple indices)
 - Tested by setting property to true/false with multiple followers with different combinations(single index and multiple indices)

### Related Issues
Resolves #1434

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
