### PR TITLE
Fix stale/negative counters in follower_stats API by deriving state from cluster metadata

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/stats/FollowerStatsResponse.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/stats/FollowerStatsResponse.kt
@@ -54,13 +54,15 @@ class FollowerStatsResponse : BaseNodesResponse<FollowerNodeStatsResponse?>, ToX
     constructor(clusterName: ClusterName?, followerNodeResponse: List<FollowerNodeStatsResponse>?, failures: List<FailedNodeException?>?
                 , metadata : ReplicationStateMetadata) : super(clusterName, followerNodeResponse, failures) {
 
-        var syncing :MutableSet<String> = mutableSetOf()
+        // Collect indices that have live shard tasks from the in-memory metrics.
+        // This is the set of indices that are actively replicating data right now.
+        val indicesWithLiveShardTasks: MutableSet<String> = mutableSetOf()
         if (followerNodeResponse != null) {
             for (response in followerNodeResponse) {
                 shardStats.putAll(response.stats)
 
                 for (i in response.stats) {
-                    syncing.add(i.key.indexName)
+                    indicesWithLiveShardTasks.add(i.key.indexName)
 
                     if (i.key.indexName !in indexStats) {
                         indexStats[i.key.indexName] = FollowerShardMetric.FollowerStats()
@@ -72,20 +74,27 @@ class FollowerStatsResponse : BaseNodesResponse<FollowerNodeStatsResponse?>, ToX
             }
         }
 
-        var totalRunning = 0 //includes boostrap and syncing
+        // Compute index-level counters from cluster state metadata (single source of truth).
+        // For RUNNING indices, cross-reference with live shard tasks to distinguish
+        // SYNCING (has active shard tasks) from BOOTSTRAPPING (task registered but not yet active).
+        // This avoids the previous formula (totalRunning - syncingIndices) which could produce
+        // negative values when in-memory metrics and metadata drift apart due to stale/orphaned tasks.
         for (entry in metadata.replicationDetails) {
             when (entry.value[REPLICATION_LAST_KNOWN_OVERALL_STATE]) {
-                ReplicationOverallState.RUNNING.name -> totalRunning++
+                ReplicationOverallState.RUNNING.name -> {
+                    if (entry.key in indicesWithLiveShardTasks) {
+                        syncingIndices++
+                    } else {
+                        bootstrappingIndices++
+                    }
+                }
                 ReplicationOverallState.FAILED.name -> failedIndices++
                 ReplicationOverallState.PAUSED.name -> pausedIndices++
             }
         }
 
-        syncingIndices = syncing.size
-        bootstrappingIndices = totalRunning - syncingIndices
-
         shardTaskCount = shardStats.size
-        indexTaskCount = totalRunning
+        indexTaskCount = syncingIndices + bootstrappingIndices
     }
 
     @Throws(IOException::class)

--- a/src/test/kotlin/org/opensearch/replication/action/stats/FollowerStatsResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/action/stats/FollowerStatsResponseTests.kt
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.action.stats
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import org.opensearch.Version
+import org.opensearch.cluster.ClusterName
+import org.opensearch.cluster.node.DiscoveryNode
+import org.opensearch.cluster.node.DiscoveryNodeRole
+import org.opensearch.core.index.Index
+import org.opensearch.core.index.shard.ShardId
+import org.opensearch.replication.metadata.ReplicationOverallState
+import org.opensearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_STATE
+import org.opensearch.replication.metadata.state.ReplicationStateMetadata
+import org.opensearch.replication.task.shard.FollowerShardMetric
+import org.opensearch.test.OpenSearchTestCase
+import java.util.Collections
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class FollowerStatsResponseTests : OpenSearchTestCase() {
+
+    private val clusterName = ClusterName("test-cluster")
+
+    private fun createNode(nodeId: String): DiscoveryNode {
+        return DiscoveryNode(
+            nodeId, buildNewFakeTransportAddress(), Collections.emptyMap(),
+            DiscoveryNodeRole.BUILT_IN_ROLES, Version.CURRENT
+        )
+    }
+
+    private fun createShardId(indexName: String, shardNum: Int): ShardId {
+        return ShardId(Index(indexName, "_na_"), shardNum)
+    }
+
+    private fun createMetadata(vararg entries: Pair<String, String>): ReplicationStateMetadata {
+        val details = entries.associate { (indexName, state) ->
+            indexName to mapOf(REPLICATION_LAST_KNOWN_OVERALL_STATE to state)
+        }
+        return ReplicationStateMetadata(details)
+    }
+
+    private fun createNodeResponse(
+        nodeId: String,
+        shardMetrics: Map<ShardId, FollowerShardMetric>
+    ): FollowerNodeStatsResponse {
+        return FollowerNodeStatsResponse(createNode(nodeId), shardMetrics)
+    }
+
+    /**
+     * Covers all code paths in a single mixed-state scenario:
+     * - RUNNING + live shard tasks → syncing
+     * - RUNNING + no shard tasks → bootstrapping
+     * - PAUSED → pausedIndices
+     * - FAILED → failedIndices
+     * - STOPPED → ignored (not counted)
+     * - Orphaned shard tasks (in-memory but not in metadata) → ignored, no negative counts
+     * - Multi-node aggregation
+     * - indexStats aggregation for syncing index
+     */
+    fun `test follower stats computation from single source of truth`() {
+        val metadata = createMetadata(
+            "index-syncing" to ReplicationOverallState.RUNNING.name,
+            "index-bootstrapping" to ReplicationOverallState.RUNNING.name,
+            "index-paused" to ReplicationOverallState.PAUSED.name,
+            "index-failed" to ReplicationOverallState.FAILED.name,
+            "index-stopped" to ReplicationOverallState.STOPPED.name
+        )
+
+        // Node 1: has shard tasks for index-syncing and an orphaned index not in metadata
+        val metric = FollowerShardMetric()
+        metric.opsWritten.set(100)
+        metric.opsRead.set(200)
+
+        val node1Metrics = mapOf(
+            createShardId("index-syncing", 0) to metric,
+            createShardId("orphan-stale-index", 0) to FollowerShardMetric()
+        )
+
+        // Node 2: has another shard for index-syncing (multi-node distribution)
+        val node2Metrics = mapOf(
+            createShardId("index-syncing", 1) to FollowerShardMetric()
+        )
+
+        val nodeResponses = listOf(
+            createNodeResponse("node-1", node1Metrics),
+            createNodeResponse("node-2", node2Metrics)
+        )
+
+        val response = FollowerStatsResponse(clusterName, nodeResponses, emptyList(), metadata)
+
+        // RUNNING + live shard tasks = syncing
+        assertEquals(1, response.syncingIndices)
+        // RUNNING + no shard tasks = bootstrapping
+        assertEquals(1, response.bootstrappingIndices)
+        // PAUSED counted
+        assertEquals(1, response.pausedIndices)
+        // FAILED counted
+        assertEquals(1, response.failedIndices)
+        // indexTaskCount = syncing + bootstrapping
+        assertEquals(2, response.indexTaskCount)
+        // shardTaskCount = total shard entries across all nodes (including orphan)
+        assertEquals(3, response.shardTaskCount)
+        // Orphaned shard tasks do NOT produce negative bootstrapping
+        assertTrue(response.bootstrappingIndices >= 0)
+        // Index stats aggregated for syncing index
+        assertTrue(response.indexStats.containsKey("index-syncing"))
+        assertEquals(100L, response.indexStats["index-syncing"]!!.opsWritten)
+    }
+}


### PR DESCRIPTION
### Description

Change: Modified FollowerStatsResponse.kt to fix the stale follower_stats counter bug.

**What changed:**

**Before:**
syncingIndices was derived from the in-memory shard metrics map (indices with live shard entries), then `bootstrappingIndices = totalRunning - syncingIndices`. This formula could produce negative values when the in-memory map had entries for indices that metadata no longer considered RUNNING (orphaned/stale tasks).

**After:**
For each index in metadata with state `RUNNING`, we check if it has live shard tasks in the in-memory map. If yes then `syncingIndices++`. If no then `bootstrappingIndices++`. This guarantees:
No negative counts (each index is counted exactly once)
Only indices that metadata says are `RUNNING` can be syncing or bootstrapping
Indices with stale in-memory entries but no metadata entry are correctly ignored
`indexTaskCount` is now `syncingIndices + bootstrappingIndices` (consistent with what it represents)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
