### PR TITLE
Index Reopen Call should not be sent when index replication task restarts if the index is already open

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -347,7 +347,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     /**
      * Checks if the specified index is currently in a closed state.
      */
-    private fun isIndexClosed(indexName: String): Boolean {
+    internal fun isIndexClosed(indexName: String): Boolean {
         return try {
             val clusterState = clusterService.state()
             val indexMetadata = clusterState.metadata.index(indexName)

--- a/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
@@ -320,11 +320,8 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
         var newClusterState = ClusterState.builder(clusterService.state()).metadata(metadata).routingTable(routingTableBuilder.build()).build()
         setState(clusterService, newClusterState)
 
-        val isIndexClosedMethod = IndexReplicationTask::class.java.getDeclaredMethod("isIndexClosed", String::class.java)
-        isIndexClosedMethod.isAccessible = true
-
         // Test with closed index - should return true
-        val isClosedResult = isIndexClosedMethod.invoke(replicationTask, followerIndex) as Boolean
+        val isClosedResult = replicationTask.isIndexClosed(followerIndex)
         assertThat(isClosedResult).isTrue()
 
         // Test case 2: Index is open - should return false
@@ -337,7 +334,7 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
         newClusterState = ClusterState.builder(clusterService.state()).metadata(metadata).routingTable(routingTableBuilder.build()).build()
         setState(clusterService, newClusterState)
 
-        val isOpenResult = isIndexClosedMethod.invoke(replicationTask, followerIndex) as Boolean
+        val isOpenResult = replicationTask.isIndexClosed(followerIndex)
         assertThat(isOpenResult).isFalse()
         
         // Test case 3: Index metadata not found - should default to true (safe fallback)
@@ -349,7 +346,7 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
         newClusterState = ClusterState.builder(clusterService.state()).metadata(metadata).routingTable(routingTableBuilder.build()).build()
         setState(clusterService, newClusterState)
 
-        val isMissingResult = isIndexClosedMethod.invoke(replicationTask, "non-existent-index") as Boolean
+        val isMissingResult = replicationTask.isIndexClosed("non-existent-index")
         assertThat(isMissingResult).isTrue() // Should default to true for safety
     }
 
@@ -361,9 +358,6 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
         val rm = ReplicationMetadata(connectionName, ReplicationStoreMetadataType.INDEX.name, ReplicationOverallState.RUNNING.name, "reason", rc, rc, Settings.EMPTY)
         replicationTask.setReplicationMetadata(rm)
 
-        val isIndexClosedMethod = IndexReplicationTask::class.java.getDeclaredMethod("isIndexClosed", String::class.java)
-        isIndexClosedMethod.isAccessible = true
-
         // Test case 1: Index is closed
         var metadata = Metadata.builder()
             .put(IndexMetadata.builder(followerIndex).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0).state(IndexMetadata.State.CLOSE))
@@ -371,7 +365,7 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
         var newClusterState = ClusterState.builder(clusterService.state()).metadata(metadata).build()
         setState(clusterService, newClusterState)
 
-        val isClosedResult = isIndexClosedMethod.invoke(replicationTask, followerIndex) as Boolean
+        val isClosedResult = replicationTask.isIndexClosed(followerIndex)
         assertThat(isClosedResult).isTrue()
 
         // Test case 2: Index is open
@@ -381,7 +375,7 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
         newClusterState = ClusterState.builder(clusterService.state()).metadata(metadata).build()
         setState(clusterService, newClusterState)
 
-        val isOpenResult = isIndexClosedMethod.invoke(replicationTask, followerIndex) as Boolean
+        val isOpenResult = replicationTask.isIndexClosed(followerIndex)
         assertThat(isOpenResult).isFalse()
 
         // Test case 3: Index metadata not found - should return true (safe fallback)
@@ -389,7 +383,7 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
         newClusterState = ClusterState.builder(clusterService.state()).metadata(metadata).build()
         setState(clusterService, newClusterState)
 
-        val isMissingResult = isIndexClosedMethod.invoke(replicationTask, "non-existent-index") as Boolean
+        val isMissingResult = replicationTask.isIndexClosed("non-existent-index")
         assertThat(isMissingResult).isTrue() // Should default to true for safety
     }
 }


### PR DESCRIPTION

### Description
During cluster recovery from an unhealthy state, replication tasks resume and make open index calls to ensure indices are in an open state. This creates a surge of urgent priority open-indices tasks that can starve shard recovery tasks, leading to slow recovery when there are many indices in the cluster. The current implementation always calls open index operations regardless of the current index state, which is inefficient and creates unnecessary load.

### Related Issues

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
