### PR TITLE
Add follower_index_pattern support to autofollow API for follower index renaming

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -221,6 +221,8 @@ curl -k -u testuser:testuser -XPOST \
 
 AutoFollow API helps to automatically start replication on indices matching a pattern.
 
+Optionally, provide `follow_index_pattern` with the `{{leader_index}}` placeholder to create follower indices under a different name. The placeholder is replaced with each matching leader index name at replication time. When omitted, the follower index uses the same name as the leader index.
+
 **Signature**
 
 ```bash
@@ -229,7 +231,7 @@ AutoFollow API helps to automatically start replication on indices matching a pa
 POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
-{"leader_alias" : "<remote cluster connection name>",  "pattern": "<index pattern>", "name": "<name to identify autofollow task>"}
+{"leader_alias" : "<remote cluster connection name>",  "pattern": "<index pattern>", "name": "<name to identify autofollow task>", "follow_index_pattern": "<optional follower index name pattern with {{leader_index}} placeholder>"}
 
 # RESPONSE
 
@@ -244,6 +246,15 @@ curl -k -u testuser:testuser -XPOST \
 "https://${FOLLOWER}/_plugins/_replication/_autofollow?pretty" \
 -H 'Content-type: application/json' \
 -d'{"leader_alias":"leader-cluster","pattern":"leader-*", "name":"my-replication"}'
+```
+
+**Example with follower index renaming**
+```bash
+# Replicate matching leader indices under a renamed follower index (e.g. leader-01 -> leader-01-replica)
+curl -k -u testuser:testuser -XPOST \
+"https://${FOLLOWER}/_plugins/_replication/_autofollow?pretty" \
+-H 'Content-type: application/json' \
+-d'{"leader_alias":"leader-cluster","pattern":"leader-*", "name":"my-replication", "follow_index_pattern":"{{leader_index}}-replica"}'
 ```
 
 ## Stop AutoFollow

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -221,7 +221,7 @@ curl -k -u testuser:testuser -XPOST \
 
 AutoFollow API helps to automatically start replication on indices matching a pattern.
 
-Optionally, provide `follow_index_pattern` with the `{{leader_index}}` placeholder to create follower indices under a different name. The placeholder is replaced with each matching leader index name at replication time. When omitted, the follower index uses the same name as the leader index.
+Optionally, provide `follower_index_pattern` with the `{{leader_index}}` placeholder to create follower indices under a different name. The placeholder is replaced with each matching leader index name at replication time. When omitted, the follower index uses the same name as the leader index.
 
 **Signature**
 
@@ -231,7 +231,7 @@ Optionally, provide `follow_index_pattern` with the `{{leader_index}}` placehold
 POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
-{"leader_alias" : "<remote cluster connection name>",  "pattern": "<index pattern>", "name": "<name to identify autofollow task>", "follow_index_pattern": "<optional follower index name pattern with {{leader_index}} placeholder>"}
+{"leader_alias" : "<remote cluster connection name>",  "pattern": "<index pattern>", "name": "<name to identify autofollow task>", "follower_index_pattern": "<optional follower index name pattern with {{leader_index}} placeholder>"}
 
 # RESPONSE
 
@@ -254,7 +254,7 @@ curl -k -u testuser:testuser -XPOST \
 curl -k -u testuser:testuser -XPOST \
 "https://${FOLLOWER}/_plugins/_replication/_autofollow?pretty" \
 -H 'Content-type: application/json' \
--d'{"leader_alias":"leader-cluster","pattern":"leader-*", "name":"my-replication", "follow_index_pattern":"{{leader_index}}-replica"}'
+-d'{"leader_alias":"leader-cluster","pattern":"leader-*", "name":"my-replication", "follower_index_pattern":"{{leader_index}}-replica"}'
 ```
 
 ## Stop AutoFollow

--- a/docs/RFC.md
+++ b/docs/RFC.md
@@ -165,11 +165,11 @@ Content-Type: application/json
   "leader_alias": "leader-cluster",
   "name": "test",
   "pattern": "*customer*",
-  "follow_index_pattern": "{{leader_index}}-replica"
+  "follower_index_pattern": "{{leader_index}}-replica"
 }
 ```
 
-The optional `follow_index_pattern` field renames follower indices using the `{{leader_index}}` placeholder, which is substituted with each matching leader index name at replication time. When omitted, the follower index uses the same name as the leader index.
+The optional `follower_index_pattern` field renames follower indices using the `{{leader_index}}` placeholder, which is substituted with each matching leader index name at replication time. When omitted, the follower index uses the same name as the leader index.
 
 ### Remove AutoFollow
 

--- a/docs/RFC.md
+++ b/docs/RFC.md
@@ -154,6 +154,23 @@ Content-Type: application/json
 }
 ```
 
+With follower index renaming:
+
+```bash
+Request
+POST $FOLLOWER/_plugins/_replication/_autofollow
+Content-Type: application/json
+
+{
+  "leader_alias": "leader-cluster",
+  "name": "test",
+  "pattern": "*customer*",
+  "follow_index_pattern": "{{leader_index}}-replica"
+}
+```
+
+The optional `follow_index_pattern` field renames follower indices using the `{{leader_index}}` placeholder, which is substituted with each matching leader index name at replication time. When omitted, the follower index uses the same name as the leader index.
+
 ### Remove AutoFollow
 
 AutoFollow can be removed by invoking API on the follower as follows. Invocation of the API is only to stop any new auto-follow activity and does NOT stop replication of indices already initiated by the auto-follow.

--- a/replication.http
+++ b/replication.http
@@ -152,6 +152,17 @@ Content-Type: application/json
   "pattern": "*customer*"
 }
 
+### Add auto follow actions with follow_index_pattern (rename follower indices)
+POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
+Content-Type: application/json
+
+{
+  "leader_alias": "source",
+  "name": "test",
+  "pattern": "*customer*",
+  "follow_index_pattern": "{{leader_index}}-replica"
+}
+
 ### Add auto follow actions with Security plugin
 POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json

--- a/replication.http
+++ b/replication.http
@@ -152,7 +152,7 @@ Content-Type: application/json
   "pattern": "*customer*"
 }
 
-### Add auto follow actions with follow_index_pattern (rename follower indices)
+### Add auto follow actions with follower_index_pattern (rename follower indices)
 POST localhost:{{foll_port}}/_plugins/_replication/_autofollow
 Content-Type: application/json
 
@@ -160,7 +160,7 @@ Content-Type: application/json
   "leader_alias": "source",
   "name": "test",
   "pattern": "*customer*",
-  "follow_index_pattern": "{{leader_index}}-replica"
+  "follower_index_pattern": "{{leader_index}}-replica"
 }
 
 ### Add auto follow actions with Security plugin

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
@@ -87,7 +87,8 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
                             false)
 
                     metadataManager.addAutofollowMetadata(request.patternName, request.connection, request.pattern!!,
-                            ReplicationOverallState.RUNNING, user, followerClusterRole, leaderClusterRole, request.settings)
+                            ReplicationOverallState.RUNNING, user, followerClusterRole, leaderClusterRole, request.settings,
+                            request.followIndexPattern)
                     startAutoFollowTask(request.connection, request.patternName)
                 }
                 AcknowledgedResponse(true)

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
@@ -88,7 +88,7 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
 
                     metadataManager.addAutofollowMetadata(request.patternName, request.connection, request.pattern!!,
                             ReplicationOverallState.RUNNING, user, followerClusterRole, leaderClusterRole, request.settings,
-                            request.followIndexPattern)
+                            request.followerIndexPattern)
                     startAutoFollowTask(request.connection, request.patternName)
                 }
                 AcknowledgedResponse(true)

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
@@ -13,8 +13,10 @@ package org.opensearch.replication.action.autofollow
 
 import org.opensearch.replication.action.index.ReplicateIndexRequest
 import org.opensearch.replication.metadata.store.KEY_SETTINGS
+import org.opensearch.replication.util.ValidationUtil
 import org.opensearch.replication.util.ValidationUtil.validateName
 import org.opensearch.replication.util.ValidationUtil.validatePattern
+import org.opensearch.Version
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.support.clustermanager.AcknowledgedRequest
 import org.opensearch.core.ParseField
@@ -38,6 +40,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
     var pattern: String? = null
     var useRoles: HashMap<String, String>? = null // roles to use - {leader_fgac_role: role1, follower_fgac_role: role2}
     var settings : Settings = Settings.EMPTY
+    var followIndexPattern: String? = null
 
     enum class Action {
         ADD, REMOVE
@@ -60,6 +63,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
                 { request: UpdateAutoFollowPatternRequest, settings: Settings -> request.settings = settings},
                 { p: XContentParser?, _: Void? -> Settings.fromXContent(p) },
                     null, ParseField(KEY_SETTINGS))
+            AUTOFOLLOW_REQ_PARSER.declareStringOrNull(UpdateAutoFollowPatternRequest::followIndexPattern::set, ParseField("follow_index_pattern"))
         }
         fun fromXContent(xcp: XContentParser, action: Action) : UpdateAutoFollowPatternRequest {
             val updateAutofollowReq = AUTOFOLLOW_REQ_PARSER.parse(xcp, null)
@@ -92,6 +96,9 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         if(leaderClusterRole != null) useRoles!![ReplicateIndexRequest.LEADER_CLUSTER_ROLE] = leaderClusterRole
         if(followerClusterRole != null) useRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerClusterRole
         settings = Settings.readSettingsFromStream(inp)
+        if (inp.version.onOrAfter(Version.V_3_7_0)) {
+            followIndexPattern = inp.readOptionalString()
+        }
     }
 
 
@@ -114,11 +121,15 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
             if(pattern != null) {
                 validationException.addValidationError("Unexpected pattern")
             }
+            if(followIndexPattern != null) {
+                validationException.addValidationError("Unexpected follow_index_pattern for remove action")
+            }
         } else {
             if(pattern == null)
                validationException.addValidationError("Missing pattern")
             else
                validatePattern(pattern, validationException)
+            ValidationUtil.validateFollowIndexPattern(followIndexPattern, validationException)
         }
 
         return if(validationException.validationErrors().isEmpty()) return null else validationException
@@ -133,6 +144,9 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         out.writeOptionalString(useRoles?.get(ReplicateIndexRequest.LEADER_CLUSTER_ROLE))
         out.writeOptionalString(useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE))
         Settings.writeSettingsToStream(settings, out)
+        if (out.version.onOrAfter(Version.V_3_7_0)) {
+            out.writeOptionalString(followIndexPattern)
+        }
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -152,6 +166,10 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         builder.startObject(KEY_SETTINGS)
         settings.toXContent(builder, ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
         builder.endObject()
+
+        if (followIndexPattern != null) {
+            builder.field("follow_index_pattern", followIndexPattern)
+        }
 
         return builder.endObject()
     }

--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/UpdateAutoFollowPatternRequest.kt
@@ -16,6 +16,7 @@ import org.opensearch.replication.metadata.store.KEY_SETTINGS
 import org.opensearch.replication.util.ValidationUtil
 import org.opensearch.replication.util.ValidationUtil.validateName
 import org.opensearch.replication.util.ValidationUtil.validatePattern
+import org.opensearch.replication.util.KEY_FOLLOWER_INDEX_PATTERN
 import org.opensearch.Version
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.support.clustermanager.AcknowledgedRequest
@@ -40,7 +41,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
     var pattern: String? = null
     var useRoles: HashMap<String, String>? = null // roles to use - {leader_fgac_role: role1, follower_fgac_role: role2}
     var settings : Settings = Settings.EMPTY
-    var followIndexPattern: String? = null
+    var followerIndexPattern: String? = null
 
     enum class Action {
         ADD, REMOVE
@@ -63,7 +64,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
                 { request: UpdateAutoFollowPatternRequest, settings: Settings -> request.settings = settings},
                 { p: XContentParser?, _: Void? -> Settings.fromXContent(p) },
                     null, ParseField(KEY_SETTINGS))
-            AUTOFOLLOW_REQ_PARSER.declareStringOrNull(UpdateAutoFollowPatternRequest::followIndexPattern::set, ParseField("follow_index_pattern"))
+            AUTOFOLLOW_REQ_PARSER.declareStringOrNull(UpdateAutoFollowPatternRequest::followerIndexPattern::set, ParseField(KEY_FOLLOWER_INDEX_PATTERN))
         }
         fun fromXContent(xcp: XContentParser, action: Action) : UpdateAutoFollowPatternRequest {
             val updateAutofollowReq = AUTOFOLLOW_REQ_PARSER.parse(xcp, null)
@@ -97,7 +98,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         if(followerClusterRole != null) useRoles!![ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE] = followerClusterRole
         settings = Settings.readSettingsFromStream(inp)
         if (inp.version.onOrAfter(Version.V_3_7_0)) {
-            followIndexPattern = inp.readOptionalString()
+            followerIndexPattern = inp.readOptionalString()
         }
     }
 
@@ -121,15 +122,15 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
             if(pattern != null) {
                 validationException.addValidationError("Unexpected pattern")
             }
-            if(followIndexPattern != null) {
-                validationException.addValidationError("Unexpected follow_index_pattern for remove action")
+            if(followerIndexPattern != null) {
+                validationException.addValidationError("Unexpected $KEY_FOLLOWER_INDEX_PATTERN for remove action")
             }
         } else {
             if(pattern == null)
                validationException.addValidationError("Missing pattern")
             else
                validatePattern(pattern, validationException)
-            ValidationUtil.validateFollowIndexPattern(followIndexPattern, validationException)
+            ValidationUtil.validateFollowerIndexPattern(followerIndexPattern, validationException)
         }
 
         return if(validationException.validationErrors().isEmpty()) return null else validationException
@@ -145,7 +146,7 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         out.writeOptionalString(useRoles?.get(ReplicateIndexRequest.FOLLOWER_CLUSTER_ROLE))
         Settings.writeSettingsToStream(settings, out)
         if (out.version.onOrAfter(Version.V_3_7_0)) {
-            out.writeOptionalString(followIndexPattern)
+            out.writeOptionalString(followerIndexPattern)
         }
     }
 
@@ -167,8 +168,8 @@ class UpdateAutoFollowPatternRequest: AcknowledgedRequest<UpdateAutoFollowPatter
         settings.toXContent(builder, ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
         builder.endObject()
 
-        if (followIndexPattern != null) {
-            builder.field("follow_index_pattern", followIndexPattern)
+        if (followerIndexPattern != null) {
+            builder.field(KEY_FOLLOWER_INDEX_PATTERN, followerIndexPattern)
         }
 
         return builder.endObject()

--- a/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
@@ -61,11 +61,12 @@ open class ReplicationMetadataManager constructor(private val clusterService: Cl
 
     suspend fun addAutofollowMetadata(patternName: String, connectionName: String, pattern: String,
                                       overallState: ReplicationOverallState, user: User?,
-                                      follower_cluster_role: String?, leader_cluster_role: String?, settings: Settings) {
+                                      follower_cluster_role: String?, leader_cluster_role: String?, settings: Settings,
+                                      followIndexPattern: String? = null) {
         val replicationMetadata = ReplicationMetadata(connectionName,
                 ReplicationStoreMetadataType.AUTO_FOLLOW.name, overallState.name, CUSTOMER_INITIATED_ACTION,
                 ReplicationContext(patternName, user?.overrideFgacRole(follower_cluster_role)),
-                ReplicationContext(pattern, user?.overrideFgacRole(leader_cluster_role)), settings)
+                ReplicationContext(pattern, user?.overrideFgacRole(leader_cluster_role)), settings, followIndexPattern)
         addMetadata(AddReplicationMetadataRequest(replicationMetadata))
     }
 

--- a/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
@@ -62,11 +62,11 @@ open class ReplicationMetadataManager constructor(private val clusterService: Cl
     suspend fun addAutofollowMetadata(patternName: String, connectionName: String, pattern: String,
                                       overallState: ReplicationOverallState, user: User?,
                                       follower_cluster_role: String?, leader_cluster_role: String?, settings: Settings,
-                                      followIndexPattern: String? = null) {
+                                      followerIndexPattern: String? = null) {
         val replicationMetadata = ReplicationMetadata(connectionName,
                 ReplicationStoreMetadataType.AUTO_FOLLOW.name, overallState.name, CUSTOMER_INITIATED_ACTION,
                 ReplicationContext(patternName, user?.overrideFgacRole(follower_cluster_role)),
-                ReplicationContext(pattern, user?.overrideFgacRole(leader_cluster_role)), settings, followIndexPattern)
+                ReplicationContext(pattern, user?.overrideFgacRole(leader_cluster_role)), settings, followerIndexPattern)
         addMetadata(AddReplicationMetadataRequest(replicationMetadata))
     }
 

--- a/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadata.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadata.kt
@@ -13,6 +13,7 @@ package org.opensearch.replication.metadata.store
 
 import org.opensearch.commons.authuser.User
 import org.opensearch.core.ParseField
+import org.opensearch.replication.util.KEY_FOLLOWER_INDEX_PATTERN
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.common.io.stream.Writeable
@@ -86,7 +87,7 @@ class ReplicationMetadata: ToXContent {
     lateinit var followerContext: ReplicationContext
     lateinit var leaderContext: ReplicationContext
     lateinit var settings: Settings
-    var followIndexPattern: String? = null
+    var followerIndexPattern: String? = null
 
 
     constructor(connectionName: String,
@@ -96,7 +97,7 @@ class ReplicationMetadata: ToXContent {
                 followerContext: ReplicationContext,
                 leaderContext: ReplicationContext,
                 settings: Settings,
-                followIndexPattern: String? = null) {
+                followerIndexPattern: String? = null) {
         this.connectionName = connectionName
         this.metadataType = metadataType
         this.overallState = overallState
@@ -104,7 +105,7 @@ class ReplicationMetadata: ToXContent {
         this.followerContext = followerContext
         this.leaderContext = leaderContext
         this.settings = settings
-        this.followIndexPattern = followIndexPattern
+        this.followerIndexPattern = followerIndexPattern
     }
 
     private constructor() {
@@ -124,8 +125,8 @@ class ReplicationMetadata: ToXContent {
             METADATA_PARSER.declareObject({ metadata: ReplicationMetadata, settings: Settings -> metadata.settings = settings},
                 { p: XContentParser?, _: Void? -> Settings.fromXContent(p) },
                     ParseField(KEY_SETTINGS))
-            METADATA_PARSER.declareStringOrNull({ metadata: ReplicationMetadata, value: String? -> metadata.followIndexPattern = value },
-                    ParseField("follow_index_pattern"))
+            METADATA_PARSER.declareStringOrNull({ metadata: ReplicationMetadata, value: String? -> metadata.followerIndexPattern = value },
+                    ParseField(KEY_FOLLOWER_INDEX_PATTERN))
         }
 
         @Throws(IOException::class)
@@ -159,8 +160,8 @@ class ReplicationMetadata: ToXContent {
         settings.toXContent(builder, ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
         builder.endObject()
 
-        if (followIndexPattern != null) {
-            builder.field("follow_index_pattern", followIndexPattern)
+        if (followerIndexPattern != null) {
+            builder.field(KEY_FOLLOWER_INDEX_PATTERN, followerIndexPattern)
         }
 
         builder.endObject()
@@ -171,6 +172,6 @@ class ReplicationMetadata: ToXContent {
     override fun toString(): String {
         return "ReplicationMetadata - [connection_name: $connectionName, metadata_type: $metadataType, " +
                 "overall_state: $overallState, reason: $reason, follower_context: ${followerContext.resource}, leader_context: ${leaderContext.resource}, " +
-                " settings: ${settings}, follow_index_pattern: $followIndexPattern ]"
+                " settings: ${settings}, follower_index_pattern: $followerIndexPattern ]"
     }
 }

--- a/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadata.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadata.kt
@@ -86,6 +86,7 @@ class ReplicationMetadata: ToXContent {
     lateinit var followerContext: ReplicationContext
     lateinit var leaderContext: ReplicationContext
     lateinit var settings: Settings
+    var followIndexPattern: String? = null
 
 
     constructor(connectionName: String,
@@ -94,7 +95,8 @@ class ReplicationMetadata: ToXContent {
                 reason: String,
                 followerContext: ReplicationContext,
                 leaderContext: ReplicationContext,
-                settings: Settings) {
+                settings: Settings,
+                followIndexPattern: String? = null) {
         this.connectionName = connectionName
         this.metadataType = metadataType
         this.overallState = overallState
@@ -102,6 +104,7 @@ class ReplicationMetadata: ToXContent {
         this.followerContext = followerContext
         this.leaderContext = leaderContext
         this.settings = settings
+        this.followIndexPattern = followIndexPattern
     }
 
     private constructor() {
@@ -121,6 +124,8 @@ class ReplicationMetadata: ToXContent {
             METADATA_PARSER.declareObject({ metadata: ReplicationMetadata, settings: Settings -> metadata.settings = settings},
                 { p: XContentParser?, _: Void? -> Settings.fromXContent(p) },
                     ParseField(KEY_SETTINGS))
+            METADATA_PARSER.declareStringOrNull({ metadata: ReplicationMetadata, value: String? -> metadata.followIndexPattern = value },
+                    ParseField("follow_index_pattern"))
         }
 
         @Throws(IOException::class)
@@ -154,6 +159,10 @@ class ReplicationMetadata: ToXContent {
         settings.toXContent(builder, ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
         builder.endObject()
 
+        if (followIndexPattern != null) {
+            builder.field("follow_index_pattern", followIndexPattern)
+        }
+
         builder.endObject()
 
         return builder
@@ -162,6 +171,6 @@ class ReplicationMetadata: ToXContent {
     override fun toString(): String {
         return "ReplicationMetadata - [connection_name: $connectionName, metadata_type: $metadataType, " +
                 "overall_state: $overallState, reason: $reason, follower_context: ${followerContext.resource}, leader_context: ${leaderContext.resource}, " +
-                " settings: ${settings} ]"
+                " settings: ${settings}, follow_index_pattern: $followIndexPattern ]"
     }
 }

--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -116,12 +116,12 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
     }
 
     /**
-     * Resolves the follower index name for a given leader index. When a follow_index_pattern
+     * Resolves the follower index name for a given leader index. When a follower_index_pattern
      * is configured on the autofollow rule, the {{leader_index}} placeholder is substituted
      * with the leader index name. Otherwise the leader index name is returned unchanged.
      */
     private fun getFollowerIndexName(leaderIndex: String): String {
-        val pattern = replicationMetadata.followIndexPattern
+        val pattern = replicationMetadata.followerIndexPattern
         return if (pattern != null) {
             pattern.replace(LEADER_INDEX_PLACEHOLDER, leaderIndex)
         } else {
@@ -154,17 +154,18 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
 
         var currentIndices = clusterService.state().metadata().concreteAllIndices.asIterable() // All indices - open and closed on the cluster
         val currentIndicesSet = currentIndices.toSet()
-        val collidingIndices = remoteIndices.filter { currentIndicesSet.contains(getFollowerIndexName(it)) }
+        val followerIndexByLeader = remoteIndices.associateWith { getFollowerIndexName(it) }
+        val collidingIndices = remoteIndices.filter { currentIndicesSet.contains(followerIndexByLeader.getValue(it)) }
         if (collidingIndices.isNotEmpty()) {
             // Log this once when we see any update on indices on the follower cluster to prevent log flood
             if (currentIndicesSet != trackingIndicesOnTheCluster) {
                 log.info("Cannot initiate replication for the following indices from leader ($leaderAlias) as " +
                         "follower indices already exist on the cluster: " +
-                        collidingIndices.joinToString { "$it -> ${getFollowerIndexName(it)}" })
+                        collidingIndices.joinToString { "$it -> ${followerIndexByLeader.getValue(it)}" })
                 trackingIndicesOnTheCluster = currentIndicesSet
             }
         }
-        remoteIndices = remoteIndices.filter { !currentIndicesSet.contains(getFollowerIndexName(it)) }
+        remoteIndices = remoteIndices.filter { !currentIndicesSet.contains(followerIndexByLeader.getValue(it)) }
                 .minus(stat.failedIndices).minus(replicationJobsQueue)
 
         stat.failCounterForRun = 0

--- a/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/autofollow/AutoFollowTask.kt
@@ -20,6 +20,7 @@ import org.opensearch.replication.task.ReplicationState
 import org.opensearch.replication.util.stackTraceToString
 import org.opensearch.replication.util.suspendExecute
 import org.opensearch.replication.util.suspending
+import org.opensearch.replication.util.LEADER_INDEX_PLACEHOLDER
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -114,6 +115,20 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         retryScheduler?.cancel()
     }
 
+    /**
+     * Resolves the follower index name for a given leader index. When a follow_index_pattern
+     * is configured on the autofollow rule, the {{leader_index}} placeholder is substituted
+     * with the leader index name. Otherwise the leader index name is returned unchanged.
+     */
+    private fun getFollowerIndexName(leaderIndex: String): String {
+        val pattern = replicationMetadata.followIndexPattern
+        return if (pattern != null) {
+            pattern.replace(LEADER_INDEX_PLACEHOLDER, leaderIndex)
+        } else {
+            leaderIndex
+        }
+    }
+
     private suspend fun pollForIndices() {
         log.debug("Checking $leaderAlias under pattern name $patternName for new indices to auto follow")
         log.debug("Polling for indices: leaderAlias=$leaderAlias, pattern=$patternName")
@@ -138,15 +153,19 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
         }
 
         var currentIndices = clusterService.state().metadata().concreteAllIndices.asIterable() // All indices - open and closed on the cluster
-        if(remoteIndices.intersect(currentIndices).isNotEmpty()) {
+        val currentIndicesSet = currentIndices.toSet()
+        val collidingIndices = remoteIndices.filter { currentIndicesSet.contains(getFollowerIndexName(it)) }
+        if (collidingIndices.isNotEmpty()) {
             // Log this once when we see any update on indices on the follower cluster to prevent log flood
-            if(currentIndices.toSet() != trackingIndicesOnTheCluster) {
-                log.info("Cannot initiate replication for the following indices from leader ($leaderAlias) as indices with " +
-                        "same name already exists on the cluster ${remoteIndices.intersect(currentIndices)}")
-                trackingIndicesOnTheCluster = currentIndices.toSet()
+            if (currentIndicesSet != trackingIndicesOnTheCluster) {
+                log.info("Cannot initiate replication for the following indices from leader ($leaderAlias) as " +
+                        "follower indices already exist on the cluster: " +
+                        collidingIndices.joinToString { "$it -> ${getFollowerIndexName(it)}" })
+                trackingIndicesOnTheCluster = currentIndicesSet
             }
         }
-        remoteIndices = remoteIndices.minus(currentIndices).minus(stat.failedIndices).minus(replicationJobsQueue)
+        remoteIndices = remoteIndices.filter { !currentIndicesSet.contains(getFollowerIndexName(it)) }
+                .minus(stat.failedIndices).minus(replicationJobsQueue)
 
         stat.failCounterForRun = 0
         startReplicationJobs(remoteIndices)
@@ -156,7 +175,8 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
     private suspend fun startReplicationJobs(remoteIndices: Iterable<String>) {
         val completedJobs = ConcurrentSkipListSet<String>()
         for(index in replicationJobsQueue) {
-            val statusReq = ShardInfoRequest(index, false)
+            val followerIdx = getFollowerIndexName(index)
+            val statusReq = ShardInfoRequest(followerIdx, false)
             try {
                 val statusRes = client.suspendExecute(ReplicationStatusAction.INSTANCE, statusReq, injectSecurityContext = true)
                 if(statusRes.status != ShardInfoResponse.BOOTSTRAPPING) {
@@ -187,17 +207,17 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
     }
 
     private suspend fun startReplication(leaderIndex: String) {
-        if (clusterService.state().metadata().hasIndex(leaderIndex)) {
-            log.info("""Cannot replicate $leaderAlias:$leaderIndex as an index with the same name already 
-                        |exists.""".trimMargin())
+        val followerIndex = getFollowerIndexName(leaderIndex)
+        if (clusterService.state().metadata().hasIndex(followerIndex)) {
+            log.info("Cannot replicate $leaderAlias:$leaderIndex -> $followerIndex as follower index already exists.")
             return
         }
 
         var successStart = false
 
         try {
-            log.info("Auto follow starting replication from ${leaderAlias}:$leaderIndex -> $leaderIndex")
-            val request = ReplicateIndexRequest(leaderIndex, leaderAlias, leaderIndex )
+            log.info("Auto follow starting replication from ${leaderAlias}:$leaderIndex -> $followerIndex")
+            val request = ReplicateIndexRequest(followerIndex, leaderAlias, leaderIndex )
             request.isAutoFollowRequest = true
             val followerRole = replicationMetadata.followerContext.user?.roles?.get(0)
             val leaderRole = replicationMetadata.leaderContext.user?.roles?.get(0)
@@ -212,13 +232,13 @@ class AutoFollowTask(id: Long, type: String, action: String, description: String
                 throw ReplicationException("Failed to auto follow leader index $leaderIndex")
             }
             successStart = true
-            log.debug("Auto follow has started replication from ${leaderAlias}:$leaderIndex -> $leaderIndex")
+            log.debug("Auto follow has started replication from ${leaderAlias}:$leaderIndex -> $followerIndex")
         } catch (e: OpenSearchSecurityException) {
             // For permission related failures, Adding as part of failed indices as autofollow role doesn't have required permissions.
             log.trace("Cannot start replication on $leaderIndex due to missing permissions $e")
         } catch (e: Exception) {
             // Any failure other than security exception can be safely retried and not adding to the failed indices
-            log.warn("Failed to start replication for $leaderAlias:$leaderIndex -> $leaderIndex.", e)
+            log.warn("Failed to start replication for $leaderAlias:$leaderIndex -> $followerIndex.", e)
         } finally {
             if (successStart) {
                 stat.successCount++

--- a/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
@@ -36,6 +36,8 @@ import java.nio.file.Path
 import java.util.*
 import java.util.function.Predicate
 
+const val LEADER_INDEX_PLACEHOLDER = "{{leader_index}}"
+
 object ValidationUtil {
 
     private val log = LogManager.getLogger(ValidationUtil::class.java)
@@ -126,6 +128,23 @@ object ValidationUtil {
         if ((pattern?.startsWith('_') ?: false) || (pattern?.startsWith('-') ?: false))
             validationException.addValidationError("Autofollow pattern: $pattern must not start with '_' or '-'")
 
+    }
+
+    /**
+     * Validate the follow_index_pattern used for renaming follower indices in autofollow.
+     * The pattern must contain the {{leader_index}} placeholder, and the static portion
+     * (with the placeholder substituted) must form a valid index name.
+     */
+    fun validateFollowIndexPattern(followIndexPattern: String?, validationException: ValidationException) {
+        if (followIndexPattern == null) return
+
+        if (!followIndexPattern.contains(LEADER_INDEX_PLACEHOLDER)) {
+            validationException.addValidationError("follow_index_pattern must contain the $LEADER_INDEX_PLACEHOLDER placeholder")
+        }
+
+        // Validate that the static portion produces a valid index name
+        val sampleResolved = followIndexPattern.replace(LEADER_INDEX_PLACEHOLDER, "sample")
+        validateName(sampleResolved, validationException)
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt
@@ -37,6 +37,7 @@ import java.util.*
 import java.util.function.Predicate
 
 const val LEADER_INDEX_PLACEHOLDER = "{{leader_index}}"
+const val KEY_FOLLOWER_INDEX_PATTERN = "follower_index_pattern"
 
 object ValidationUtil {
 
@@ -131,19 +132,19 @@ object ValidationUtil {
     }
 
     /**
-     * Validate the follow_index_pattern used for renaming follower indices in autofollow.
+     * Validate the follower_index_pattern used for renaming follower indices in autofollow.
      * The pattern must contain the {{leader_index}} placeholder, and the static portion
      * (with the placeholder substituted) must form a valid index name.
      */
-    fun validateFollowIndexPattern(followIndexPattern: String?, validationException: ValidationException) {
-        if (followIndexPattern == null) return
+    fun validateFollowerIndexPattern(followerIndexPattern: String?, validationException: ValidationException) {
+        if (followerIndexPattern == null) return
 
-        if (!followIndexPattern.contains(LEADER_INDEX_PLACEHOLDER)) {
-            validationException.addValidationError("follow_index_pattern must contain the $LEADER_INDEX_PLACEHOLDER placeholder")
+        if (!followerIndexPattern.contains(LEADER_INDEX_PLACEHOLDER)) {
+            validationException.addValidationError("$KEY_FOLLOWER_INDEX_PATTERN must contain the $LEADER_INDEX_PLACEHOLDER placeholder")
         }
 
         // Validate that the static portion produces a valid index name
-        val sampleResolved = followIndexPattern.replace(LEADER_INDEX_PLACEHOLDER, "sample")
+        val sampleResolved = followerIndexPattern.replace(LEADER_INDEX_PLACEHOLDER, "sample")
         validateName(sampleResolved, validationException)
     }
 

--- a/src/main/resources/mappings/replication-metadata-store.json
+++ b/src/main/resources/mappings/replication-metadata-store.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 1
+    "schema_version": 2
   },
   "dynamic": "strict",
   "properties": {
@@ -107,6 +107,9 @@
     "settings": {
       "dynamic": true,
       "properties": {}
+    },
+    "follow_index_pattern": {
+      "type": "keyword"
     },
     "leader_context": {
       "type": "nested",

--- a/src/main/resources/mappings/replication-metadata-store.json
+++ b/src/main/resources/mappings/replication-metadata-store.json
@@ -108,7 +108,7 @@
       "dynamic": true,
       "properties": {}
     },
-    "follow_index_pattern": {
+    "follower_index_pattern": {
       "type": "keyword"
     },
     "leader_context": {

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -351,7 +351,7 @@ fun RestHighLevelClient.waitForReplicationStop(index: String, waitFor : TimeValu
 fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName: String, pattern: String,
                                                 settings: Settings = Settings.EMPTY,
                                                 useRoles: UseRoles = UseRoles(),
-                                                followIndexPattern: String? = null,
+                                                followerIndexPattern: String? = null,
                                                 requestOptions: RequestOptions = RequestOptions.DEFAULT,
                                                 ignoreIfExists: Boolean = false,
                                                 clusterManagerTimeout: String? = null) {
@@ -367,8 +367,8 @@ fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName:
                                         "follower_cluster_role": "${useRoles.followerClusterRole}"
                                        }"""
     )
-    if (followIndexPattern != null) {
-        bodyParts.add(""""follow_index_pattern": "${followIndexPattern}"""")
+    if (followerIndexPattern != null) {
+        bodyParts.add(""""follower_index_pattern": "${followerIndexPattern}"""")
     }
     if (settings != Settings.EMPTY) {
         bodyParts.add(""""settings": $settings""")

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -351,34 +351,29 @@ fun RestHighLevelClient.waitForReplicationStop(index: String, waitFor : TimeValu
 fun RestHighLevelClient.updateAutoFollowPattern(connection: String, patternName: String, pattern: String,
                                                 settings: Settings = Settings.EMPTY,
                                                 useRoles: UseRoles = UseRoles(),
+                                                followIndexPattern: String? = null,
                                                 requestOptions: RequestOptions = RequestOptions.DEFAULT,
                                                 ignoreIfExists: Boolean = false,
                                                 clusterManagerTimeout: String? = null) {
     var url = REST_AUTO_FOLLOW_PATTERN
     if (clusterManagerTimeout != null) url += "?cluster_manager_timeout=$clusterManagerTimeout"
     val lowLevelRequest = Request("POST", url)
-    if (settings == Settings.EMPTY) {
-        lowLevelRequest.setJsonEntity("""{
-                                       "leader_alias" : "${connection}",
-                                       "name" : "${patternName}",
-                                       "pattern": "${pattern}",
-                                       "use_roles": {
+    val bodyParts = mutableListOf(
+        """"leader_alias" : "${connection}"""",
+        """"name" : "${patternName}"""",
+        """"pattern": "${pattern}"""",
+        """"use_roles": {
                                         "leader_cluster_role": "${useRoles.leaderClusterRole}",
                                         "follower_cluster_role": "${useRoles.followerClusterRole}"
-                                       }
-                                     }""")
-    } else {
-        lowLevelRequest.setJsonEntity("""{
-                                       "leader_alias" : "${connection}",
-                                       "name" : "${patternName}",
-                                       "pattern": "${pattern}",
-                                       "use_roles": {
-                                        "leader_cluster_role": "${useRoles.leaderClusterRole}",
-                                        "follower_cluster_role": "${useRoles.followerClusterRole}"
-                                       },
-                                       "settings": $settings
-                                     }""")
+                                       }"""
+    )
+    if (followIndexPattern != null) {
+        bodyParts.add(""""follow_index_pattern": "${followIndexPattern}"""")
     }
+    if (settings != Settings.EMPTY) {
+        bodyParts.add(""""settings": $settings""")
+    }
+    lowLevelRequest.setJsonEntity("{${bodyParts.joinToString(",")}}")
     lowLevelRequest.setOptions(requestOptions)
     try {
         val lowLevelResponse = lowLevelClient.performRequest(lowLevelRequest)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -113,13 +113,13 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         }
     }
 
-    fun `test auto follow pattern with follow_index_pattern renames follower`() {
+    fun `test auto follow pattern with follower_index_pattern renames follower`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
         try {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
-                    followIndexPattern = "{{leader_index}}-replica")
+                    followerIndexPattern = "{{leader_index}}-replica")
             val leaderIndexName = createRandomIndex(leaderClient)
             // Verify the follower index is created with the renamed name
             assertBusy({
@@ -136,7 +136,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         }
     }
 
-    fun `test auto follow pattern follow_index_pattern avoids collision with existing index`() {
+    fun `test auto follow pattern follower_index_pattern avoids collision with existing index`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
@@ -147,7 +147,7 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
             // Same-named index on leader
             leaderClient.indices().create(CreateIndexRequest(existingIndex), RequestOptions.DEFAULT)
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
-                    followIndexPattern = "{{leader_index}}-replica")
+                    followerIndexPattern = "{{leader_index}}-replica")
             // The renamed follower index is created (no collision with the local index)
             assertBusy({
                 Assertions.assertThat(followerClient.indices()
@@ -159,17 +159,17 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         }
     }
 
-    fun `test auto follow pattern follow_index_pattern validation rejects missing placeholder`() {
+    fun `test auto follow pattern follower_index_pattern validation rejects missing placeholder`() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
         Assertions.assertThatThrownBy {
             followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
-                    followIndexPattern = "static-name-no-placeholder")
+                    followerIndexPattern = "static-name-no-placeholder")
         }.isInstanceOf(ResponseException::class.java)
-                .hasMessageContaining("follow_index_pattern must contain")
+                .hasMessageContaining("follower_index_pattern must contain")
     }
 
-    fun `test auto follow pattern without follow_index_pattern preserves backward compat`() {
+    fun `test auto follow pattern without follower_index_pattern preserves backward compat`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -113,6 +113,80 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         }
     }
 
+    fun `test auto follow pattern with follow_index_pattern renames follower`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+        try {
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
+                    followIndexPattern = "{{leader_index}}-replica")
+            val leaderIndexName = createRandomIndex(leaderClient)
+            // Verify the follower index is created with the renamed name
+            assertBusy({
+                Assertions.assertThat(followerClient.indices()
+                        .exists(GetIndexRequest("${leaderIndexName}-replica"), RequestOptions.DEFAULT))
+                        .isEqualTo(true)
+            }, 60, TimeUnit.SECONDS)
+            // Verify the un-renamed name does NOT exist on the follower
+            Assertions.assertThat(followerClient.indices()
+                    .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT))
+                    .isEqualTo(false)
+        } finally {
+            followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+        }
+    }
+
+    fun `test auto follow pattern follow_index_pattern avoids collision with existing index`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+        val existingIndex = "${indexPrefix}existing"
+        try {
+            // Local index on follower with the same name as the leader index
+            followerClient.indices().create(CreateIndexRequest(existingIndex), RequestOptions.DEFAULT)
+            // Same-named index on leader
+            leaderClient.indices().create(CreateIndexRequest(existingIndex), RequestOptions.DEFAULT)
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
+                    followIndexPattern = "{{leader_index}}-replica")
+            // The renamed follower index is created (no collision with the local index)
+            assertBusy({
+                Assertions.assertThat(followerClient.indices()
+                        .exists(GetIndexRequest("${existingIndex}-replica"), RequestOptions.DEFAULT))
+                        .isEqualTo(true)
+            }, 60, TimeUnit.SECONDS)
+        } finally {
+            followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+        }
+    }
+
+    fun `test auto follow pattern follow_index_pattern validation rejects missing placeholder`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+        Assertions.assertThatThrownBy {
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern,
+                    followIndexPattern = "static-name-no-placeholder")
+        }.isInstanceOf(ResponseException::class.java)
+                .hasMessageContaining("follow_index_pattern must contain")
+    }
+
+    fun `test auto follow pattern without follow_index_pattern preserves backward compat`() {
+        val followerClient = getClientForCluster(FOLLOWER)
+        val leaderClient = getClientForCluster(LEADER)
+        createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
+        try {
+            followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
+            val leaderIndexName = createRandomIndex(leaderClient)
+            // Without a pattern, follower index name equals leader index name
+            assertBusy({
+                Assertions.assertThat(followerClient.indices()
+                        .exists(GetIndexRequest(leaderIndexName), RequestOptions.DEFAULT))
+                        .isEqualTo(true)
+            }, 60, TimeUnit.SECONDS)
+        } finally {
+            followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)
+        }
+    }
+
     fun `test auto follow pattern with updated delay for poll`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)

--- a/src/test/kotlin/org/opensearch/replication/util/ValidationUtilTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/util/ValidationUtilTests.kt
@@ -73,34 +73,34 @@ class ValidationUtilTests : OpenSearchTestCase() {
         return clusterService
     }
 
-    fun testValidateFollowIndexPattern_nullIsValid() {
+    fun testValidateFollowerIndexPattern_nullIsValid() {
         val validationException = ValidationException()
-        ValidationUtil.validateFollowIndexPattern(null, validationException)
+        ValidationUtil.validateFollowerIndexPattern(null, validationException)
         assertThat(validationException.validationErrors()).isEmpty()
     }
 
-    fun testValidateFollowIndexPattern_validPatternPasses() {
+    fun testValidateFollowerIndexPattern_validPatternPasses() {
         val validationException = ValidationException()
-        ValidationUtil.validateFollowIndexPattern("{{leader_index}}-replica", validationException)
+        ValidationUtil.validateFollowerIndexPattern("{{leader_index}}-replica", validationException)
         assertThat(validationException.validationErrors()).isEmpty()
     }
 
-    fun testValidateFollowIndexPattern_missingPlaceholderIsInvalid() {
+    fun testValidateFollowerIndexPattern_missingPlaceholderIsInvalid() {
         val validationException = ValidationException()
-        ValidationUtil.validateFollowIndexPattern("static-name", validationException)
+        ValidationUtil.validateFollowerIndexPattern("static-name", validationException)
         assertThat(validationException.validationErrors()).isNotEmpty()
         assertThat(validationException.validationErrors()[0]).contains("{{leader_index}}")
     }
 
-    fun testValidateFollowIndexPattern_invalidCharsInStaticPortion() {
+    fun testValidateFollowerIndexPattern_invalidCharsInStaticPortion() {
         val validationException = ValidationException()
-        ValidationUtil.validateFollowIndexPattern("{{leader_index}}:invalid", validationException)
+        ValidationUtil.validateFollowerIndexPattern("{{leader_index}}:invalid", validationException)
         assertThat(validationException.validationErrors()).isNotEmpty()
     }
 
-    fun testValidateFollowIndexPattern_prefixWithDotIsInvalid() {
+    fun testValidateFollowerIndexPattern_prefixWithDotIsInvalid() {
         val validationException = ValidationException()
-        ValidationUtil.validateFollowIndexPattern(".{{leader_index}}-replica", validationException)
+        ValidationUtil.validateFollowerIndexPattern(".{{leader_index}}-replica", validationException)
         assertThat(validationException.validationErrors()).isNotEmpty()
     }
 }

--- a/src/test/kotlin/org/opensearch/replication/util/ValidationUtilTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/util/ValidationUtilTests.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
 import org.opensearch.common.settings.Settings
+import org.opensearch.common.ValidationException
 import org.opensearch.test.OpenSearchTestCase
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
@@ -70,5 +71,36 @@ class ValidationUtilTests : OpenSearchTestCase() {
         whenever(clusterService.settings).thenReturn(settings)
         whenever(clusterService.clusterSettings).thenReturn(clusterSettings)
         return clusterService
+    }
+
+    fun testValidateFollowIndexPattern_nullIsValid() {
+        val validationException = ValidationException()
+        ValidationUtil.validateFollowIndexPattern(null, validationException)
+        assertThat(validationException.validationErrors()).isEmpty()
+    }
+
+    fun testValidateFollowIndexPattern_validPatternPasses() {
+        val validationException = ValidationException()
+        ValidationUtil.validateFollowIndexPattern("{{leader_index}}-replica", validationException)
+        assertThat(validationException.validationErrors()).isEmpty()
+    }
+
+    fun testValidateFollowIndexPattern_missingPlaceholderIsInvalid() {
+        val validationException = ValidationException()
+        ValidationUtil.validateFollowIndexPattern("static-name", validationException)
+        assertThat(validationException.validationErrors()).isNotEmpty()
+        assertThat(validationException.validationErrors()[0]).contains("{{leader_index}}")
+    }
+
+    fun testValidateFollowIndexPattern_invalidCharsInStaticPortion() {
+        val validationException = ValidationException()
+        ValidationUtil.validateFollowIndexPattern("{{leader_index}}:invalid", validationException)
+        assertThat(validationException.validationErrors()).isNotEmpty()
+    }
+
+    fun testValidateFollowIndexPattern_prefixWithDotIsInvalid() {
+        val validationException = ValidationException()
+        ValidationUtil.validateFollowIndexPattern(".{{leader_index}}-replica", validationException)
+        assertThat(validationException.validationErrors()).isNotEmpty()
     }
 }


### PR DESCRIPTION
### Description

Add an optional `follower_index_pattern` field to the autofollow API that allows users to rename follower indices using a `{{leader_index}}` placeholder. The placeholder is substituted with the actual leader index name at replication time, enabling users to avoid name collisions when a same-named local index exists or when replicating from multiple leader clusters.

**Example:**

```json
POST /_plugins/_replication/_autofollow
{
  "leader_alias": "leader-cluster",
  "name": "my-rule",
  "pattern": "logs-*",
  "follower_index_pattern": "{{leader_index}}-replica"
}
```

A leader index `logs-production` is replicated as `logs-production-replica` on the follower. When omitted, existing behavior is preserved (follower name = leader name).

**Implementation highlights:**

- Shared `LEADER_INDEX_PLACEHOLDER` constant in `ValidationUtil` for consistency
- Version-guarded (`V_3_7_0`) stream serialization in `UpdateAutoFollowPatternRequest` for BWC
- `ReplicationMetadata` stores the field via XContent (system index, not Writeable)
- System index mapping bumped to `schema_version: 2` for automatic upgrade
- `AutoFollowTask.getFollowerIndexName()` resolves names; collision detection in `pollForIndices()` uses resolved names
- `AutoFollowStat` intentionally NOT modified (deferred to avoid cross-node Writeable BWC risk)

### Related Issues

Resolves #265

### Testing

| Test Suite | Status | Duration |
|-----------|--------|----------|
| Unit tests (5 new in ValidationUtilTests) | ✅ Pass | 24s |
| Full integration suite (all test classes) | ✅ Pass | ~29m |
| BWC tests (mixed cluster, rolling upgrade, full restart — 3.3.0→3.7.0) | ✅ Pass | 2m 48s |
| Security tests (-Psecurity=true) | ✅ Pass | 44m |
| Manual E2E (10 scenarios on local clusters) | ✅ Pass | — |

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request created ([link](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)).
- [x] Commits are signed per the DCO using --signoff.
- [ ] Public documentation issue/PR created ([link](https://github.com/opensearch-project/documentation-website/issues/new/choose)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).