### PR TITLE
Add Mohit (@mohit10011999) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This list should match with the maintainters list.
-* @krishna-ggk @ankitkala @saikaranam-amazon @soosinha @gbbafna @monusingh-1
+* @krishna-ggk @ankitkala @saikaranam-amazon @soosinha @gbbafna @monusingh-1 mohit10011999

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,3 +12,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sooraj Sinha     | [soosinha](https://github.com/soosinha)            | Amazon      |
 | Gaurav Bafna     | [gbbafna](https://github.com/gbbafna)              | Amazon      |
 | Monu Singh       | [monusingh-1](https://github.com/monusingh-1)          | Amazon      |
+| Mohit Kumar      | [mohit10011999](https://github.com/mohit10011999)          | Amazon      |


### PR DESCRIPTION
### Description
Adding Mohit (@mohit10011999) as a maintainer.
Mohit has made substantial contribution to cross cluster replication plugin. Lists of PRs: https://github.com/opensearch-project/cross-cluster-replication/pulls?q=is%3Apr+author%3Amohit10011999+
He is actively involved in making CCR more robust and has been driving the new version releases as well.

### Related Issues
[1686](https://github.com/opensearch-project/cross-cluster-replication/issues/1686)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
