### PR TITLE
fix mapping update not replicated when only new field is added

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -352,7 +352,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         return try {
             val clusterState = clusterService.state()
             val indexMetadata = clusterState.metadata.index(indexName)
-            
+
             if (indexMetadata == null) {
                 log.warn("Index metadata not found for $indexName, defaulting to open operation for safety")
                 true // Default to performing open operation for safety
@@ -637,11 +637,16 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 mappingResponse = client.suspending(client.admin().indices()::getMappings, injectSecurityContext = true)(gmr)
                 @Suppress("UNCHECKED_CAST")
                 val followerProperties = mappingResponse?.mappings()?.get(this.followerIndexName)?.sourceAsMap()?.toMap()?.get("properties") as? Map<String,Any>?
-                for((key,value) in followerProperties?: emptyMap()) {
-                    if (leaderProperties?.getValue(key).toString() != (value).toString()) {
-                        log.debug("Updating Multi-field Mapping at Follower")
-                        updateFollowerMapping(this.followerIndexName, leaderMappingSource)
-                        break
+                if (leaderProperties?.size != followerProperties?.size) {
+                    log.debug("Updating Multi-field Mapping at Follower - Mapping Size Difference Detected")
+                    updateFollowerMapping(this.followerIndexName, leaderMappingSource)
+                } else {
+                    for((key,value) in followerProperties?: emptyMap()) {
+                        if (leaderProperties?.getValue(key).toString() != (value).toString()) {
+                            log.debug("Updating Multi-field Mapping at Follower")
+                            updateFollowerMapping(this.followerIndexName, leaderMappingSource)
+                            break
+                        }
                     }
                 }
             } catch (e: Exception) {

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -1276,7 +1276,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         )
     }
 
-    fun `test that follower index mapping does not update when only new fields are added but not respective docs in leader index`() {
+    fun `test that follower index mapping updates when only new fields are added but not respective docs in leader index`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
@@ -1306,7 +1306,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         val leaderMappings = leaderClient.indices().getMapping(GetMappingsRequest().indices(leaderIndexName), RequestOptions.DEFAULT)
             .mappings()[leaderIndexName]
         TimeUnit.MINUTES.sleep(2)
-        Assert.assertNotEquals(
+        Assert.assertEquals(
             leaderMappings,
             followerClient.indices().getMapping(GetMappingsRequest().indices(followerIndexName), RequestOptions.DEFAULT)
                 .mappings()[followerIndexName]


### PR DESCRIPTION
### Description
Makes it so that adding only a new field to the leader index's mapping will trigger a replication to the follower. This was raised as a bug in #1430.

I tracked this behavior to `pollForMetadata()` where the code previously only checks if a property in the follower has been modified. The fix is simply to add an additional check that the leader has more/fewer properties than the follower.

There is a test in the code that makes it look like this is intended behavior (which I've altered to check the opposite). PTAL and let me know if there should be any change to this PR.

### Related Issues
Resolves #1430 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
