### PR TITLE
Upgrade filelock to 3.20.3 (CVE-2025-68146 and CVE-2026-22701)

### DIFF
--- a/perf_workflow/requirements.txt
+++ b/perf_workflow/requirements.txt
@@ -3,6 +3,7 @@ validators
 yamlfix
 cerberus
 pipenv
+filelock>=3.20.3
 requests~=2.32.4
 retry2
 ndg-httpsclient


### PR DESCRIPTION

- CVE-2025-68146: Race condition allowing file corruption/truncation through symlink attacks (fixed in 3.20.1)
- CVE-2026-22701: Race condition in SoftFileLock implementation (fixed in 3.20.3)


### Description
Upgrade filelock to 3.20.3 (CVE-2025-68146 and CVE-2026-22701)

### Related Issues
Resolves: #1627
Resolves: #1628

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
