### PR TITLE
Fix NPE in ShardReplicationTask under high shard concurrency (#1660)

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/shard/FollowerClusterStats.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/FollowerClusterStats.kt
@@ -20,6 +20,7 @@ import org.opensearch.core.xcontent.ToXContentFragment
 import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.core.index.shard.ShardId
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 class FollowerShardMetric  {
@@ -116,5 +117,6 @@ class FollowerShardMetric  {
 
 @Singleton
 class FollowerClusterStats {
-    var stats :MutableMap<ShardId, FollowerShardMetric> =  mutableMapOf()
+    // ConcurrentHashMap: concurrent put/remove/get from multiple ShardReplicationTasks (issue #1660)
+    val stats: MutableMap<ShardId, FollowerShardMetric> = ConcurrentHashMap()
 }


### PR DESCRIPTION

### Description
FollowerClusterStats.stats was backed by a non-thread-safe LinkedHashMap (mutableMapOf()). The singleton is shared across all ShardReplicationTasks (one per shard), and under concurrent puts from ~1024 shards, internal rehashing caused stats[shardId] to return a transient null, which the '!!' assertion in ShardReplicationTask.replicate() and TranslogSequencer turned into a NullPointerException, auto-pausing replication.

Replace mutableMapOf() with ConcurrentHashMap() so concurrent put/get/remove never observe a spurious null. Change var to val since the reference is never reassigned.

### Related Issues
Resolves #1660 


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
