### PR TITLE
Replace all instances of ARCHIVE with INTEG_TEST

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ buildscript {
 
 
         // for bwc tests
-        opensearch_previous_version = System.getProperty("bwc_older_version", "2.6.0")
+        opensearch_previous_version = System.getProperty("bwc_older_version", "3.3.0")
         plugin_previous_version = opensearch_previous_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
@@ -927,7 +927,7 @@ task "bwcTestSuite"(type: RestIntegTestTask) {
     dependsOn tasks.named("fullRestartClusterTask")
 }
 
-task integTestRemote (type: RestIntegTestTask) {
+task integTestRemote (type: Test) {
     doFirst {
         systemProperty "tests.cluster.followCluster.http_hosts", System.getProperty("follower.http_host")
         systemProperty "tests.cluster.followCluster.transport_hosts", System.getProperty("follower.transport_host")

--- a/perf_workflow/requirements.txt
+++ b/perf_workflow/requirements.txt
@@ -4,7 +4,7 @@ yamlfix
 cerberus
 pipenv
 requests~=2.32.4
-retry
+retry2
 ndg-httpsclient
 psutil
 pyopenssl


### PR DESCRIPTION
### Description

Companion core PR: https://github.com/opensearch-project/OpenSearch/pull/20241

The advantage of using INTEG_TEST is predictability because it uses the `build/` directory and checks out the latest commit from the corresponding branch of core to build against. When using `ARCHIVE` it uses the min distribution (which can sometimes be out of sync) and also downloads it to the gradle cache which is currently causing issues in the 3.4.0 release.

More details to follow

### Related Issues

Resolves https://github.com/opensearch-project/cross-cluster-replication/issues/1610

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
