### PR TITLE
Fixing CVE-2026-25645 and CVE-2026-24400 (#1650)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     implementation "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
 
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
-    testImplementation "org.assertj:assertj-core:3.17.2"
+    testImplementation "org.assertj:assertj-core:3.27.7"
     testImplementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0" // Moving away from kotlin_version
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"

--- a/perf_workflow/requirements.txt
+++ b/perf_workflow/requirements.txt
@@ -4,7 +4,7 @@ yamlfix
 cerberus
 pipenv
 filelock>=3.20.3
-requests~=2.32.4
+requests>=2.33.0
 retry2
 ndg-httpsclient
 psutil


### PR DESCRIPTION
* Fixing CVE-2026-25645 and CVE-2026-24400



---------



(cherry picked from commit 2af49c105ddfabe0ed62647290b073865a9930f7)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
