### PR TITLE
Fix isRemoteStoreEnabledCluster to handle List<String> prefix type

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
@@ -182,12 +182,8 @@ object ValidationUtil {
         }
     }
 
-    fun isRemoteStoreEnabledCluster(clusterService: ClusterService): Boolean {
-        return clusterService.settings.getByPrefix(Node.NODE_ATTRIBUTES.key + RemoteStoreNodeAttribute.REMOTE_STORE_NODE_ATTRIBUTE_KEY_PREFIX).isEmpty == false
-    }
-
     fun isRemoteEnabledOrMigrating(clusterService: ClusterService): Boolean {
-        return isRemoteStoreEnabledCluster(clusterService) ||
+        return RemoteStoreNodeAttribute.isRemoteDataAttributePresent(clusterService.settings) ||
                 clusterService.clusterSettings.get(RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING).equals(RemoteStoreNodeService.CompatibilityMode.MIXED)
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/util/ValidationUtilTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/util/ValidationUtilTests.kt
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.util
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.test.OpenSearchTestCase
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class ValidationUtilTests : OpenSearchTestCase() {
+
+    fun testIsRemoteEnabledOrMigrating_returnsTrueWhenRemoteStoreDataAttributesPresent() {
+        val settings = Settings.builder()
+            .put("node.attr.remote_store.segment.repository", "my-segment-repo")
+            .put("node.attr.remote_store.translog.repository", "my-translog-repo")
+            .build()
+
+        val clusterService = mockClusterService(settings)
+
+        assertThat(ValidationUtil.isRemoteEnabledOrMigrating(clusterService)).isTrue()
+    }
+
+    fun testIsRemoteEnabledOrMigrating_returnsFalseWhenNoRemoteStoreAttributes() {
+        val settings = Settings.builder()
+            .put("node.attr.zone", "us-east-1a")
+            .build()
+
+        val clusterService = mockClusterService(settings)
+
+        assertThat(ValidationUtil.isRemoteEnabledOrMigrating(clusterService)).isFalse()
+    }
+
+    fun testIsRemoteEnabledOrMigrating_returnsTrueWhenOnlySegmentRepoPresent() {
+        val settings = Settings.builder()
+            .put("node.attr.remote_store.segment.repository", "my-segment-repo")
+            .build()
+
+        val clusterService = mockClusterService(settings)
+
+        assertThat(ValidationUtil.isRemoteEnabledOrMigrating(clusterService)).isTrue()
+    }
+
+    fun testIsRemoteEnabledOrMigrating_returnsTrueWhenOnlyTranslogRepoPresent() {
+        val settings = Settings.builder()
+            .put("node.attr.remote_store.translog.repository", "my-translog-repo")
+            .build()
+
+        val clusterService = mockClusterService(settings)
+
+        assertThat(ValidationUtil.isRemoteEnabledOrMigrating(clusterService)).isTrue()
+    }
+
+    private fun mockClusterService(settings: Settings): ClusterService {
+        val clusterSettings = ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        val clusterService: ClusterService = mock()
+        whenever(clusterService.settings).thenReturn(settings)
+        whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
+        return clusterService
+    }
+}


### PR DESCRIPTION
REMOTE_STORE_NODE_ATTRIBUTE_KEY_PREFIX changed from String to List<String> in OpenSearch 2.19 (#16271). The code concatenated String + List, producing an invalid prefix that matched no settings, causing isRemoteEnabledOrMigrating() to always return false on remote-store clusters. This led to reading a stale checkpoint and ~5 minute cross-cluster replication delays.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
