### PR TITLE
[2.19] Force resolution of log4j-core to 2.25.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ import org.opensearch.gradle.testclusters.OpenSearchNode
 import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
+    configurations.all {
+        resolutionStrategy {
+            force 'org.codehaus.plexus:plexus-utils:3.5.1'
+        }
+    }
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "2.19.5-SNAPSHOT")
@@ -129,7 +134,7 @@ configurations.all {
         force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
         force 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
         force 'org.yaml:snakeyaml:2.0'
-        force 'org.codehaus.plexus:plexus-utils:3.0.24'
+        force 'org.codehaus.plexus:plexus-utils:3.5.1'
         force 'org.apache.logging.log4j:log4j-core:2.25.3'
     }
 }


### PR DESCRIPTION
### Description

Force resolution of log4j-core to 2.25.3

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
