### PR TITLE
Add missing method for RemoteClusterRepository class

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -116,6 +116,10 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         throw UnsupportedOperationException("Operation not permitted")
     }
 
+    override fun getLowPriorityRemoteDownloadThrottleTimeInNanos(): Long {
+        throw UnsupportedOperationException("Operation not permitted")
+    }
+
     override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
                                   snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
                                   stateTransformer: Function<ClusterState, ClusterState>?,


### PR DESCRIPTION
### Description
Add missing method for RemoteClusterRepository class


```

> Task :compileKotlin FAILED
e: file:///Users/gaiksaya/opensearch-project/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt:83:1 Class 'RemoteClusterRepository' is not abstract and does not implement abstract member public abstract fun getLowPriorityRemoteDownloadThrottleTimeInNanos(): Long defined in org.opensearch.repositories.Repository

[Incubating] Problems report is available at: file:///Users/gaiksaya/opensearch-project/cross-cluster-replication/build/reports/problems/problems-report.html
```

### Related Issues
https://github.com/opensearch-project/cross-cluster-replication/issues/1557

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
