### PR TITLE
Build failure fix for 3.5

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -143,11 +143,10 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         throw UnsupportedOperationException("Operation not permitted")
     }
 
-    override fun snapshotShard(store: Store?, mapperService: MapperService?, snapshotId: SnapshotId?, indexId: IndexId?,
-                               snapshotIndexCommit: IndexCommit?, @Nullable shardStateIdentifier: String?,
-                               snapshotStatus: IndexShardSnapshotStatus?, repositoryMetaVersion: Version?,
-                               userMetadata: MutableMap<String, Any>?, listener: ActionListener<String>?,
-                               indexMetadata: IndexMetadata?) {
+    override fun snapshotShard(store: Store, mapperService: MapperService, snapshotId: SnapshotId, indexId: IndexId,
+                               snapshotIndexCommit: IndexCommit, @Nullable shardStateIdentifier: String?,
+                               snapshotStatus: IndexShardSnapshotStatus, repositoryMetaVersion: Version,
+                               userMetadata: MutableMap<String, Any>, listener: ActionListener<String>) {
         throw UnsupportedOperationException("Operation not permitted")
     }
 


### PR DESCRIPTION
### Description
[Describe what this change achieves]

```
> Task :compileKotlin FAILED

e: file:///D:/a/cross-cluster-replication/cross-cluster-replication/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt:83:1 Class 'RemoteClusterRepository' is not abstract and does not implement abstract member:

fun snapshotShard(p0: Store!, p1: MapperService!, p2: SnapshotId!, p3: IndexId!, p4: IndexCommit!, p5: String?, p6: IndexShardSnapshotStatus!, p7: Version!, p8: (Mutable)Map<String!, Any!>!, p9: ActionListener<String!>!, p10: IndexMetadata?): Unit

FAILURE: Build failed with an exception.

* What went wrong:

Execution failed for task ':compileKotlin'.

> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction

 > Compilation error. See log for more details
```


Testing:-

```
./gradlew compileKotlin 

=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 9.2.1
  OS Info               : Mac OS X 26.2 (aarch64)
  JDK Version           : 21 (Amazon Corretto JDK 21 (21.0.8+9-LTS))
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home
  Random Testing Seed   : 7FB880934ACC580F
  Crypto Standard       : any-supported
=======================================

BUILD SUCCESSFUL in 1s
1 actionable task: 1 up-to-date
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
