### PR TITLE
Fix: Replication of large documents breaches the size limit (2GB) of ReleasableBytesStreamOutput

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
+++ b/src/main/kotlin/org/opensearch/replication/ReplicationPlugin.kt
@@ -169,8 +169,12 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
         const val REPLICATION_EXECUTOR_NAME_FOLLOWER = "replication_follower"
         val REPLICATED_INDEX_SETTING: Setting<String> = Setting.simpleString("index.plugins.replication.follower.leader_index",
             Setting.Property.InternalIndex, Setting.Property.IndexScope)
+        // Node-level batch size setting
         val REPLICATION_FOLLOWER_OPS_BATCH_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.follower.index.ops_batch_size", 50000, 16,
             Setting.Property.Dynamic, Setting.Property.NodeScope)
+        // Index-level batch size setting
+        val REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX: Setting<Int> = Setting.intSetting("index.plugins.replication.follower.ops_batch_size", 50000, 16,
+            Setting.Property.Dynamic, Setting.Property.IndexScope)
         val REPLICATION_LEADER_THREADPOOL_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.leader.thread_pool.size", 0, 0,
             Setting.Property.Dynamic, Setting.Property.NodeScope)
         val REPLICATION_LEADER_THREADPOOL_QUEUE_SIZE: Setting<Int> = Setting.intSetting("plugins.replication.leader.thread_pool.queue_size", 1000, 0,
@@ -358,7 +362,7 @@ internal class ReplicationPlugin : Plugin(), ActionPlugin, PersistentTaskPlugin,
     }
 
     override fun getSettings(): List<Setting<*>> {
-        return listOf(REPLICATED_INDEX_SETTING, REPLICATION_FOLLOWER_OPS_BATCH_SIZE, REPLICATION_LEADER_THREADPOOL_SIZE,
+        return listOf(REPLICATED_INDEX_SETTING, REPLICATION_FOLLOWER_OPS_BATCH_SIZE, REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX, REPLICATION_LEADER_THREADPOOL_SIZE,
             REPLICATION_LEADER_THREADPOOL_QUEUE_SIZE, REPLICATION_FOLLOWER_CONCURRENT_READERS_PER_SHARD,
             REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE, REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS,
             REPLICATION_PARALLEL_READ_POLL_INTERVAL, REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,

--- a/src/main/kotlin/org/opensearch/replication/task/shard/BatchSizeSettings.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/BatchSizeSettings.kt
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.task.shard
+
+import org.opensearch.index.IndexSettings
+import org.opensearch.replication.ReplicationPlugin
+import org.opensearch.replication.ReplicationSettings
+
+/**
+ * Helper class to manage batch size settings with fallback from index-level to cluster-level
+ */
+class BatchSizeSettings(
+    private val indexSettings: IndexSettings,
+    private val replicationSettings: ReplicationSettings
+) {
+
+    /**
+     * Get the effective batch size - index-level if set, otherwise cluster-level
+     */
+    fun getBatchSize(): Int {
+        return if (hasIndexLevelSetting()) {
+            ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.get(indexSettings.settings)
+        } else {
+            replicationSettings.batchSize
+        }
+    }
+
+    /**
+     * Check if index-level setting is configured
+     */
+    fun hasIndexLevelSetting(): Boolean {
+        return indexSettings.settings.hasValue(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key)
+    }
+
+    /**
+     * Get the source of the current batch size setting
+     */
+    fun getBatchSizeSource(): String {
+        return if (hasIndexLevelSetting()) "index-level" else "cluster-level"
+    }
+
+    // For dynamic batch size adjustment (2GB fix)
+    @Volatile
+    private var dynamicBatchSize: Int? = null
+    private val minBatchSize = 16
+
+    /**
+     * Get effective batch size considering dynamic adjustments
+     */
+    fun getEffectiveBatchSize(): Int {
+        return dynamicBatchSize ?: getBatchSize()
+    }
+
+    /**
+     * Reduce batch size for 2GB limit handling
+     */
+    fun reduceBatchSize() {
+        val currentSize = getEffectiveBatchSize()
+        dynamicBatchSize = maxOf(currentSize / 2, minBatchSize)
+    }
+
+    /**
+     * Reset to original batch size after successful operations
+     */
+    fun resetBatchSize() {
+        dynamicBatchSize = null
+    }
+
+    /**
+     * Check if batch size has been dynamically reduced
+     */
+    fun isDynamicallyReduced(): Boolean {
+        return dynamicBatchSize != null
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationChangesTracker.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationChangesTracker.kt
@@ -37,7 +37,8 @@ class ShardReplicationChangesTracker(indexShard: IndexShard, private val replica
     private val missingBatches = Collections.synchronizedList(ArrayList<Pair<Long, Long>>())
     private val observedSeqNoAtLeader = AtomicLong(indexShard.localCheckpoint)
     private val seqNoAlreadyRequested = AtomicLong(indexShard.localCheckpoint)
-    private val batchSize = replicationSettings.batchSize
+    private val batchSizeSettings = BatchSizeSettings(indexShard.indexSettings(), replicationSettings)
+
 
     /**
      * Provides a range of operations to be fetched next.
@@ -67,12 +68,41 @@ class ShardReplicationChangesTracker(indexShard: IndexShard, private val replica
                 missingBatches.removeAt(0)
             } else {
                 // return the next batch to fetch and update seqNoAlreadyRequested.
-                val fromSeq = seqNoAlreadyRequested.getAndAdd(batchSize.toLong()) + 1
-                val toSeq = fromSeq + batchSize - 1
-                logDebug("Fetching the batch $fromSeq-$toSeq")
+                val currentBatchSize = batchSizeSettings.getEffectiveBatchSize()
+                val fromSeq = seqNoAlreadyRequested.getAndAdd(currentBatchSize.toLong()) + 1
+                val toSeq = fromSeq + currentBatchSize - 1
+                val sizeInfo = if (batchSizeSettings.isDynamicallyReduced()) {
+                    "reduced to $currentBatchSize"
+                } else {
+                    "$currentBatchSize from ${batchSizeSettings.getBatchSizeSource()}"
+                }
+                logDebug("Fetching the batch $fromSeq-$toSeq (batch size: $sizeInfo)")
                 Pair(fromSeq, toSeq)
             }
         }
+    }
+
+    /**
+     * Reduce batch size
+     */
+    fun reduceBatchSize() {
+        batchSizeSettings.reduceBatchSize()
+        logDebug("Batch size reduced to ${batchSizeSettings.getEffectiveBatchSize()}")
+    }
+
+    /**
+     * Reset batch size
+     */
+    fun resetBatchSize() {
+        batchSizeSettings.resetBatchSize()
+        logDebug("Batch size reset to ${batchSizeSettings.getEffectiveBatchSize()}")
+    }
+
+    /**
+     * Batch Size Settings
+     */
+    fun batchSizeSettings() : BatchSizeSettings {
+        return batchSizeSettings
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -11,20 +11,6 @@
 
 package org.opensearch.replication.task.shard
 
-import org.opensearch.replication.ReplicationSettings
-import org.opensearch.replication.action.changes.GetChangesAction
-import org.opensearch.replication.action.changes.GetChangesRequest
-import org.opensearch.replication.action.changes.GetChangesResponse
-import org.opensearch.replication.metadata.ReplicationMetadataManager
-import org.opensearch.replication.metadata.ReplicationOverallState
-import org.opensearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_STATE
-import org.opensearch.replication.metadata.state.getReplicationStateParamsForIndex
-import org.opensearch.replication.seqno.RemoteClusterRetentionLeaseHelper
-import org.opensearch.replication.task.CrossClusterReplicationTask
-import org.opensearch.replication.task.ReplicationState
-import org.opensearch.replication.util.indicesService
-import org.opensearch.replication.util.stackTraceToString
-import org.opensearch.replication.util.suspendExecuteWithRetries
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -39,21 +25,34 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withContext
 import org.opensearch.OpenSearchException
 import org.opensearch.OpenSearchTimeoutException
-import org.opensearch.transport.client.Client
 import org.opensearch.cluster.ClusterChangedEvent
 import org.opensearch.cluster.ClusterStateListener
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.logging.Loggers
-import org.opensearch.index.seqno.RetentionLeaseActions
-import org.opensearch.index.seqno.RetentionLeaseInvalidRetainingSeqNoException
-import org.opensearch.index.seqno.RetentionLeaseNotFoundException
 import org.opensearch.core.index.shard.ShardId
-import org.opensearch.persistent.PersistentTaskState
-import org.opensearch.persistent.PersistentTasksNodeService
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.tasks.TaskId
+import org.opensearch.index.seqno.RetentionLeaseInvalidRetainingSeqNoException
+import org.opensearch.index.seqno.RetentionLeaseNotFoundException
+import org.opensearch.persistent.PersistentTaskState
+import org.opensearch.persistent.PersistentTasksNodeService
+import org.opensearch.replication.ReplicationSettings
+import org.opensearch.replication.action.changes.GetChangesAction
+import org.opensearch.replication.action.changes.GetChangesRequest
+import org.opensearch.replication.action.changes.GetChangesResponse
+import org.opensearch.replication.metadata.ReplicationMetadataManager
+import org.opensearch.replication.metadata.ReplicationOverallState
+import org.opensearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_STATE
+import org.opensearch.replication.metadata.state.getReplicationStateParamsForIndex
+import org.opensearch.replication.seqno.RemoteClusterRetentionLeaseHelper
+import org.opensearch.replication.task.CrossClusterReplicationTask
+import org.opensearch.replication.task.ReplicationState
+import org.opensearch.replication.util.indicesService
+import org.opensearch.replication.util.stackTraceToString
+import org.opensearch.replication.util.suspendExecuteWithRetries
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.NodeNotConnectedException
+import org.opensearch.transport.client.Client
 import java.time.Duration
 
 
@@ -255,6 +254,18 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                     } catch (e: Exception) {
                         followerClusterStats.stats[followerShardId]!!.opsReadFailures.addAndGet(1)
                         logInfo("Unable to get changes from seqNo: $fromSeqNo. ${e.stackTraceToString()}")
+
+                        // Handle 2GB limit exception specifically
+                        if (e is IllegalArgumentException &&
+                            e.message?.equals("ReleasableBytesStreamOutput cannot hold more than 2GB of data") == true) {
+                            logError("Hit 2GB limit with current batch size ${changeTracker.batchSizeSettings().getEffectiveBatchSize()}. Reducing batch size.")
+                            changeTracker.reduceBatchSize()
+                            logError("Reduced batch size to ${changeTracker.batchSizeSettings().getEffectiveBatchSize()}. Retrying immediately.")
+                            changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1, -1)
+                            // No delay for 2GB limit - retry immediately with smaller batch
+                            return@launch
+                        }
+
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                         // Propagate 4xx exceptions up the chain and halt replication as they are irrecoverable
                         val range4xx = 400.rangeTo(499)

--- a/src/test/kotlin/org/opensearch/replication/task/shard/BatchSizeSettingsTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/shard/BatchSizeSettingsTests.kt
@@ -1,0 +1,445 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.task.shard
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.opensearch.Version
+import org.opensearch.cluster.ClusterName
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.index.IndexSettings
+import org.opensearch.replication.ReplicationPlugin
+import org.opensearch.replication.ReplicationSettings
+import org.opensearch.test.ClusterServiceUtils
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.TestThreadPool
+import java.util.concurrent.TimeUnit
+
+class BatchSizeSettingsTests : OpenSearchTestCase() {
+
+    private lateinit var clusterService: ClusterService
+    private lateinit var replicationSettings: ReplicationSettings
+    private lateinit var threadPool: TestThreadPool
+
+    @Before
+    fun setup() {
+        threadPool = TestThreadPool("BatchSizeSettingsTest")
+        
+        // Create cluster settings with all replication plugin settings registered
+        val clusterSettings = ClusterSettings(
+            Settings.EMPTY,
+            setOf(
+                ReplicationPlugin.REPLICATION_FOLLOWER_CONCURRENT_READERS_PER_SHARD,
+                ReplicationPlugin.REPLICATION_FOLLOWER_CONCURRENT_WRITERS_PER_SHARD,
+                ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE,
+                ReplicationPlugin.REPLICATION_PARALLEL_READ_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL,
+                ReplicationPlugin.REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION,
+                ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE,
+                ReplicationPlugin.REPLICATION_REPLICATE_INDEX_DELETION,
+                ReplicationPlugin.REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE,
+                ReplicationPlugin.REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS
+            )
+        )
+        
+        // Create cluster state and cluster service with the proper settings
+        val clusterState = ClusterState.builder(ClusterName.DEFAULT).build()
+        clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
+        
+        // Replace the cluster settings in the cluster service
+        val clusterServiceField = clusterService.javaClass.getDeclaredField("clusterSettings")
+        clusterServiceField.isAccessible = true
+        clusterServiceField.set(clusterService, clusterSettings)
+        
+        replicationSettings = ReplicationSettings(clusterService)
+    }
+
+    @Test
+    fun `test fallback to cluster level when index level not set`() {
+        // Create index settings without the index-level batch size setting
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Should fallback to cluster-level setting
+        assertEquals(50000, batchSizeSettings.getBatchSize()) // Default cluster value
+        assertEquals("cluster-level", batchSizeSettings.getBatchSizeSource())
+        assertFalse(batchSizeSettings.hasIndexLevelSetting())
+    }
+
+    @Test
+    fun `test index level setting takes precedence`() {
+        // Create index settings with index-level batch size
+        val settings = Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 25000)
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE.key, 50000)
+            .build()
+        val indexSettings = createIndexSettings(settings)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Should use index-level setting
+        assertEquals(25000, batchSizeSettings.getBatchSize())
+        assertEquals("index-level", batchSizeSettings.getBatchSizeSource())
+        assertTrue(batchSizeSettings.hasIndexLevelSetting())
+    }
+
+    @Test
+    fun `test dynamic batch size reduction`() {
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Initial state
+        assertEquals(50000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+
+        // Reduce batch size
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(25000, batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+
+        // Reduce again
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(12500, batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+
+        // Reset to original
+        batchSizeSettings.resetBatchSize()
+        assertEquals(50000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test minimum batch size limit`() {
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Reduce multiple times to hit minimum
+        repeat(20) { batchSizeSettings.reduceBatchSize() }
+
+        // Should not go below minimum (16)
+        assertTrue(batchSizeSettings.getEffectiveBatchSize() >= 16)
+    }
+
+    @Test
+    fun `test reset when not dynamically reduced does nothing`() {
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        val originalSize = batchSizeSettings.getEffectiveBatchSize()
+        
+        // Reset without reducing first
+        batchSizeSettings.resetBatchSize()
+        
+        // Should remain unchanged
+        assertEquals(originalSize, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test index level setting with dynamic reduction`() {
+        // Create index settings with custom batch size
+        val settings = Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 10000)
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE.key, 50000)
+            .build()
+        val indexSettings = createIndexSettings(settings)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Initial state uses index-level setting
+        assertEquals(10000, batchSizeSettings.getEffectiveBatchSize())
+
+        // Reduce batch size
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(5000, batchSizeSettings.getEffectiveBatchSize())
+
+        // Reset should go back to index-level setting
+        batchSizeSettings.resetBatchSize()
+        assertEquals(10000, batchSizeSettings.getEffectiveBatchSize())
+    }
+
+    // Additional comprehensive test cases for 2GB limit handling and edge cases
+
+    @Test
+    fun `test batch size reduction with very small initial size`() {
+        // Test with small initial batch size
+        val settings = Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 32)
+            .build()
+        val indexSettings = createIndexSettings(settings)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        assertEquals(32, batchSizeSettings.getEffectiveBatchSize())
+        
+        // First reduction: 32 -> 16 (minimum)
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Second reduction: should stay at minimum (16)
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Reset should go back to original
+        batchSizeSettings.resetBatchSize()
+        assertEquals(32, batchSizeSettings.getEffectiveBatchSize())
+    }
+
+    @Test
+    fun `test batch size reduction with large initial size`() {
+        // Test with large initial batch size
+        val settings = Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 100000)
+            .build()
+        val indexSettings = createIndexSettings(settings)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        assertEquals(100000, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Progressive reductions
+        batchSizeSettings.reduceBatchSize() // 100000 -> 50000
+        assertEquals(50000, batchSizeSettings.getEffectiveBatchSize())
+        
+        batchSizeSettings.reduceBatchSize() // 50000 -> 25000
+        assertEquals(25000, batchSizeSettings.getEffectiveBatchSize())
+        
+        batchSizeSettings.reduceBatchSize() // 25000 -> 12500
+        assertEquals(12500, batchSizeSettings.getEffectiveBatchSize())
+        
+        batchSizeSettings.reduceBatchSize() // 12500 -> 6250
+        assertEquals(6250, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Reset should go back to original large size
+        batchSizeSettings.resetBatchSize()
+        assertEquals(100000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test concurrent batch size operations`() {
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Test thread safety of batch size operations
+        val threads = mutableListOf<Thread>()
+        val results = mutableListOf<Int>()
+        
+        // Create multiple threads that reduce batch size
+        repeat(5) { i ->
+            val thread = Thread {
+                batchSizeSettings.reduceBatchSize()
+                results.add(batchSizeSettings.getEffectiveBatchSize())
+            }
+            threads.add(thread)
+        }
+        
+        // Start all threads
+        threads.forEach { it.start() }
+        
+        // Wait for all threads to complete
+        threads.forEach { it.join() }
+        
+        // Verify that batch size was reduced and all results are valid
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        assertTrue(batchSizeSettings.getEffectiveBatchSize() < 50000)
+        assertTrue(batchSizeSettings.getEffectiveBatchSize() >= 16)
+        assertEquals(1562, results[4])
+    }
+
+    @Test
+    fun `test batch size state consistency`() {
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Initial state
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        assertEquals(batchSizeSettings.getBatchSize(), batchSizeSettings.getEffectiveBatchSize())
+        
+        // After reduction
+        batchSizeSettings.reduceBatchSize()
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        assertNotEquals(batchSizeSettings.getBatchSize(), batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.getEffectiveBatchSize() < batchSizeSettings.getBatchSize())
+        
+        // After reset
+        batchSizeSettings.resetBatchSize()
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        assertEquals(batchSizeSettings.getBatchSize(), batchSizeSettings.getEffectiveBatchSize())
+    }
+
+    @Test
+    fun `test batch size source tracking`() {
+        // Test cluster-level source
+        val clusterOnlySettings = createIndexSettings(Settings.EMPTY)
+        val clusterBatchSettings = BatchSizeSettings(clusterOnlySettings, replicationSettings)
+        
+        assertEquals("cluster-level", clusterBatchSettings.getBatchSizeSource())
+        assertFalse(clusterBatchSettings.hasIndexLevelSetting())
+        
+        // Test index-level source
+        val indexSettings = Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 30000)
+            .build()
+        val indexOnlySettings = createIndexSettings(indexSettings)
+        val indexBatchSettings = BatchSizeSettings(indexOnlySettings, replicationSettings)
+        
+        assertEquals("index-level", indexBatchSettings.getBatchSizeSource())
+        assertTrue(indexBatchSettings.hasIndexLevelSetting())
+        
+        // Source should remain consistent even after dynamic changes
+        indexBatchSettings.reduceBatchSize()
+        assertEquals("index-level", indexBatchSettings.getBatchSizeSource())
+        assertTrue(indexBatchSettings.hasIndexLevelSetting())
+    }
+
+    @Test
+    fun `test edge case with minimum batch size`() {
+        // Test behavior when starting at minimum
+        val settings = Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 16) // Minimum
+            .build()
+        val indexSettings = createIndexSettings(settings)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        
+        // Reduction should still work but stay at minimum
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        
+        // Multiple reductions should stay at minimum
+        repeat(5) {
+            batchSizeSettings.reduceBatchSize()
+            assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+            assertTrue(batchSizeSettings.isDynamicallyReduced())
+        }
+        
+        // Reset should work normally
+        batchSizeSettings.resetBatchSize()
+        assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test multiple reset calls`() {
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        val originalSize = batchSizeSettings.getEffectiveBatchSize()
+        
+        // Reduce batch size
+        batchSizeSettings.reduceBatchSize()
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        
+        // Multiple reset calls should be safe
+        batchSizeSettings.resetBatchSize()
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        assertEquals(originalSize, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Additional reset calls should be no-op
+        batchSizeSettings.resetBatchSize()
+        batchSizeSettings.resetBatchSize()
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        assertEquals(originalSize, batchSizeSettings.getEffectiveBatchSize())
+    }
+
+    @Test
+    fun `test batch size reduction sequence for 2GB handling simulation`() {
+        // Simulate the exact scenario from 2GB exception handling
+        val settings = Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 1000)
+            .build()
+        val indexSettings = createIndexSettings(settings)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Initial state
+        assertEquals(1000, batchSizeSettings.getEffectiveBatchSize())
+        assertEquals("index-level", batchSizeSettings.getBatchSizeSource())
+        
+        // Simulate multiple 2GB exceptions requiring progressive reduction
+        val reductionSequence = mutableListOf<Int>()
+        
+        // First 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        reductionSequence.add(batchSizeSettings.getEffectiveBatchSize())
+        
+        // Second 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        reductionSequence.add(batchSizeSettings.getEffectiveBatchSize())
+        
+        // Third 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        reductionSequence.add(batchSizeSettings.getEffectiveBatchSize())
+        
+        // Verify reduction sequence: 1000 -> 500 -> 250 -> 125
+        assertEquals(listOf(500, 250, 125), reductionSequence)
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        
+        // Simulate successful operation - reset batch size
+        batchSizeSettings.resetBatchSize()
+        assertEquals(1000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    private fun createIndexSettings(settings: Settings): IndexSettings {
+        val indexMetadata = org.opensearch.cluster.metadata.IndexMetadata.builder("test-index")
+            .settings(Settings.builder()
+                .put(settings)
+                .put("index.version.created", Version.CURRENT)
+                .put("index.number_of_shards", 1)
+                .put("index.number_of_replicas", 0)
+                .build())
+            .build()
+        return IndexSettings(indexMetadata, Settings.EMPTY)
+    }
+
+    @After
+    fun cleanup() {
+        try {
+            // Close cluster service first to stop all background tasks
+            clusterService.close()
+        } catch (e: Exception) {
+            logger.warn("Exception during cluster service cleanup", e)
+        }
+        
+        try {
+            // Shutdown thread pool gracefully
+            threadPool.shutdown()
+            if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.warn("Thread pool did not terminate gracefully, forcing shutdown")
+                threadPool.shutdownNow()
+                // Wait a bit more for forced shutdown
+                if (!threadPool.awaitTermination(2, TimeUnit.SECONDS)) {
+                    logger.warn("Thread pool did not terminate even after forced shutdown")
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn("Exception during thread pool cleanup", e)
+            try {
+                threadPool.shutdownNow()
+            } catch (e2: Exception) {
+                logger.warn("Exception during forced thread pool shutdown", e2)
+            }
+        }
+    }
+
+    override fun tearDown() {
+        super.tearDown()
+    }
+}

--- a/src/test/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask2GBLimitTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask2GBLimitTests.kt
@@ -1,0 +1,442 @@
+package org.opensearch.replication.task.shard
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.opensearch.Version
+import org.opensearch.cluster.ClusterName
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.core.index.shard.ShardId
+import org.opensearch.index.IndexSettings
+import org.opensearch.index.shard.IndexShard
+import org.opensearch.replication.ReplicationPlugin
+import org.opensearch.replication.ReplicationSettings
+import org.opensearch.test.ClusterServiceUtils
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.TestThreadPool
+import java.util.concurrent.TimeUnit
+
+/**
+ * Unit tests for 2GB limit exception handling in ShardReplicationTask.
+ * 
+ * These tests verify that when a 2GB limit is hit during batch operations,
+ * the system properly:
+ * 1. Detects the specific 2GB exception
+ * 2. Reduces batch size appropriately
+ * 3. Retries immediately without delay
+ * 4. Maintains proper state throughout the process
+ */
+class ShardReplicationTask2GBLimitTests : OpenSearchTestCase() {
+
+    private lateinit var clusterService: ClusterService
+    private lateinit var replicationSettings: ReplicationSettings
+    private lateinit var threadPool: TestThreadPool
+    private lateinit var mockIndexShard: IndexShard
+
+    @Before
+    fun setup() {
+        threadPool = TestThreadPool("ShardReplicationTask2GBLimitTests")
+        
+        val clusterSettings = ClusterSettings(
+            Settings.EMPTY,
+            setOf(
+                ReplicationPlugin.REPLICATION_FOLLOWER_CONCURRENT_READERS_PER_SHARD,
+                ReplicationPlugin.REPLICATION_FOLLOWER_CONCURRENT_WRITERS_PER_SHARD,
+                ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE,
+                ReplicationPlugin.REPLICATION_PARALLEL_READ_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL,
+                ReplicationPlugin.REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION,
+                ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE,
+                ReplicationPlugin.REPLICATION_REPLICATE_INDEX_DELETION,
+                ReplicationPlugin.REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE,
+                ReplicationPlugin.REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS
+            )
+        )
+        
+        val clusterState = ClusterState.builder(ClusterName.DEFAULT).build()
+        clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
+        
+        val clusterServiceField = clusterService.javaClass.getDeclaredField("clusterSettings")
+        clusterServiceField.isAccessible = true
+        clusterServiceField.set(clusterService, clusterSettings)
+        
+        replicationSettings = ReplicationSettings(clusterService)
+        
+        mockIndexShard = mock(IndexShard::class.java)
+        val shardId = ShardId("test-index", "test-uuid", 0)
+        `when`(mockIndexShard.shardId()).thenReturn(shardId)
+        `when`(mockIndexShard.localCheckpoint).thenReturn(0L)
+        `when`(mockIndexShard.lastSyncedGlobalCheckpoint).thenReturn(0L)
+    }
+
+    @Test
+    fun `test 2GB exception detection`() {
+        // Test the exact exception message pattern used in ShardReplicationTask
+        val twoGBException = IllegalArgumentException("ReleasableBytesStreamOutput cannot hold more than 2GB of data")
+        
+        val is2GBException = twoGBException is IllegalArgumentException &&
+                twoGBException.message?.contains("ReleasableBytesStreamOutput cannot hold more than 2GB") == true
+        
+        assertTrue("Should detect 2GB exception", is2GBException)
+        
+        // Test that other exceptions are not detected as 2GB exceptions
+        val otherException = IllegalArgumentException("Some other error")
+        val isNot2GBException = otherException is IllegalArgumentException &&
+                otherException.message?.contains("ReleasableBytesStreamOutput cannot hold more than 2GB") == true
+        
+        assertFalse("Should not detect non-2GB exception", isNot2GBException)
+    }
+
+    @Test
+    fun `test batch size reduction on 2GB exception`() {
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 100000)
+            .build())
+        
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+        
+        // Initial state
+        assertEquals(100000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        
+        // Simulate 2GB exception handling
+        val exception = IllegalArgumentException("ReleasableBytesStreamOutput cannot hold more than 2GB of data")
+        
+        if (exception is IllegalArgumentException &&
+            exception.message?.contains("ReleasableBytesStreamOutput cannot hold more than 2GB") == true) {
+            
+            batchSizeSettings.reduceBatchSize()
+        }
+        
+        // Verify batch size was reduced
+        assertEquals(50000, batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test multiple 2GB exceptions reduce batch size progressively`() {
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 80000)
+            .build())
+        
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+        
+        assertEquals(80000, batchSizeSettings.getEffectiveBatchSize())
+        
+        // First 2GB exception: 80000 -> 40000
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(40000, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Second 2GB exception: 40000 -> 20000
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(20000, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Third 2GB exception: 20000 -> 10000
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(10000, batchSizeSettings.getEffectiveBatchSize())
+        
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test batch size respects minimum limit`() {
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 32)
+            .build())
+        
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+        
+        assertEquals(32, batchSizeSettings.getEffectiveBatchSize())
+        
+        // First reduction: 32 -> 16 (minimum)
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Second reduction: should stay at minimum
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        
+        // Multiple reductions should not go below minimum
+        repeat(5) {
+            batchSizeSettings.reduceBatchSize()
+            assertEquals(16, batchSizeSettings.getEffectiveBatchSize())
+        }
+    }
+
+    @Test
+    fun `test batch size reset after successful operations`() {
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 60000)
+            .build())
+        
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+        
+        // Reduce batch size due to 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(30000, batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        
+        // Reset after successful operation
+        batchSizeSettings.resetBatchSize()
+        assertEquals(60000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test cluster level batch size fallback with 2GB handling`() {
+        // No index-level setting, should use cluster-level default
+        val indexSettings = createIndexSettings(Settings.EMPTY)
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+        
+        assertEquals(50000, batchSizeSettings.getEffectiveBatchSize()) // Default cluster value
+        assertEquals("cluster-level", batchSizeSettings.getBatchSizeSource())
+        assertFalse(batchSizeSettings.hasIndexLevelSetting())
+        
+        // Reduce due to 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        assertEquals(25000, batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        
+        // Source should still be cluster-level
+        assertEquals("cluster-level", batchSizeSettings.getBatchSizeSource())
+        
+        // Reset should go back to cluster default
+        batchSizeSettings.resetBatchSize()
+        assertEquals(50000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test batch size settings with 2GB scenario simulation`() {
+        // Test the BatchSizeSettings behavior that's used by ShardReplicationChangesTracker
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 1000)
+            .build())
+        
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+        
+        // Initial state
+        assertEquals(1000, batchSizeSettings.getEffectiveBatchSize())
+        assertEquals("index-level", batchSizeSettings.getBatchSizeSource())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        
+        // Simulate 2GB exception scenario - progressive reductions
+        val reductionSequence = mutableListOf<Int>()
+        
+        // First 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        reductionSequence.add(batchSizeSettings.getEffectiveBatchSize())
+        
+        // Second 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        reductionSequence.add(batchSizeSettings.getEffectiveBatchSize())
+        
+        // Third 2GB exception
+        batchSizeSettings.reduceBatchSize()
+        reductionSequence.add(batchSizeSettings.getEffectiveBatchSize())
+        
+        // Verify reduction sequence: 1000 -> 500 -> 250 -> 125
+        assertEquals(listOf(500, 250, 125), reductionSequence)
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        
+        // Simulate successful operation - reset batch size
+        batchSizeSettings.resetBatchSize()
+        assertEquals(1000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test 2GB exception message variations`() {
+        val validMessages = listOf(
+            "ReleasableBytesStreamOutput cannot hold more than 2GB of data",
+            "ReleasableBytesStreamOutput cannot hold more than 2GB",
+            "Error: ReleasableBytesStreamOutput cannot hold more than 2GB of data occurred"
+        )
+
+        validMessages.forEach { message ->
+            val exception = IllegalArgumentException(message)
+            val is2GBException = exception is IllegalArgumentException &&
+                    exception.message?.contains("ReleasableBytesStreamOutput cannot hold more than 2GB") == true
+
+            assertTrue("Should detect 2GB exception for message: $message", is2GBException)
+        }
+
+        val invalidMessages = listOf(
+            "ReleasableBytesStreamOutput cannot hold more than 1GB of data",
+            "BytesStreamOutput cannot hold more than 2GB of data",
+            "Some other error message",
+            null
+        )
+
+        invalidMessages.forEach { message ->
+            val exception = IllegalArgumentException(message)
+            val is2GBException = exception is IllegalArgumentException &&
+                    exception.message?.contains("ReleasableBytesStreamOutput cannot hold more than 2GB") == true
+
+            assertFalse("Should not detect 2GB exception for message: $message", is2GBException)
+        }
+    }
+
+    @Test
+    fun `test 2GB exception handling workflow simulation`() {
+        // Test the complete workflow logic as it happens in ShardReplicationTask
+        // without mocking the actual tracker class
+        val fromSeqNo = 1000L
+        val toSeqNo = 51000L
+        
+        // Simulate the exception handling logic from ShardReplicationTask
+        val exception = IllegalArgumentException("ReleasableBytesStreamOutput cannot hold more than 2GB of data")
+        var immediateRetry = false
+        var delayTriggered = false
+        var batchSizeReduced = false
+        var batchMarkedAsFailed = false
+        
+        try {
+            throw exception
+        } catch (e: Exception) {
+            if (e is IllegalArgumentException &&
+                e.message?.contains("ReleasableBytesStreamOutput cannot hold more than 2GB") == true) {
+                
+                // Should reduce batch size
+                batchSizeReduced = true
+                
+                // Should update batch as failed
+                batchMarkedAsFailed = true
+                
+                // Should retry immediately (no delay)
+                immediateRetry = true
+                // In real code: return@launch (immediate retry)
+                
+            } else {
+                // Other exceptions would trigger delay
+                delayTriggered = true
+            }
+        }
+        
+        assertTrue("Should retry immediately for 2GB exception", immediateRetry)
+        assertTrue("Should reduce batch size for 2GB exception", batchSizeReduced)
+        assertTrue("Should mark batch as failed for 2GB exception", batchMarkedAsFailed)
+        assertFalse("Should not trigger delay for 2GB exception", delayTriggered)
+    }
+
+    @Test
+    fun `test batch size state consistency`() {
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 5000)
+            .build())
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Initial state
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        assertEquals(batchSizeSettings.getBatchSize(), batchSizeSettings.getEffectiveBatchSize())
+        assertEquals("index-level", batchSizeSettings.getBatchSizeSource())
+        
+        // After reduction
+        batchSizeSettings.reduceBatchSize()
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        assertNotEquals(batchSizeSettings.getBatchSize(), batchSizeSettings.getEffectiveBatchSize())
+        assertTrue(batchSizeSettings.getEffectiveBatchSize() < batchSizeSettings.getBatchSize())
+        assertEquals("index-level", batchSizeSettings.getBatchSizeSource()) // Source unchanged
+        
+        // After reset
+        batchSizeSettings.resetBatchSize()
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+        assertEquals(batchSizeSettings.getBatchSize(), batchSizeSettings.getEffectiveBatchSize())
+        assertEquals("index-level", batchSizeSettings.getBatchSizeSource())
+    }
+
+    @Test
+    fun `test concurrent batch size operations`() {
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 10000)
+            .build())
+        val batchSizeSettings = BatchSizeSettings(indexSettings, replicationSettings)
+
+        // Simulate multiple concurrent reductions (as might happen with multiple reader coroutines)
+        repeat(5) {
+            batchSizeSettings.reduceBatchSize()
+        }
+
+        // Should be significantly reduced but not below minimum
+        assertTrue(batchSizeSettings.getEffectiveBatchSize() < 10000)
+        assertTrue(batchSizeSettings.getEffectiveBatchSize() >= 16)
+        assertTrue(batchSizeSettings.isDynamicallyReduced())
+        
+        // Reset should work correctly
+        batchSizeSettings.resetBatchSize()
+        assertEquals(10000, batchSizeSettings.getEffectiveBatchSize())
+        assertFalse(batchSizeSettings.isDynamicallyReduced())
+    }
+
+    @Test
+    fun `test changes tracker batch size reduction integration`() {
+        // Test the actual ShardReplicationChangesTracker with batch size reduction
+        val indexSettings = createIndexSettings(Settings.builder()
+            .put(ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE_INDEX.key, 2000)
+            .build())
+        
+        `when`(mockIndexShard.indexSettings()).thenReturn(indexSettings)
+        `when`(mockIndexShard.localCheckpoint).thenReturn(50L)
+
+        val changesTracker = ShardReplicationChangesTracker(mockIndexShard, replicationSettings)
+
+        // Test batch size reduction directly
+        changesTracker.reduceBatchSize()
+        
+        // Test reset functionality
+        changesTracker.resetBatchSize()
+        
+        // Verify the tracker can handle multiple reductions
+        repeat(3) {
+            changesTracker.reduceBatchSize()
+        }
+        
+        // This verifies the integration works without exceptions
+        assertTrue("Changes tracker should handle batch size operations", true)
+    }
+
+    private fun createIndexSettings(settings: Settings): IndexSettings {
+        val indexMetadata = IndexMetadata.builder("test-index")
+            .settings(Settings.builder()
+                .put(settings)
+                .put("index.version.created", Version.CURRENT)
+                .put("index.number_of_shards", 1)
+                .put("index.number_of_replicas", 0)
+                .build())
+            .build()
+        return IndexSettings(indexMetadata, Settings.EMPTY)
+    }
+
+    @After
+    fun cleanup() {
+        try {
+            clusterService.close()
+        } catch (e: Exception) {
+            logger.warn("Exception during cluster service cleanup", e)
+        }
+        
+        try {
+            threadPool.shutdown()
+            if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.warn("Thread pool did not terminate gracefully, forcing shutdown")
+                threadPool.shutdownNow()
+            }
+        } catch (e: Exception) {
+            logger.warn("Exception during thread pool cleanup", e)
+            threadPool.shutdownNow()
+        }
+    }
+
+    override fun tearDown() {
+        super.tearDown()
+    }
+}


### PR DESCRIPTION
### Description
When the follower cluster fetches the data from the leader node it breaches the 2GB limit for a single call. This PR handles that issue in the following ways
1. Introducing an Index level batch size, which can be maintain by the clients via the index settings.
2. Retry immediately by reducing the batch size. This batch size is dynamically maintained by the node. If the node is destroy then this values will be discarded.

### Related Issues
Resolves #1568
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


