### PR TITLE
Added diagnostic logging to identify CCR replication failures

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
@@ -106,9 +106,10 @@ class TransportGetChangesAction @Inject constructor(threadPool: ThreadPool, clus
                 if(fetchFromTranslog) {
                     try {
                         ops = translogService.getHistoryOfOperations(indexShard, request.fromSeqNo, toSeqNo)
-                    } catch (e: Exception) {
                         log.debug("Fetching changes from translog for ${request.shardId} " +
-                                "- from:${request.fromSeqNo}, to:$toSeqNo failed with exception - ${e.stackTraceToString()}")
+                                "from: ${request.fromSeqNo} to: $toSeqNo")
+                    } catch (e: Exception) {
+                        log.warn("Translog fetch failed for shard=${request.shardId}, from=${request.fromSeqNo}, to=$toSeqNo - falling back to Lucene: ${e.message}")
                         fetchFromTranslog = false
                     }
                 }

--- a/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/changes/TransportGetChangesAction.kt
@@ -109,7 +109,8 @@ class TransportGetChangesAction @Inject constructor(threadPool: ThreadPool, clus
                         log.debug("Fetching changes from translog for ${request.shardId} " +
                                 "from: ${request.fromSeqNo} to: $toSeqNo")
                     } catch (e: Exception) {
-                        log.warn("Translog fetch failed for shard=${request.shardId}, from=${request.fromSeqNo}, to=$toSeqNo - falling back to Lucene: ${e.message}")
+                        log.debug("Fetching changes from translog for ${request.shardId} " +
+                                "- from:${request.fromSeqNo}, to:$toSeqNo failed with exception - ${e.stackTraceToString()}")
                         fetchFromTranslog = false
                     }
                 }

--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
@@ -126,6 +126,7 @@ class TransportReplicateIndexClusterManagerNodeAction @Inject constructor(transp
                     listener.onResponse(ReplicateIndexResponse(false))
                 }
 
+                log.info("Persistent task created for replication: follower=${replicateIndexReq.followerIndex}, leader=${replicateIndexReq.leaderAlias}:${replicateIndexReq.leaderIndex}, taskId=${task.id}")
                 log.debug("Waiting for persistent task to move to following state")
                 // Now wait for the replication to start and the follower index to get created before returning
                 persistentTasksService.waitForTaskCondition(task.id, replicateIndexReq.timeout()) { t ->

--- a/src/main/kotlin/org/opensearch/replication/action/replay/TransportReplayChangesAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/replay/TransportReplayChangesAction.kt
@@ -194,7 +194,7 @@ class TransportReplayChangesAction @Inject constructor(settings: Settings, trans
             //TODO: call .masterNodeTimeout() with the setting indices.mapping.dynamic_timeout
         val updateMappingRequest = UpdateMetadataRequest(followerIndex, UpdateMetadataRequest.Type.MAPPING, putMappingRequest)
         client.suspendExecute(UpdateMetadataAction.INSTANCE, updateMappingRequest, injectSecurityContext = true)
-        log.debug("Mappings synced for $followerIndex")
+        log.debug("Mappings synced for $followerIndex from ${leaderAlias}:${leaderIndex}")
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -132,8 +132,8 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
         val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient)
         shards?.forEach {
             val followerShardId = it.value.shardId
-
-            if  (!retentionLeaseHelper.verifyRetentionLeaseExist(ShardId(params.leaderIndex, followerShardId.id), followerShardId)) {
+            if (!retentionLeaseHelper.verifyRetentionLeaseExist(ShardId(params.leaderIndex, followerShardId.id), followerShardId)) {
+                log.info("Retention lease missing for follower=${params.followerIndexName}, followerShard=$followerShardId, leaderShard=${ShardId(params.leaderIndex, followerShardId.id)} - replication cannot be resumed")
                 isResumable = false
             }
         }

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -321,7 +321,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
                 leaderShardId, fileMetadata, leaderClusterClient, recoveryState, replicationSettings.chunkSize,
                 object : ActionListener<Void> {
                     override fun onFailure(e: java.lang.Exception?) {
-                        log.error("Restore of ${store.shardId()} failed due to ${e?.stackTraceToString()}")
+                        log.error("Restore of ${store.shardId()} failed due to follower=$followerIndexName, leaderShard=$leaderShardId, error=${e?.stackTraceToString()}")
                         if (e is NodeDisconnectedException || e is NodeNotConnectedException || e is ConnectTransportException) {
                             log.info("Retrying restore shard for ${store.shardId()}")
                             Thread.sleep(1000) // to get updated leader cluster state
@@ -330,7 +330,7 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
                                         recoveryState, listener, ::restoreShardUsingMultiChunkTransfer, log = log)
                             }
                         } else {
-                            log.error("Not retrying restore shard for ${store.shardId()}")
+                            log.error("Not retrying restore shard for ${store.shardId()} follower=$followerIndexName, leaderShard=$leaderShardId")
                             store.decRef()
                             releaseLeaderResources(restoreUUID, leaderShardNode, leaderShardId, followerShardId, followerIndexName)
                             listener.onFailure(e)

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -316,6 +316,8 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
         // 2. Request for individual files from leader cluster for this shardId
         // make sure the store is not released until we are done.
         val fileMetadata = ArrayList(metadataSnapshot.asMap().values)
+        val totalSizeBytes = fileMetadata.sumOf { it.length() }
+        log.info("Starting bootstrap restore: follower=$followerIndexName, followerShard=$followerShardId, leaderShard=$leaderShardId, fileCount=${fileMetadata.size}, totalSizeBytes=$totalSizeBytes")
         multiChunkTransfer = RemoteClusterMultiChunkTransfer(log, clusterService.clusterName.value(), client.threadPool().threadContext,
                 store, replicationSettings.concurrentFileChunks, restoreUUID, replMetadata, leaderShardNode,
                 leaderShardId, fileMetadata, leaderClusterClient, recoveryState, replicationSettings.chunkSize,

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -110,7 +110,7 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
             log.info("Added new retention lease: id=$retentionLeaseId, leaderShard=$leaderShardId, seqNo=$seqNo")
             return true
         } catch (e: Exception) {
-            log.warn("Failed to add new retention lease: id=$retentionLeaseId, leaderShard=$leaderShardId, seqNo=$seqNo, error=${e.message}")
+            log.info("Failed to add new retention lease: id=$retentionLeaseId, leaderShard=$leaderShardId, seqNo=$seqNo, error=${e.message}")
             return false
         }
     }

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterRetentionLeaseHelper.kt
@@ -107,9 +107,10 @@ class RemoteClusterRetentionLeaseHelper constructor(var followerClusterNameWithU
         val request = RetentionLeaseActions.AddRequest(leaderShardId, retentionLeaseId, seqNo, retentionLeaseSource)
         try {
             client.suspendExecute(RetentionLeaseActions.Add.INSTANCE, request)
+            log.info("Added new retention lease: id=$retentionLeaseId, leaderShard=$leaderShardId, seqNo=$seqNo")
             return true
         } catch (e: Exception) {
-            log.info("Exception while adding new retention lease with i: $retentionLeaseId")
+            log.warn("Failed to add new retention lease: id=$retentionLeaseId, leaderShard=$leaderShardId, seqNo=$seqNo, error=${e.message}")
             return false
         }
     }

--- a/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterTranslogService.kt
+++ b/src/main/kotlin/org/opensearch/replication/seqno/RemoteClusterTranslogService.kt
@@ -56,6 +56,9 @@ class RemoteClusterTranslogService : AbstractLifecycleComponent(){
                 op = snapshot.next()
             }
         }
+        if (filteredOpsFromTranslog != opsSize.toInt()) {
+            log.error("Translog operation count mismatch for shard=${indexShard.shardId()}: expected=$opsSize, got=$filteredOpsFromTranslog, range=$startSeqNo-$toSeqNo")
+        }
         assert(filteredOpsFromTranslog == opsSize.toInt()) {"Missing operations while fetching from translog"}
 
         val sortedOps = ArrayList<Translog.Operation>(opsSize.toInt())

--- a/src/main/kotlin/org/opensearch/replication/task/CrossClusterReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/CrossClusterReplicationTask.kt
@@ -98,7 +98,7 @@ abstract class CrossClusterReplicationTask(id: Long, type: String, action: Strin
                 markAsCompleted()
             } catch (e: Exception) {
                 log.error(
-                    "Exception encountered in CrossClusterReplicationTask - coroutine:isActive=${isActive} Context=${coroutineContext}", e)
+                    "Exception encountered in CrossClusterReplicationTask - task=${this.javaClass.simpleName}, id=$id, follower=$followerIndexName, leader=$leaderAlias, coroutine:isActive=${isActive} Context=${coroutineContext}", e)
                 if (isCancelled || e is CancellationException) {
                     markAsCompleted()
                     log.info("Completed the task with id:$id")
@@ -211,7 +211,7 @@ abstract class CrossClusterReplicationTask(id: Long, type: String, action: Strin
                     if(e.status().status < 500 && e.status() != RestStatus.TOO_MANY_REQUESTS) {
                         throw e
                     }
-                    log.error("Failed to fetch replication metadata due to ", e)
+                    log.error("Failed to fetch replication metadata due to task=${this.javaClass.simpleName}, id=$id, error=${e.message}", e)
                     delay(DEFAULT_WAIT_ON_ERRORS)
                 }
             }

--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -70,6 +70,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
 
     override suspend fun execute(scope: CoroutineScope, initialState: PersistentTaskState?) {
         stat = AutoFollowStat(params.patternName, replicationMetadata.leaderContext.resource, params.leaderCluster)
+        log.info("AutoFollow task started: leaderAlias=$leaderAlias, pattern=${params.patternName}, resource=${replicationMetadata.leaderContext.resource}")
         while (scope.isActive) {
             try {
                 addRetryScheduler()
@@ -81,7 +82,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
                 // Any transient error encountered during auto follow execution should be re-tried
                 val status = e.status().status
                 if(status < 500 && status != RestStatus.TOO_MANY_REQUESTS.status) {
-                    log.error("Exiting autofollow task", e)
+                    log.error("Exiting autofollow task: leaderAlias=$leaderAlias, pattern=${params.patternName}, status=$status", e)
                     throw e
                 }
                 log.debug("Encountered transient error while running autofollow task", e)
@@ -104,7 +105,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
                     replicationSettings.autofollowRetryPollDuration,
                     ThreadPool.Names.SAME)
         } catch (e: Exception) {
-            log.error("Error scheduling retry on failed autofollow indices ${e.stackTraceToString()}")
+            log.error("Error scheduling retry on failed autofollow indices leaderAlias=$leaderAlias, pattern=$patternName, error=${e.stackTraceToString()}")
              retryScheduler = null
         }
     }
@@ -115,6 +116,7 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
 
     private suspend fun pollForIndices() {
         log.debug("Checking $leaderAlias under pattern name $patternName for new indices to auto follow")
+        log.debug("Polling for indices: leaderAlias=$leaderAlias, pattern=$patternName")
         val entry = replicationMetadata.leaderContext.resource
 
         // Fetch remote indices matching auto follow pattern
@@ -126,12 +128,11 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
                     .indicesOptions(IndicesOptions.lenientExpandOpen())
             val response = remoteClient.suspending(remoteClient.admin().indices()::getIndex, true)(indexReq)
             remoteIndices = response.indices.asIterable()
-
         } catch (e: Exception) {
             // Ideally, Calls to the remote cluster shouldn't fail and autofollow task should be able to pick-up the newly created indices
             // matching the pattern. Should be safe to retry after configured delay.
             if(stat.failedLeaderCall >= 0 && stat.failedLeaderCall.rem(10) == 0L) {
-                log.error("Fetching remote indices failed with error - ${e.stackTraceToString()}")
+                log.error("Fetching remote indices failed with error - leaderAlias=$leaderAlias, pattern=$patternName, consecutiveFailures=${stat.failedLeaderCall}, error=${e.stackTraceToString()}")
             }
             stat.failedLeaderCall++
         }

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -188,6 +188,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                             log.debug("Resuming tasks now.")
                             InitFollowState
                         } else {
+                            log.info("Starting new index replication: follower=$followerIndexName, leader=$leaderAlias:${leaderIndex.name}")
                             setupAndStartRestore()
                         }
                     }
@@ -263,7 +264,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 }
                 if (isCompleted) break
             } catch(e: ReplicationException) {
-                log.error("Exiting index replication task", e)
+                log.error("Exiting index replication task follower=$followerIndexName, leader=$leaderAlias:${leaderIndex.name}", e)
                 throw e
             } catch(e: OpenSearchException) {
                 val status = e.status().status
@@ -272,7 +273,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 // should continue to poll and Any failure encoutered from shard task should
                 // invoke state transition and exit
                 if(status < 500 && status != RestStatus.TOO_MANY_REQUESTS.status) {
-                    log.error("Exiting index replication task", e)
+                    log.error("Exiting index replication task follower=$followerIndexName, status=$status", e)
                     throw e
                 }
                 log.debug("Encountered transient error while running index replication task", e)
@@ -284,7 +285,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
     private suspend fun failReplication(failedState: FailedState) {
         withContext(NonCancellable) {
             val reason = failedState.errorMsg
-            log.error("Moving replication[IndexReplicationTask:$id][reason=${reason}] to failed state")
+            log.error("Moving replication[IndexReplicationTask:$id][follower=$followerIndexName, leader=$leaderAlias:${leaderIndex.name}, reason=${reason}] to failed state")
             try {
                 replicationMetadataManager.updateIndexReplicationState(
                     followerIndexName,
@@ -372,9 +373,9 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
      */
     private suspend fun conditionallyOpenIndex(indexName: String, logSuffix: String = "") {
         if (isIndexClosed(indexName)) {
-            log.info("Index $indexName is closed, opening it")
             val updateRequest = UpdateMetadataRequest(indexName, UpdateMetadataRequest.Type.OPEN, Requests.openIndexRequest(indexName))
             client.suspendExecute(UpdateMetadataAction.INSTANCE, updateRequest, injectSecurityContext = true)
+            log.info("Index $indexName is closed, opening it")
             if (logSuffix.isNotEmpty()) {
                 log.info("Opened the index $indexName $logSuffix")
             }
@@ -431,7 +432,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         } catch (e: Exception) {
             errorEncountered = true
             if (shouldAliasLogError) {
-                log.error("Encountered exception while updating alias ${e.stackTraceToString()}")
+                log.error("Encountered exception while updating alias follower=$followerIndexName, error=${e.stackTraceToString()}")
             }
         } finally {
             if (errorEncountered) {
@@ -448,7 +449,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         } catch (e: Exception) {
             errorEncountered = true
             if (shouldSettingsLogError) {
-                log.error("Encountered exception while updating settings ${e.stackTraceToString()}")
+                log.error("Encountered exception while updating settings follower=$followerIndexName, error=${e.stackTraceToString()}")
             }
         } finally {
             if (errorEncountered) {
@@ -645,7 +646,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     }
                 }
             } catch (e: Exception) {
-                log.error("Error in getting the required metadata ${e.stackTraceToString()}")
+                log.error("Error in getting the required metadata follower=$followerIndexName, leader=$leaderAlias:${leaderIndex.name}, error=${e.stackTraceToString()}")
             } finally {
                 withContext(NonCancellable) {
                     log.debug("Metadata sync sleeping for ${replicationSettings.metadataSyncInterval.millis}")
@@ -721,7 +722,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
     private suspend fun pauseReplication(state: FailedState): IndexReplicationState {
         try {
-            log.error("Going to initiate auto-pause of $followerIndexName due to shard failures - $state")
+            log.error("Going to initiate auto-pause of $followerIndexName due to shard failures - failedShards=${state.failedShards.keys}, reason=${state.errorMsg}")
             val pauseReplicationResponse = client.suspendExecute(
                 replicationMetadata,
                 PauseIndexReplicationAction.INSTANCE, PauseIndexReplicationRequest(followerIndexName, "$AUTOPAUSED_REASON_PREFIX + ${state.errorMsg}"),
@@ -916,7 +917,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         val updateSettingsRequest = remoteClient.admin().indices().prepareUpdateSettings().setSettings(settingsBuilder).setIndices(leaderIndex.name).request()
         val updateResponse = remoteClient.suspending(remoteClient.admin().indices()::updateSettings, injectSecurityContext = true)(updateSettingsRequest)
         if(!updateResponse.isAcknowledged) {
-            log.error("Unable to update setting for translog pruning based on retention lease")
+            log.error("Unable to update setting for translog pruning based on retention lease leaderIndex=${leaderIndex.name}")
         }
 
         val restoreRequest = client.admin().cluster()

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -410,6 +410,8 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 .collect(Collectors.toList())
 
         if (runningShardTasksForIndex.size != followerShardIds.size) {
+            val missingShardsIds = followerShardIds - runningShardTasksForIndex.map { it.followerShardId }.toSet()
+            log.info("Shard task count mismatch for follower=$followerIndexName: expected=${followerShardIds.size}, running=${runningShardTasksForIndex.size}, missingShards=$missingShardsIds")
             return InitFollowState
         }
 
@@ -874,6 +876,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
             it.value.shardId
         }?.associate { shardId ->
             val task = runningShardTasks.getOrElse(shardId) {
+                log.info("Starting missing shard task for follower=$followerIndexName, shardId=$shardId, leaderShard=${ShardId(leaderIndex, shardId.id)}")
                 startReplicationTask(ShardReplicationParams(leaderAlias, ShardId(leaderIndex, shardId.id), shardId))
             }
             return@associate shardId to task
@@ -949,16 +952,20 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         cso.waitForNextChange("remote restore start") { inProgressRestore(it) != null }
         return RestoreState
     }
-
+ 
     private suspend fun waitForRestore(): IndexReplicationState {
         var restore = inProgressRestore(clusterService.state())
+        var timeoutCount = 0
+        val restoreStartTime = System.currentTimeMillis()
 
         // Waiting for snapshot restore to reach a terminal stage.
         while (restore != null && restore.state() != RestoreInProgress.State.FAILURE && restore.state() != RestoreInProgress.State.SUCCESS) {
             try {
                 cso.waitForNextChange("remote restore finish")
             } catch(e: OpenSearchTimeoutException) {
-                log.info("Timed out while waiting for restore to complete.")
+                timeoutCount++
+                val elapsedSecs = (System.currentTimeMillis() - restoreStartTime) / 1000
+                log.debug("Timed out while waiting for restore to complete. follower=$followerIndexName, leader=$leaderAlias:${leaderIndex.name}, elapsedSecs=$elapsedSecs, timeoutCount=$timeoutCount, restoreState=${restore?.state()}")
             }
             restore = inProgressRestore(clusterService.state())
         }

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -126,7 +126,7 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                 val throwable: Throwable = downstreamException as Throwable
 
                 withContext(NonCancellable) {
-                    logInfo("Going to mark ShardReplicationTask as Failed with ${throwable.stackTraceToString()}")
+                    logInfo("Going to mark ShardReplicationTask as Failed: leaderShard=$leaderShardId, followerShard=$followerShardId, cause=${throwable.stackTraceToString()}")
                     try {
                         updateTaskState(FailedState(toESException(throwable)))
                     } catch (inner: Exception) {
@@ -197,15 +197,17 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
         updateTaskState(FollowingState)
         val followerIndexService = indicesService.indexServiceSafe(followerShardId.index)
         val indexShard = followerIndexService.getShard(followerShardId.id)
+        logInfo("Shard replication started: leaderShard=$leaderShardId, followerShard=$followerShardId, localCheckpoint=${indexShard.localCheckpoint}, globalCheckpoint=${indexShard.lastSyncedGlobalCheckpoint}")
 
         try {
             //Retention leases preserve the operations including and starting from the retainingSequenceNumber we specify when we take the lease .
             //hence renew retention lease with lastSyncedGlobalCheckpoint + 1
             retentionLeaseHelper.renewRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint + 1, followerShardId)
+            log.debug("${Thread.currentThread().name}: Initial retention lease renewed: leaderShard=$leaderShardId, followerShard=$followerShardId, seqNo=${indexShard.lastSyncedGlobalCheckpoint + 1}")
         } catch (ex: Exception) {
             // In case of a failure, we just log it and move on. All failures scenarios are being handled below with
             // retries and backoff depending on exception.
-            log.error("Retention lease renewal failed: ${ex.stackTraceToString()}")
+            log.error("Retention lease renewal failed: leaderShard=$leaderShardId, followerShard=$followerShardId, error=${ex.stackTraceToString()}")
         }
 
         addListenerToInterruptTask()
@@ -243,17 +245,17 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                         backOffForRetry = initialBackoffMillis
                     } catch (e: OpenSearchTimeoutException) {
                         //TimeoutException is thrown if leader fails to send new changes in 1 minute, so we dont need a backoff again here for this exception
-                        logInfo("Timed out waiting for new changes. Current seqNo: $fromSeqNo. $e")
+                        logInfo("Long-poll timed out waiting for new changes from $leaderShardId. Current seqNo: $fromSeqNo")
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                     } catch (e: NodeNotConnectedException) {
                         followerClusterStats.stats[followerShardId]!!.opsReadFailures.addAndGet(1)
-                        logInfo("Node not connected. Retrying request using a different node. ${e.stackTraceToString()}")
+                        logWarn("Node not connected to $leaderAlias, retrying with different node. followerShard=$followerShardId, seqNo=$fromSeqNo: ${e.message}")
                         delay(backOffForRetry)
                         backOffForRetry = (backOffForRetry * factor).toLong().coerceAtMost(maxTimeOut)
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                     } catch (e: Exception) {
                         followerClusterStats.stats[followerShardId]!!.opsReadFailures.addAndGet(1)
-                        logInfo("Unable to get changes from seqNo: $fromSeqNo. ${e.stackTraceToString()}")
+                        logWarn("Failed to get changes from $leaderShardId: seqNo=$fromSeqNo, backoffMs=$backOffForRetry, error=${e.message}")
 
                         // Handle 2GB limit exception specifically
                         if (e is IllegalArgumentException &&
@@ -290,9 +292,13 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                 try {
                     retentionLeaseHelper.renewRetentionLease(leaderShardId, indexShard.lastSyncedGlobalCheckpoint + 1, followerShardId)
                     lastLeaseRenewalMillis = System.currentTimeMillis()
+                    log.debug("${Thread.currentThread().name}: Retention lease renewed: leaderShard=$leaderShardId, followerShard=$followerShardId, seqNo=${indexShard.lastSyncedGlobalCheckpoint + 1}")
                 } catch (ex: Exception) {
                     when (ex) {
-                        is RetentionLeaseNotFoundException ->  throw ex
+                        is RetentionLeaseNotFoundException -> {
+                            logError("Retention lease not found for $leaderShardId/$followerShardId - replication cannot continue")
+                            throw ex
+                        }
                         is RetentionLeaseInvalidRetainingSeqNoException -> {
                             if (System.currentTimeMillis() - lastLeaseRenewalMillis >  replicationSettings.leaseRenewalMaxFailureDuration.millis) {
                                 log.error("Retention lease renewal has been failing for last " +
@@ -325,6 +331,9 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
     }
     private fun logInfo(msg: String) {
         log.info("${Thread.currentThread().name}: $msg")
+    }
+    private fun logWarn(msg: String) {
+        log.warn("${Thread.currentThread().name}: $msg")
     }
     private fun logError(msg: String) {
         log.error("${Thread.currentThread().name}: $msg")

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -245,17 +245,17 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                         backOffForRetry = initialBackoffMillis
                     } catch (e: OpenSearchTimeoutException) {
                         //TimeoutException is thrown if leader fails to send new changes in 1 minute, so we dont need a backoff again here for this exception
-                        logInfo("Long-poll timed out waiting for new changes from $leaderShardId. Current seqNo: $fromSeqNo")
+                        logInfo("Timed out waiting for new changes. Current seqNo: $fromSeqNo. $e")
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                     } catch (e: NodeNotConnectedException) {
                         followerClusterStats.stats[followerShardId]!!.opsReadFailures.addAndGet(1)
-                        logWarn("Node not connected to $leaderAlias, retrying with different node. followerShard=$followerShardId, seqNo=$fromSeqNo: ${e.message}")
+                        logInfo("Node not connected to $leaderAlias, retrying with different node. followerShard=$followerShardId, seqNo=$fromSeqNo: ${e.message}")
                         delay(backOffForRetry)
                         backOffForRetry = (backOffForRetry * factor).toLong().coerceAtMost(maxTimeOut)
                         changeTracker.updateBatchFetched(false, fromSeqNo, toSeqNo, fromSeqNo - 1,-1)
                     } catch (e: Exception) {
                         followerClusterStats.stats[followerShardId]!!.opsReadFailures.addAndGet(1)
-                        logWarn("Failed to get changes from $leaderShardId: seqNo=$fromSeqNo, backoffMs=$backOffForRetry, error=${e.message}")
+                        logInfo("Unable to get changes from seqNo: $fromSeqNo. ${e.stackTraceToString()}")
 
                         // Handle 2GB limit exception specifically
                         if (e is IllegalArgumentException &&


### PR DESCRIPTION
### Description
During CCR replication incidents, operators lacks sufficient logging to identify replication failures. Troubleshooting requires extensive cross-referencing of task IDs and cluster state without clear failure context, significantly increasing time-to-diagnosis. Added targeted diagnostic logging to significantly improve time to diagnosis for future CCR-related incidents and provide better operational visibility into replication health. 

Resolves: 

### Related Issues
Resolves  #3040091
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
