### PR TITLE
Fix write index conflicts in bidirectional replication

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -583,7 +583,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     request = null
                 } else {
                     log.info("All aliases are not equal on $followerIndexName. Will sync up them")
-                    request  = IndicesAliasesRequest()
+                    request = IndicesAliasesRequest()
                     var toAdd = leaderAliases - followerAliases
 
                     for (alias in toAdd) {
@@ -593,8 +593,14 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                             .alias(alias.alias)
                             .indexRouting(alias.indexRouting)
                             .searchRouting(alias.searchRouting)
-                            .writeIndex(false) // Always strip write index on follower to allow bidirectional replication
                             .isHidden(alias.isHidden)
+
+                        val writeIndex = alias.writeIndex()
+                        if (writeIndex == true) {
+                            aliasAction.writeIndex(false) // Strip write index if it's true on leader
+                        } else {
+                            aliasAction.writeIndex(writeIndex) // Preserve null or false
+                        }
 
                         if (alias.filteringRequired())  {
                             aliasAction = aliasAction.filter(alias.filter.string())
@@ -609,7 +615,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                         // Only remove if it doesn't exist on the leader at all (by name).
                         // If it exists on leader but differs (e.g. writeIndex), it was added/updated in the 'toAdd' loop above.
                         if (!leaderAliasNames.contains(alias.alias())) {
-                            log.info("Removing alias  ${alias.alias} from $followerIndexName")
+                            log.info("Removing alias ${alias.alias} from $followerIndexName")
                             request.addAliasAction(AliasActions.remove().index(followerIndexName)
                                 .alias(alias.alias))
                         }

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -812,7 +812,6 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         setMetadataSyncDelay() // Ensure sync happens reasonably fast
         createConnectionBetweenClusters(FOLLOWER, LEADER)
 
-        // Create leader index with a write alias
         val createIndexResponse = leaderClient.indices().create(
             CreateIndexRequest(leaderIndexName)
                 .alias(Alias("write_alias").writeIndex(true)),
@@ -820,7 +819,6 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         )
         assertThat(createIndexResponse.isAcknowledged).isTrue()
 
-        // Start replication
         followerClient.startReplication(
             StartReplicationRequest("source", leaderIndexName, followerIndexName),
             waitForRestore = true
@@ -830,14 +828,12 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isEqualTo(true)
         }
 
-        // Verify follower alias exists but has write_index=false initially
         var followerAliases = followerClient.indices().getAlias(GetAliasesRequest().indices(followerIndexName), RequestOptions.DEFAULT)
         var aliasMetadata = followerAliases.aliases[followerIndexName]?.find { it.alias == "write_alias" }
         assertThat(aliasMetadata).isNotNull
         assertThat(aliasMetadata?.writeIndex()).isFalse()
 
-        // Phase 2: Trigger metadata sync/update on leader to ensure it doesn't revert
-        // Add a new alias on leader to force a diff and sync
+        // trigger a metadata sync to ensure the alias state is persisted
         val indicesAliasesRequest = IndicesAliasesRequest()
         indicesAliasesRequest.addAliasAction(
             IndicesAliasesRequest.AliasActions.add().index(leaderIndexName).alias("new_alias")
@@ -847,12 +843,10 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         TimeUnit.SECONDS.sleep(SLEEP_TIME_BETWEEN_SYNC + 2) // Wait for sync
 
         assertBusy {
-            // Check new alias appeared
             val aliases = followerClient.indices().getAlias(GetAliasesRequest().indices(followerIndexName), RequestOptions.DEFAULT)
             assertThat(aliases.aliases[followerIndexName]?.find { it.alias == "new_alias" }).isNotNull
         }
 
-        // Re-verify "write_alias" still has write_index=false after sync
         followerAliases = followerClient.indices().getAlias(GetAliasesRequest().indices(followerIndexName), RequestOptions.DEFAULT)
         aliasMetadata = followerAliases.aliases[followerIndexName]?.find { it.alias == "write_alias" }
         assertThat(aliasMetadata).isNotNull
@@ -1415,11 +1409,37 @@ class StartReplicationIT: MultiClusterRestTestCase() {
     private fun assertEqualAliases() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
-        var getAliasesRequest = GetAliasesRequest().indices(followerIndexName)
-        var aliasRespone = followerClient.indices().getAlias(getAliasesRequest, RequestOptions.DEFAULT)
-        var followerAliases = aliasRespone.aliases.get(followerIndexName)
-        aliasRespone = leaderClient.indices().getAlias(GetAliasesRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
-        var leaderAliases = aliasRespone.aliases.get(leaderIndexName)
-        Assert.assertEquals(followerAliases, leaderAliases)
+        val getAliasesRequest = GetAliasesRequest().indices(followerIndexName)
+        var aliasResponse = followerClient.indices().getAlias(getAliasesRequest, RequestOptions.DEFAULT)
+        val followerAliases = aliasResponse.aliases.get(followerIndexName)
+        aliasResponse = leaderClient.indices().getAlias(GetAliasesRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
+        val leaderAliases = aliasResponse.aliases.get(leaderIndexName)
+
+        if (followerAliases == null || leaderAliases == null) {
+            Assert.fail("Aliases are null. Leader: $leaderAliases, Follower: $followerAliases")
+        }
+        if (followerAliases!!.size != leaderAliases!!.size) {
+            Assert.fail("Alias count mismatch. Leader: ${leaderAliases.size}, Follower: ${followerAliases.size}")
+        }
+
+        for (leader in leaderAliases) {
+            val follower = followerAliases.find { it.alias() == leader.alias() }
+            Assert.assertNotNull("Follower missing alias ${leader.alias()}", follower)
+
+            Assert.assertEquals("Filter mismatch for ${leader.alias()}", leader.filter(), follower!!.filter())
+            Assert.assertEquals("IndexRouting mismatch for ${leader.alias()}", leader.indexRouting(), follower.indexRouting())
+            Assert.assertEquals("SearchRouting mismatch for ${leader.alias()}", leader.searchRouting(), follower.searchRouting())
+            Assert.assertEquals("IsHidden mismatch for ${leader.alias()}", leader.isHidden(), follower.isHidden())
+
+            val leaderWrite = leader.writeIndex()
+            val followerWrite = follower.writeIndex()
+
+            if (leaderWrite == true) {
+                Assert.assertFalse("Follower alias ${follower.alias()} should have writeIndex=false when leader is true", followerWrite == true)
+            } else {
+                Assert.assertEquals("WriteIndex mismatch for ${leader.alias()} (Leader: $leaderWrite)", leaderWrite, followerWrite)
+            }
+        }
     }
 }
+


### PR DESCRIPTION
In bidirectional replication setups, aliases with is_write_index: true on the leader are replicated to the follower with the same attribute. This causes conflicts when the follower cluster attempts to manage its own write index for the same alias.

This change addresses the issue by:
1. Applying AliasWriteIndexPolicy.STRIP_WRITE_INDEX during the initial snapshot restore (bootstrap).
2. Forcing writeIndex to false during periodic metadata synchronization in IndexReplicationTask.
3. Modifying the alias removal logic to prevent accidental deletion of aliases that exist on the leader but differ in metadata (e.g., writeIndex mismatch) during the sync diff. Added regression test in StartReplicationIT to verify alias behavior during bootstrap and subsequent metadata updates.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
