### PR TITLE
Skip syncing number_of_replicas when follower has auto_expand_replica…

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -166,6 +166,21 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         const val AUTOPAUSED_REASON_PREFIX = "AutoPaused: "
         const val TASK_CANCELLATION_REASON = AUTOPAUSED_REASON_PREFIX + "Index replication task was cancelled by user"
 
+        /**
+         * Determines whether a given setting key should be skipped during metadata sync
+         * from leader to follower. When auto_expand_replicas is active on the follower,
+         * number_of_replicas must not be synced because the follower computes it locally
+         * based on its own node count.
+         *
+         * See: https://github.com/opensearch-project/cross-cluster-replication/issues/1661
+         */
+        fun shouldSkipSettingSync(key: String, followerSettings: Settings): Boolean {
+            if (key != IndexMetadata.SETTING_NUMBER_OF_REPLICAS) {
+                return false
+            }
+            val autoExpandReplicas = followerSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)
+            return autoExpandReplicas != null && autoExpandReplicas != "false"
+        }
     }
 
     //only for testing
@@ -515,6 +530,11 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                 for (settings in settingsList) {
                     for (key in settings.keySet()) {
                         if (indexScopedSettings.isPrivateSetting(key)) {
+                            continue
+                        }
+                        // Skip number_of_replicas when auto_expand_replicas is active on the follower.
+                        // See: https://github.com/opensearch-project/cross-cluster-replication/issues/1661
+                        if (shouldSkipSettingSync(key, followerSettings)) {
                             continue
                         }
                         val setting = indexScopedSettings[key]

--- a/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationTaskTests.kt
@@ -31,6 +31,7 @@ import org.opensearch.cluster.node.DiscoveryNodes
 import org.opensearch.cluster.routing.RoutingTable
 import org.opensearch.common.settings.Settings
 import org.opensearch.common.settings.SettingsModule
+import org.opensearch.index.IndexSettings
 import org.opensearch.common.unit.TimeValue
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.index.Index
@@ -385,5 +386,43 @@ class IndexReplicationTaskTests : OpenSearchTestCase()  {
 
         val isMissingResult = replicationTask.isIndexClosed("non-existent-index")
         assertThat(isMissingResult).isTrue() // Should default to true for safety
+    }
+
+    fun testShouldSkipNumberOfReplicasWhenAutoExpandIsActive() {
+        // auto_expand_replicas = "0-all" → should skip number_of_replicas
+        val followerSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+            .build()
+        assertThat(IndexReplicationTask.shouldSkipSettingSync(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, followerSettings)).isTrue()
+    }
+
+    fun testShouldSkipNumberOfReplicasWhenAutoExpandIsRange() {
+        // auto_expand_replicas = "0-5" → should skip number_of_replicas
+        val followerSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-5")
+            .build()
+        assertThat(IndexReplicationTask.shouldSkipSettingSync(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, followerSettings)).isTrue()
+    }
+
+    fun testShouldNotSkipNumberOfReplicasWhenAutoExpandIsFalse() {
+        // auto_expand_replicas = "false" → should NOT skip number_of_replicas
+        val followerSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+            .build()
+        assertThat(IndexReplicationTask.shouldSkipSettingSync(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, followerSettings)).isFalse()
+    }
+
+    fun testShouldNotSkipNumberOfReplicasWhenAutoExpandIsAbsent() {
+        // auto_expand_replicas not set → should NOT skip number_of_replicas
+        val followerSettings = Settings.builder().build()
+        assertThat(IndexReplicationTask.shouldSkipSettingSync(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, followerSettings)).isFalse()
+    }
+
+    fun testShouldNotSkipOtherSettingsWhenAutoExpandIsActive() {
+        // auto_expand_replicas is active, but the key is NOT number_of_replicas → should NOT skip
+        val followerSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+            .build()
+        assertThat(IndexReplicationTask.shouldSkipSettingSync(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.key, followerSettings)).isFalse()
     }
 }


### PR DESCRIPTION
### Description
Fixes #1661.                                                                                                                                                                                                                                       
   
When CCR syncs index settings from leader to follower via `pollForMetadata()`, it copies the leader's `number_of_replicas` value. If the follower has `auto_expand_replicas` active (e.g., `"0-all"`) and the leader has fewer data nodes, this triggers a destructive cycle every 60 seconds:

  1. CCR pushes leader's lower `number_of_replicas` → destroys STARTED replica shards on follower
  2. `adaptAutoExpandReplicas()` corrects the count back up → creates new INITIALIZING shards (requires peer recovery) → cluster goes **YELLOW**
  3. Next sync (60s later) destroys the recovering shards → cycle repeats → **perpetual YELLOW**

### Fix

Adds a `shouldSkipSettingSync()` companion method in `IndexReplicationTask` that skips `number_of_replicas` inside the `desiredSettingsBuilder` loop when `auto_expand_replicas` is active on the follower. This ensures `number_of_replicas` never enters `desiredSettings`, avoiding unnecessary computation in downstream diff and update logic.

When `auto_expand_replicas` is disabled (`"false"`) or absent, `number_of_replicas` continues to sync as before.

  **Edge case:** If the leader disables `auto_expand_replicas` and sets `number_of_replicas` manually in the same sync, the fix skips `number_of_replicas` for that cycle (since `auto_expand_replicas` is still active on the follower). The `auto_expand_replicas: false` change gets applied, and on the next sync (60s later) `number_of_replicas` syncs normally. The follower has extra replicas for up to 60 seconds, which is harmless and self-corrects.

  ### Testing

  Added 5 unit tests for `shouldSkipSettingSync()`:
  | Test | Scenario | Expected |
  |------|----------|----------|
  | `testShouldSkipNumberOfReplicasWhenAutoExpandIsActive` | `auto_expand_replicas = "0-all"` | skip |
  | `testShouldSkipNumberOfReplicasWhenAutoExpandIsRange` | `auto_expand_replicas = "0-5"` | skip |
  | `testShouldNotSkipNumberOfReplicasWhenAutoExpandIsFalse` | `auto_expand_replicas = "false"` | don't skip |
  | `testShouldNotSkipNumberOfReplicasWhenAutoExpandIsAbsent` | setting absent | don't skip |
  | `testShouldNotSkipOtherSettingsWhenAutoExpandIsActive` | different setting key | don't skip |

### Related Issues
Resolves #1661
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
