### PR TITLE
[Backport PR] Clear Stale Persistent Tasks in Stop/Pause API (#1629)

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/index/TransportReplicateIndexClusterManagerNodeAction.kt
@@ -17,6 +17,7 @@ import org.opensearch.replication.task.ReplicationState
 import org.opensearch.replication.task.index.IndexReplicationExecutor
 import org.opensearch.replication.task.index.IndexReplicationParams
 import org.opensearch.replication.task.index.IndexReplicationState
+import org.opensearch.replication.util.StaleTaskUtils
 import org.opensearch.replication.util.coroutineContext
 import org.opensearch.replication.util.startTask
 import org.opensearch.replication.util.suspending
@@ -104,6 +105,12 @@ class TransportReplicateIndexClusterManagerNodeAction @Inject constructor(transp
                 if (state.routingTable.hasIndex(replicateIndexReq.followerIndex)) {
                     throw IllegalArgumentException("Cant use same index again for replication. " +
                     "Delete the index:${replicateIndexReq.followerIndex}")
+                }
+
+                // Remove all replication tasks before creating new ones
+                val removedTaskCount = StaleTaskUtils.removeAllTasksForIndex(clusterService, nodeClient, replicateIndexReq.followerIndex)
+                if (removedTaskCount > 0) {
+                    log.info("Cleaned up $removedTaskCount tasks for ${replicateIndexReq.followerIndex}")
                 }
 
                 indexScopedSettings.validate(replicateIndexReq.settings,

--- a/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/resume/TransportResumeIndexReplicationAction.kt
@@ -84,6 +84,10 @@ class TransportResumeIndexReplicationAction @Inject constructor(transportService
             listener.completeWith {
                 log.info("Resuming index replication on index:" + request.indexName)
                 validateResumeReplicationRequest(request)
+
+                // Remove all existing tasks before resuming to ensure a clean slate
+                StaleTaskUtils.removeAllTasksForIndex(clusterService, client, request.indexName)
+
                 val replMetdata = replicationMetadataManager.getIndexReplicationMetadata(request.indexName)
                 val remoteMetadata = getLeaderIndexMetadata(replMetdata.connectionName, replMetdata.leaderContext.resource)
                 val params = IndexReplicationParams(replMetdata.connectionName, remoteMetadata.index, request.indexName)

--- a/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stop/TransportStopIndexReplicationAction.kt
@@ -19,12 +19,10 @@ import org.opensearch.replication.action.index.block.UpdateIndexBlockAction
 import org.opensearch.replication.action.index.block.UpdateIndexBlockRequest
 import org.opensearch.replication.metadata.INDEX_REPLICATION_BLOCK
 import org.opensearch.replication.metadata.ReplicationMetadataManager
-import org.opensearch.replication.metadata.ReplicationOverallState
 import org.opensearch.replication.metadata.UpdateMetadataAction
 import org.opensearch.replication.metadata.UpdateMetadataRequest
-import org.opensearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_STATE
-import org.opensearch.replication.metadata.state.getReplicationStateParamsForIndex
 import org.opensearch.replication.seqno.RemoteClusterRetentionLeaseHelper
+import org.opensearch.replication.util.StaleTaskUtils
 import org.opensearch.replication.util.coroutineContext
 import org.opensearch.replication.util.suspendExecute
 import org.opensearch.replication.util.suspending
@@ -35,6 +33,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.apache.logging.log4j.LogManager
 import org.opensearch.OpenSearchException
+import org.opensearch.ResourceNotFoundException
 import org.opensearch.core.action.ActionListener
 import org.opensearch.action.admin.indices.open.OpenIndexRequest
 import org.opensearch.action.support.ActionFilters
@@ -56,8 +55,6 @@ import org.opensearch.common.inject.Inject
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.common.settings.Settings
 import org.opensearch.replication.util.stackTraceToString
-import org.opensearch.persistent.PersistentTasksCustomMetadata
-import org.opensearch.persistent.RemovePersistentTaskAction
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 import java.io.IOException
@@ -106,8 +103,6 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                     throw OpenSearchException("Failed to remove index block on ${request.indexName}")
                 }
 
-                validateReplicationStateOfIndex(request)
-
                 // Index will be deleted if replication is stopped while it is restoring.  So no need to close/reopen
                 val restoring = clusterService.state().custom<RestoreInProgress>(RestoreInProgress.TYPE, RestoreInProgress.EMPTY).any { entry ->
                     entry.indices().any { it == request.indexName }
@@ -148,70 +143,23 @@ class TransportStopIndexReplicationAction @Inject constructor(transportService: 
                         throw OpenSearchException("Failed to reopen index: ${request.indexName}")
                     }
                 }
-                replicationMetadataManager.deleteIndexReplicationMetadata(request.indexName)
-                removeStaleReplicationTasksFromClusterState(request)
+
+                // Remove stale persistent replication tasks from cluster state.
+                // Unassigned tasks are always removed. Assigned tasks are removed only if
+                // the task is not actually running in the task manager or the node is invalid.
+                StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, request.indexName)
+                try {
+                    replicationMetadataManager.deleteIndexReplicationMetadata(request.indexName)
+                } catch (e: ResourceNotFoundException) {
+                    throw IllegalArgumentException("No replication in progress for index:${request.indexName}")
+                }
+
                 listener.onResponse(AcknowledgedResponse(true))
             } catch (e: Exception) {
                 log.error("Stop replication failed for index[${request.indexName}] with error ${e.stackTraceToString()}")
                 listener.onFailure(e)
             }
         }
-    }
-
-    private suspend fun removeStaleReplicationTasksFromClusterState(request: StopIndexReplicationRequest) {
-        try {
-            val allTasks: PersistentTasksCustomMetadata =
-                clusterService.state().metadata().custom(PersistentTasksCustomMetadata.TYPE)
-            for (singleTask in allTasks.tasks()) {
-                if (isReplicationTask(singleTask, request) && !singleTask.isAssigned){
-                    log.info("Removing task: ${singleTask.id} from cluster state")
-                    val removeRequest: RemovePersistentTaskAction.Request =
-                        RemovePersistentTaskAction.Request(singleTask.id)
-                    client.suspendExecute(RemovePersistentTaskAction.INSTANCE, removeRequest)
-                }
-            }
-        } catch (e: Exception) {
-            log.info("Could not update cluster state")
-        }
-    }
-
-    // Remove index replication task metadata, format replication:index:fruit-1
-    // Remove shard replication task metadata, format replication:[fruit-1][0]
-    private fun isReplicationTask(
-        singleTask: PersistentTasksCustomMetadata.PersistentTask<*>,
-        request: StopIndexReplicationRequest
-    ) = singleTask.id.startsWith("replication:") &&
-            (singleTask.id == "replication:index:${request.indexName}" || singleTask.id.split(":")[1].contains(request.indexName))
-
-
-    private fun validateReplicationStateOfIndex(request: StopIndexReplicationRequest) {
-        // If replication blocks/settings are present, Stop action should proceed with the clean-up
-        // This can happen during settings of follower index are carried over in the snapshot and the restore is
-        // performed using this snapshot.
-        if (clusterService.state().blocks.hasIndexBlock(request.indexName, INDEX_REPLICATION_BLOCK)
-                || clusterService.state().metadata.index(request.indexName)?.settings?.get(REPLICATED_INDEX_SETTING.key) != null) {
-            return
-        }
-
-        //check for stale replication tasks
-        val allTasks: PersistentTasksCustomMetadata? =
-            clusterService.state()?.metadata()?.custom(PersistentTasksCustomMetadata.TYPE)
-        allTasks?.tasks()?.forEach{
-            if (isReplicationTask(it, request) && !it.isAssigned){
-                return
-            }
-        }
-
-        val replicationStateParams = getReplicationStateParamsForIndex(clusterService, request.indexName)
-                ?:
-            throw IllegalArgumentException("No replication in progress for index:${request.indexName}")
-        val replicationOverallState = replicationStateParams[REPLICATION_LAST_KNOWN_OVERALL_STATE]
-        if (replicationOverallState == ReplicationOverallState.RUNNING.name ||
-            replicationOverallState == ReplicationOverallState.STOPPED.name ||
-            replicationOverallState == ReplicationOverallState.FAILED.name ||
-            replicationOverallState == ReplicationOverallState.PAUSED.name)
-            return
-        throw IllegalStateException("Unknown value of replication state:$replicationOverallState")
     }
 
     override fun executor(): String {

--- a/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
@@ -138,7 +138,10 @@ open class ReplicationMetadataManager constructor(private val clusterService: Cl
     private suspend fun deleteMetadata(deleteReq: DeleteReplicationMetadataRequest) {
         executeAndWrapExceptionIfAny({
             val delRes = replicaionMetadataStore.deleteMetadata(deleteReq)
-            if(delRes.result != DocWriteResponse.Result.DELETED && delRes.result != DocWriteResponse.Result.NOT_FOUND) {
+            if(delRes.result == DocWriteResponse.Result.NOT_FOUND) {
+                throw ResourceNotFoundException("Metadata for ${deleteReq.resourceName} doesn't exist")
+            }
+            if(delRes.result != DocWriteResponse.Result.DELETED) {
                 log.error("Encountered error with result - ${delRes.result}, while deleting metadata")
                 throw ReplicationException("Error deleting replication metadata")
             }

--- a/src/main/kotlin/org/opensearch/replication/util/StaleTaskUtils.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/StaleTaskUtils.kt
@@ -1,0 +1,247 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.util
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.ResourceNotFoundException
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.persistent.PersistentTasksCustomMetadata
+import org.opensearch.persistent.RemovePersistentTaskAction
+import org.opensearch.replication.task.index.IndexReplicationParams
+import org.opensearch.replication.task.shard.ShardReplicationParams
+import org.opensearch.transport.client.Client
+
+/**
+ * Utility object for stale replication task detection and cleanup.
+ * Replication tasks follow these ID patterns:
+ * - Index task: "replication:index:{indexName}"
+ * - Shard task: "replication:[{indexName}][{shardId}]"
+ * A task is considered stale if:
+ * It is unassigned (no executor node), OR
+ * t is assigned but the executor node is no longer part of the cluster, OR
+ * It is assigned but the corresponding task is not running in the task manager
+ * All operations are idempotent — calling them multiple times with the same
+ * inputs produces the same result.
+ */
+object StaleTaskUtils {
+
+    private val log = LogManager.getLogger(StaleTaskUtils::class.java)
+
+    /**
+     * Shard task pattern: replication:[indexName][shardId]
+     * Captures the index name from the first bracket group.
+     */
+    private val SHARD_TASK_PATTERN = Regex("^replication:\\[([^\\]]+)\\]\\[\\d+\\]$")
+
+    //  Finds all replication tasks for the given index from the cluster state.
+    private fun findReplicationTasksForIndex(
+        clusterService: ClusterService,
+        indexName: String
+    ): List<PersistentTasksCustomMetadata.PersistentTask<*>> {
+        val allTasks = clusterService.state().metadata
+            .custom<PersistentTasksCustomMetadata>(PersistentTasksCustomMetadata.TYPE)
+            ?: return emptyList()
+
+        return allTasks.tasks().filter { task ->
+            isReplicationTaskForIndex(task, indexName)
+        }
+    }
+
+    // Determines whether a persistent task is a replication task for the given index.
+    fun isReplicationTaskForIndex(
+        task: PersistentTasksCustomMetadata.PersistentTask<*>,
+        indexName: String
+    ): Boolean {
+        val taskId = task.id
+        if (!taskId.startsWith("replication:")) return false
+
+        // Index task format: replication:index:{indexName}
+        if (taskId == "replication:index:$indexName") return true
+
+        // Shard task format: replication:[{indexName}][{shardId}]
+        val match = SHARD_TASK_PATTERN.find(taskId)
+        return match?.groupValues?.get(1) == indexName
+    }
+
+    /**
+     * Removes stale replication tasks for the given index from the cluster state
+     * A task is removed only if it is truly stale:
+     * Unassigned tasks are always removed
+     * Assigned tasks are removed only if the assigned node is no longer in the cluster
+     * or the task is not actually running in the task manager on that node
+     * @return the number of tasks successfully removed
+     */
+    suspend fun removeStaleTasksForIndex(
+        clusterService: ClusterService,
+        client: Client,
+        indexName: String
+    ): Int {
+        log.info("Starting stale task cleanup for index $indexName")
+
+        val replicationTasks = findReplicationTasksForIndex(clusterService, indexName)
+        if (replicationTasks.isEmpty()) {
+            log.info("No replication tasks found for index $indexName")
+            return 0
+        }
+
+        log.info("Found ${replicationTasks.size} replication task(s) for index $indexName: ${replicationTasks.map { it.id }}")
+
+        val clusterState = clusterService.state()
+        val validNodeIds = clusterState.nodes().dataNodes.keys
+
+        // Group tasks by executor node (null for unassigned)
+        val tasksByNode = replicationTasks.groupBy {
+            if (it.isAssigned) it.assignment.executorNode else null
+        }
+
+        var removed = 0
+
+        // Remove all unassigned tasks immediately
+        tasksByNode[null]?.forEach { task ->
+            if (removeTask(client, task, indexName)) removed++
+        }
+
+        // Process assigned tasks per node
+        for ((nodeId, tasks) in tasksByNode) {
+            if (nodeId == null) continue
+
+            // If the assigned node is no longer in the cluster, remove all its tasks
+            if (!validNodeIds.contains(nodeId)) {
+                log.info("Node $nodeId is no longer in the cluster, removing its tasks")
+                tasks.forEach { task ->
+                    if (removeTask(client, task, indexName)) removed++
+                }
+                continue
+            }
+
+            // Node is valid — check task manager to see if tasks are actually running
+            val runningDescriptions = getRunningTaskDescriptions(client, nodeId)
+            for (task in tasks) {
+                if (!isTaskRunningOnNode(task, runningDescriptions)) {
+                    log.info("Task ${task.id} is assigned to node $nodeId but not running in task manager")
+                    if (removeTask(client, task, indexName)) removed++
+                }
+            }
+        }
+
+        log.info("Successfully cleaned up $removed stale task(s) for index $indexName")
+        return removed
+    }
+
+    /**
+     * Removes ALL replication tasks for the given index from the cluster state,
+     * regardless of whether they are stale or actively running.
+     * Used by the Start and Resume APIs to ensure a clean slate before creating new tasks.
+     * @return the number of tasks successfully removed
+     */
+    suspend fun removeAllTasksForIndex(
+        clusterService: ClusterService,
+        client: Client,
+        indexName: String
+    ): Int {
+        log.info("Removing all replication tasks for index $indexName")
+
+        val replicationTasks = findReplicationTasksForIndex(clusterService, indexName)
+        if (replicationTasks.isEmpty()) {
+            log.info("No replication tasks found for index $indexName")
+            return 0
+        }
+
+        log.info("Found ${replicationTasks.size} replication task(s) for index $indexName: ${replicationTasks.map { it.id }}")
+
+        var removed = 0
+        replicationTasks.forEach { task ->
+            if (removeTask(client, task, indexName)) removed++
+        }
+
+        log.info("Removed $removed task(s) for index $indexName")
+        return removed
+    }
+
+    // Removes a single persistent task from the cluster state.
+    private suspend fun removeTask(
+        client: Client,
+        task: PersistentTasksCustomMetadata.PersistentTask<*>,
+        indexName: String
+    ): Boolean {
+        return try {
+            log.info("Removing task: ${task.id} from cluster state")
+            val removeRequest = RemovePersistentTaskAction.Request(task.id)
+            client.suspendExecute(RemovePersistentTaskAction.INSTANCE, removeRequest)
+            log.info("Removed stale task ${task.id} for index $indexName")
+            true
+        } catch (e: ResourceNotFoundException) {
+            log.debug("Stale task ${task.id} already removed for index $indexName")
+            true
+        } catch (e: Exception) {
+            if (hasCause(e, ResourceNotFoundException::class.java)) {
+                log.debug("Stale task ${task.id} already removed for index $indexName")
+                true
+            } else {
+                log.error("Failed to remove task ${task.id}: ${e.message}")
+                false
+            }
+        }
+    }
+
+    //  Queries the task manager on a specific node to get descriptions of running replication tasks.
+    private suspend fun getRunningTaskDescriptions(client: Client, nodeId: String): Set<String> {
+        return try {
+            val listTasksRequest = ListTasksRequest()
+                .setActions("cluster:indices/admin/replication*", "cluster:indices/shards/replication*")
+                .setNodes(nodeId)
+                .setDetailed(true)
+
+            val response = client.suspendExecute(ListTasksAction.INSTANCE, listTasksRequest)
+            response.tasks.mapNotNull { it.description }.toSet()
+        } catch (e: Exception) {
+            log.error("Failed to fetch running tasks from node $nodeId: ${e.message}")
+            emptySet()
+        }
+    }
+
+    /**
+     * Checks if a persistent task is actually running on its assigned node by matching
+     * the task's params against the running task descriptions from the task manager.
+     */
+    private fun isTaskRunningOnNode(
+        persistentTask: PersistentTasksCustomMetadata.PersistentTask<*>,
+        runningDescriptions: Set<String>
+    ): Boolean {
+        val params = persistentTask.params
+        val pattern = when (params) {
+            is IndexReplicationParams -> {
+                Regex("->\\s+${Regex.escape(params.followerIndexName)}\\s*$")
+            }
+            is ShardReplicationParams -> {
+                val followerIndex = params.followerShardId.indexName
+                val shardId = params.followerShardId.id
+                Regex("->\\s+\\[${Regex.escape(followerIndex)}\\]\\[${shardId}\\]\\s*$")
+            }
+            else -> return true // Unknown params type — assume running to be safe
+        }
+
+        return runningDescriptions.any { pattern.containsMatchIn(it) }
+    }
+
+    //  Checks if the given exception or any of its causes is an instance of the specified type.
+    private fun hasCause(e: Throwable, type: Class<out Throwable>): Boolean {
+        var current: Throwable? = e
+        while (current != null) {
+            if (type.isInstance(current)) return true
+            current = current.cause
+        }
+        return false
+    }
+}

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/StopReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/StopReplicationIT.kt
@@ -284,10 +284,10 @@ class StopReplicationIT: MultiClusterRestTestCase() {
         assertBusy {
             assertThat(leaderClient.indices().exists(GetIndexRequest("restored-$followerIndexName"), RequestOptions.DEFAULT)).isEqualTo(true)
         }
-        // Invoke stop on the new leader cluster index
+        // Stop on restored index - metadata document doesn't exist
         assertThatThrownBy { leaderClient.stopReplication("restored-$followerIndexName") }
                 .isInstanceOf(ResponseException::class.java)
-                .hasMessageContaining("Metadata for restored-$followerIndexName doesn't exist")
+                .hasMessageContaining("No replication in progress for index:restored-$followerIndexName")
         // Start replication on the new leader index
         followerClient.startReplication(
                 StartReplicationRequest("source", "restored-$followerIndexName", "restored-$followerIndexName"),
@@ -299,5 +299,35 @@ class StopReplicationIT: MultiClusterRestTestCase() {
             `validate status syncing response`(statusResp)
             assertThat(followerClient.getShardReplicationTasks("restored-$followerIndexName")).isNotEmpty()
         }, 60, TimeUnit.SECONDS)
+    }
+
+    fun `test stop replication cleans up and allows restart`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER)
+        val createIndexResponse = leaderClient.indices().create(CreateIndexRequest(leaderIndexName), RequestOptions.DEFAULT)
+        assertThat(createIndexResponse.isAcknowledged).isTrue()
+        followerClient.startReplication(
+            StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true
+        )
+        val sourceMap = mapOf("name" to randomAlphaOfLength(5))
+        leaderClient.index(IndexRequest(leaderIndexName).id("1").source(sourceMap), RequestOptions.DEFAULT)
+        assertBusy {
+            assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isTrue()
+        }
+        // Stop replication
+        followerClient.stopReplication(followerIndexName)
+        // Verify follower index is still accessible (unblocked) after stop
+        followerClient.index(IndexRequest(followerIndexName).id("2").source(sourceMap), RequestOptions.DEFAULT)
+        // Delete follower index and restart replication
+        followerClient.indices().delete(DeleteIndexRequest(followerIndexName), RequestOptions.DEFAULT)
+        followerClient.startReplication(
+            StartReplicationRequest("source", leaderIndexName, followerIndexName),
+            waitForRestore = true
+        )
+        assertBusy {
+            assertThat(followerClient.indices().exists(GetIndexRequest(followerIndexName), RequestOptions.DEFAULT)).isTrue()
+        }
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/util/StaleTaskUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/util/StaleTaskUtilsTests.kt
@@ -1,0 +1,433 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.util
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.opensearch.Version
+import org.opensearch.ResourceNotFoundException
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionType
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.Metadata
+import org.opensearch.cluster.node.DiscoveryNode
+import org.opensearch.cluster.node.DiscoveryNodeRole
+import org.opensearch.cluster.node.DiscoveryNodes
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.core.index.Index
+import org.opensearch.core.index.shard.ShardId
+import org.opensearch.persistent.PersistentTaskParams
+import org.opensearch.persistent.PersistentTaskResponse
+import org.opensearch.persistent.PersistentTasksCustomMetadata
+import org.opensearch.persistent.RemovePersistentTaskAction
+import org.opensearch.replication.task.index.IndexReplicationExecutor
+import org.opensearch.replication.task.index.IndexReplicationParams
+import org.opensearch.replication.task.shard.ShardReplicationExecutor
+import org.opensearch.replication.task.shard.ShardReplicationParams
+import org.opensearch.test.ClusterServiceUtils
+import org.opensearch.test.ClusterServiceUtils.setState
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.test.client.NoOpNodeClient
+import org.opensearch.threadpool.TestThreadPool
+import java.util.Collections
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class StaleTaskUtilsTests : OpenSearchTestCase() {
+
+    private val followerIndex = "test-follower-index"
+    private val otherIndex = "other-index"
+    private val threadPool = TestThreadPool("StaleTaskUtilsTests")
+    private val clusterService = ClusterServiceUtils.createClusterService(threadPool)
+
+    override fun tearDown() {
+        super.tearDown()
+        clusterService.close()
+        threadPool.shutdown()
+    }
+
+    // isReplicationTaskForIndex
+
+    fun testIsReplicationTaskForIndex_matchesIndexTask() {
+        val task = buildPersistentTask("replication:index:$followerIndex")
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task, followerIndex)).isTrue()
+    }
+
+    fun testIsReplicationTaskForIndex_matchesShardTask() {
+        val task = buildPersistentTask("replication:[$followerIndex][0]")
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task, followerIndex)).isTrue()
+    }
+
+    fun testIsReplicationTaskForIndex_matchesShardTaskMultipleShards() {
+        val task0 = buildPersistentTask("replication:[$followerIndex][0]")
+        val task1 = buildPersistentTask("replication:[$followerIndex][1]")
+        val task5 = buildPersistentTask("replication:[$followerIndex][5]")
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task0, followerIndex)).isTrue()
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task1, followerIndex)).isTrue()
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task5, followerIndex)).isTrue()
+    }
+
+    fun testIsReplicationTaskForIndex_doesNotMatchDifferentIndex() {
+        val indexTask = buildPersistentTask("replication:index:$otherIndex")
+        val shardTask = buildPersistentTask("replication:[$otherIndex][0]")
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(indexTask, followerIndex)).isFalse()
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(shardTask, followerIndex)).isFalse()
+    }
+
+    fun testIsReplicationTaskForIndex_doesNotMatchNonReplicationTask() {
+        val task = buildPersistentTask("some-other-task:$followerIndex")
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task, followerIndex)).isFalse()
+    }
+
+    fun testIsReplicationTaskForIndex_doesNotMatchPartialIndexName() {
+        val task = buildPersistentTask("replication:index:test-follower")
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task, followerIndex)).isFalse()
+    }
+
+    fun testIsReplicationTaskForIndex_doesNotMatchSupersetIndexName() {
+        val task = buildPersistentTask("replication:index:${followerIndex}-extra")
+        assertThat(StaleTaskUtils.isReplicationTaskForIndex(task, followerIndex)).isFalse()
+    }
+
+    // removeStaleTasksForIndex
+
+    fun testRemoveStaleTasksForIndex_returnsZeroWhenNoTasks() = runBlocking {
+        val metadata = Metadata.builder().build()
+        val newState = ClusterState.builder(clusterService.state()).metadata(metadata).build()
+        setState(clusterService, newState)
+
+        val client = StaleTaskTestClient("noTasks")
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(0)
+    }
+
+    fun testRemoveStaleTasksForIndex_removesUnassignedTasks() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasks(tasks.build())
+
+        val client = StaleTaskTestClient("unassigned")
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1)
+        assertThat(client.removedTaskIds).hasSize(1)
+    }
+
+    fun testRemoveStaleTasksForIndex_removesTasksOnInvalidNode() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.Assignment("gone_node", "test")
+        )
+        // Set cluster state with NO data nodes — so "gone_node" is invalid
+        setClusterStateWithTasksAndNodes(tasks.build(), emptyList())
+
+        val client = StaleTaskTestClient("invalidNode")
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1)
+        assertThat(client.removedTaskIds).hasSize(1)
+    }
+
+    fun testRemoveStaleTasksForIndex_removesTaskNotRunningOnValidNode() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.Assignment("valid_node", "test")
+        )
+        // Node exists but ListTasks returns empty — task not running
+        setClusterStateWithTasksAndNodes(tasks.build(), listOf("valid_node"))
+
+        val client = StaleTaskTestClient("notRunning", runningDescriptions = emptySet())
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1)
+        assertThat(client.removedTaskIds).hasSize(1)
+    }
+
+    fun testRemoveStaleTasksForIndex_handlesResourceNotFoundExceptionIdempotently() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasks(tasks.build())
+
+        // Client throws ResourceNotFoundException on remove — task already gone
+        val client = StaleTaskTestClient("alreadyRemoved", removeThrows = ResourceNotFoundException("already gone"))
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1) // idempotent success
+    }
+
+    fun testRemoveStaleTasksForIndex_handlesWrappedResourceNotFoundException() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasks(tasks.build())
+
+        // Wrapped ResourceNotFoundException
+        val wrappedException = RuntimeException("wrapper", ResourceNotFoundException("already gone"))
+        val client = StaleTaskTestClient("wrappedRNFE", removeThrows = wrappedException)
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1) // idempotent success via hasCause
+    }
+
+    fun testRemoveStaleTasksForIndex_returnsFalseOnOtherException() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasks(tasks.build())
+
+        val client = StaleTaskTestClient("otherError", removeThrows = RuntimeException("something broke"))
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(0) // failure
+    }
+
+    fun testRemoveStaleTasksForIndex_mixedUnassignedAndAssigned() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        // Unassigned index task
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        // Assigned shard task on valid node, not running
+        val shardId = ShardId(Index(followerIndex, "_na_"), 0)
+        tasks.addTask<PersistentTaskParams>(
+            "replication:[$followerIndex][0]",
+            ShardReplicationExecutor.TASK_NAME,
+            ShardReplicationParams("remote", shardId, shardId),
+            PersistentTasksCustomMetadata.Assignment("valid_node", "test")
+        )
+        // Task for a different index — should not be touched
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$otherIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(otherIndex, "_na_"), otherIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasksAndNodes(tasks.build(), listOf("valid_node"))
+
+        val client = StaleTaskTestClient("mixed", runningDescriptions = emptySet())
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(2)
+        assertThat(client.removedTaskIds).hasSize(2)
+    }
+
+    // removeAllTasksForIndex
+
+    fun testRemoveAllTasksForIndex_returnsZeroWhenNoTasks() = runBlocking {
+        val metadata = Metadata.builder().build()
+        val newState = ClusterState.builder(clusterService.state()).metadata(metadata).build()
+        setState(clusterService, newState)
+
+        val client = StaleTaskTestClient("allNoTasks")
+        val removed = StaleTaskUtils.removeAllTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(0)
+    }
+
+    fun testRemoveAllTasksForIndex_removesUnassignedTask() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasks(tasks.build())
+
+        val client = StaleTaskTestClient("allUnassigned")
+        val removed = StaleTaskUtils.removeAllTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1)
+        assertThat(client.removedTaskIds).hasSize(1)
+    }
+
+    fun testRemoveAllTasksForIndex_removesAssignedRunningTask() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.Assignment("valid_node", "test")
+        )
+        setClusterStateWithTasksAndNodes(tasks.build(), listOf("valid_node"))
+
+        val client = StaleTaskTestClient("allRunning")
+        val removed = StaleTaskUtils.removeAllTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1)
+        assertThat(client.removedTaskIds).hasSize(1)
+    }
+
+    fun testRemoveAllTasksForIndex_removesMixedTasks() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        // Unassigned index task
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        // Assigned shard task on valid node
+        val shardId = ShardId(Index(followerIndex, "_na_"), 0)
+        tasks.addTask<PersistentTaskParams>(
+            "replication:[$followerIndex][0]",
+            ShardReplicationExecutor.TASK_NAME,
+            ShardReplicationParams("remote", shardId, shardId),
+            PersistentTasksCustomMetadata.Assignment("valid_node", "test")
+        )
+        // Task for a different index — should not be touched
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$otherIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(otherIndex, "_na_"), otherIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasksAndNodes(tasks.build(), listOf("valid_node"))
+
+        val client = StaleTaskTestClient("allMixed")
+        val removed = StaleTaskUtils.removeAllTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(2)
+        assertThat(client.removedTaskIds).hasSize(2)
+    }
+
+    fun testRemoveAllTasksForIndex_handlesRemovalFailure() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasks(tasks.build())
+
+        val client = StaleTaskTestClient("allFail", removeThrows = RuntimeException("something broke"))
+        val removed = StaleTaskUtils.removeAllTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(0)
+    }
+
+    fun testRemoveAllTasksForIndex_handlesResourceNotFoundIdempotently() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+        )
+        setClusterStateWithTasks(tasks.build())
+
+        val client = StaleTaskTestClient("allAlreadyGone", removeThrows = ResourceNotFoundException("already gone"))
+        val removed = StaleTaskUtils.removeAllTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(1)
+    }
+
+    //Helpers
+
+    private fun buildPersistentTask(
+        taskId: String,
+        assignment: PersistentTasksCustomMetadata.Assignment = PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT
+    ): PersistentTasksCustomMetadata.PersistentTask<*> {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            taskId,
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            assignment
+        )
+        return tasks.build().getTask(taskId)!!
+    }
+
+    private fun setClusterStateWithTasks(persistentTasks: PersistentTasksCustomMetadata) {
+        val metadata = Metadata.builder()
+            .putCustom(PersistentTasksCustomMetadata.TYPE, persistentTasks)
+            .build()
+        val newState = ClusterState.builder(clusterService.state()).metadata(metadata).build()
+        setState(clusterService, newState)
+    }
+
+    private fun setClusterStateWithTasksAndNodes(
+        persistentTasks: PersistentTasksCustomMetadata,
+        dataNodeIds: List<String>
+    ) {
+        val metadata = Metadata.builder()
+            .putCustom(PersistentTasksCustomMetadata.TYPE, persistentTasks)
+            .build()
+        val nodesBuilder = DiscoveryNodes.builder()
+        for (nodeId in dataNodeIds) {
+            nodesBuilder.add(DiscoveryNode(nodeId, buildNewFakeTransportAddress(), Collections.emptyMap(),
+                DiscoveryNodeRole.BUILT_IN_ROLES, Version.CURRENT))
+        }
+        val newState = ClusterState.builder(clusterService.state())
+            .metadata(metadata)
+            .nodes(nodesBuilder.build())
+            .build()
+        setState(clusterService, newState)
+    }
+
+    /**
+     * Test client that tracks removed task IDs and can simulate ListTasks responses.
+     * Overrides threadPool() to provide the test thread pool needed by suspendExecute.
+     */
+    inner class StaleTaskTestClient(
+        testName: String,
+        private val runningDescriptions: Set<String> = emptySet(),
+        private val removeThrows: Exception? = null
+    ) : NoOpNodeClient(testName) {
+
+        val removedTaskIds = mutableListOf<String>()
+
+        override fun <Request : ActionRequest, Response : ActionResponse> doExecute(
+            action: ActionType<Response>?,
+            request: Request?,
+            listener: ActionListener<Response>
+        ) {
+            when (action) {
+                RemovePersistentTaskAction.INSTANCE -> {
+                    if (removeThrows != null) {
+                        listener.onFailure(removeThrows)
+                    } else {
+                        removedTaskIds.add("removed")
+                        val response = PersistentTaskResponse(null as PersistentTasksCustomMetadata.PersistentTask<*>?)
+                        listener.onResponse(response as Response)
+                    }
+                }
+                ListTasksAction.INSTANCE -> {
+                    val response = ListTasksResponse(emptyList(), emptyList(), emptyList())
+                    listener.onResponse(response as Response)
+                }
+                else -> {
+                    listener.onFailure(UnsupportedOperationException("Unexpected action: ${action?.name()}"))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Stab at Fixing integ tests



* Revert "Stab at Fixing integ tests"

This reverts commit 0e4b126b6adbdb4558046c3b50cf746bc5293da7.



* Stab at Fixing integ tests



* Fixing CVE-2026-25645 and CVE-2026-24400



* Adding validation in resume replication and stop replication api should clear all stale replication metadata



* Fixing StopReplicationIT



* Fixing SecurityCustomRolesIT and SingleClusterSanityIT



* Adding integ tests for test start replication is blocked when replication is already running, test start replication succeeds after stop cleans up, test idempotent stop replication can be called multiple times and test stop replication cleans up and allows restart



* Eliminating race condition between waitForClusterStateUpdate and removeReplicationTasksFromClusterState function



* Modifying test delete follower index when leader index is unavailable



* Removing try catch from stop api whereever not needed



* Adding ITs in Stop and StartReplicationITs



* Fix stale persistent task cleanup in stop/start/resume APIs to prevent orphaned tasks from blocking replication restart



* Remove duplicacy for validation in TransportReplicateIndexClusterManagerNodeAction.kt



* Addressing comments



* Using StaleTaskUtils.removeStaleTasksForIndex instead of removeStaleReplicationTasksFromClusterState in STOP api



* Fixing deletion of follower index when leader index is deleted



* Fixing deletion of follower index when leader index is deleted



* Fixing follower index automated deletion when leader index is deleted + Clear all unassigned tasks Clear assigned tasks only if the task is not present in task manager or the assigned node is invalid



* Adding UTs for StaleTaskUtils.kt file



* Removing duplicate ITs from StartReplicationIT



* Removing duplicate ITs from StartReplicationIT



* Throw IllegalStateException for active running tasks during stale task cleanup instead of post-validation



* Throw IllegalStateException for active running tasks during stale task cleanup instead of post-validation



* Add removeAllTasksForIndex for Start API to clean up all tasks and revert removeStaleTasksForIndex to skip active tasks so Stop API no longer throws on running tasks



* Remove redundant validateNoActiveMetadata in Start API and duplicate stale task cleanup logging in Resume API



* Use removeAllTasksForIndex in Resume API to ensure clean slate before creating new tasks



---------

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
