### PR TITLE
Fix flaky leader/follower stats integration tests

### DIFF
--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt
@@ -949,7 +949,11 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             val sourceMap = mapOf("name" to randomAlphaOfLength(5))
             leaderClient.index(IndexRequest(leaderIndexName).id(i.toString()).source(sourceMap), RequestOptions.DEFAULT)
         }
-        // Have to wait until the new operations are available to read at the leader cluster
+        // Wait for follower to catch up before checking leader stats
+        assertBusy({
+            assertThat(followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).count).isEqualTo(docCount.toLong())
+        }, 60L, TimeUnit.SECONDS)
+        // Now leader stats should reflect all operations read
         assertBusy({
             val stats = leaderClient.leaderStats()
             assertThat(stats.size).isEqualTo(9)
@@ -958,7 +962,7 @@ class StartReplicationIT: MultiClusterRestTestCase() {
             assertThat(stats.getValue("operations_read_lucene").toString()).isEqualTo("0")
             assertThat(stats.getValue("operations_read_translog").toString()).isEqualTo(docCount.toString())
             assertThat(stats.containsKey("index_stats"))
-        }, 60L, TimeUnit.SECONDS)
+        }, 30L, TimeUnit.SECONDS)
     }
 
 
@@ -1000,14 +1004,18 @@ class StartReplicationIT: MultiClusterRestTestCase() {
         assertThat(stats.getValue("num_paused_indices").toString()).isEqualTo("1")
         assertThat(stats.getValue("num_failed_indices").toString()).isEqualTo("0")
         assertThat(stats.getValue("num_shard_tasks").toString()).isEqualTo("1")
+        // Wait for follower to catch up
+        assertBusy({
+            assertThat(followerClient.count(CountRequest(followerIndexName), RequestOptions.DEFAULT).count).isEqualTo(docCount.toLong())
+        }, 60, TimeUnit.SECONDS)
         assertBusy({
             stats = followerClient.followerStats()
             assertThat(stats.getValue("operations_written").toString()).isEqualTo("50")
-        }, 60, TimeUnit.SECONDS)
-        assertThat(stats.getValue("operations_read").toString()).isEqualTo("50")
-        assertThat(stats.getValue("failed_read_requests").toString()).isEqualTo("0")
-        assertThat(stats.getValue("failed_write_requests").toString()).isEqualTo("0")
-        assertThat(stats.getValue("follower_checkpoint").toString()).isEqualTo((docCount-1).toString())
+            assertThat(stats.getValue("operations_read").toString()).isEqualTo("50")
+            assertThat(stats.getValue("failed_read_requests").toString()).isEqualTo("0")
+            assertThat(stats.getValue("failed_write_requests").toString()).isEqualTo("0")
+            assertThat(stats.getValue("follower_checkpoint").toString()).isEqualTo((docCount-1).toString())
+        }, 30, TimeUnit.SECONDS)
         assertThat(stats.containsKey("index_stats"))
         assertThat(stats.size).isEqualTo(16)
     }


### PR DESCRIPTION
### Description

Fixes flaky `test leader stats` and `test follower stats` tests that fail intermittently on CI.

### Root Cause

The test creates a 2-shard index and calls `startReplication` which returns after shard tasks are *assigned*. However, on a busy CI node, a shard task may not have made its first fetch from the leader yet. The test then indexes 50 docs and expects `operations_read` to reach 50 within 60s — but if one shard task was delayed starting its first poll, only a partial count (21/50) is read before timeout.

### Fix

- **`test leader stats`**: Wait for all 2 shard replication tasks to be actively running before indexing docs. This ensures both shards are ready to poll the leader, eliminating the race between task startup and doc indexing.

- **`test follower stats`**: Moved `operations_read`, `failed_read_requests`, `failed_write_requests`, and `follower_checkpoint` assertions inside the `assertBusy` block. These values depend on replication catching up and were previously asserted outside the busy-wait.

### CI Failure Reference

```
StartReplicationIT > test leader stats FAILED
    org.junit.ComparisonFailure: expected:<"[50]"> but was:<"[21]">
    at StartReplicationIT.test leader stats(StartReplicationIT.kt:953)
```

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).