### PR TITLE
Batch cluster-state updates for concurrent per-index writes in bulk APIs

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/bulk/TransportBulkReplicationAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/TransportBulkReplicationAction.kt
@@ -61,6 +61,7 @@ import org.opensearch.persistent.PersistentTasksService
 import org.opensearch.replication.ReplicationPlugin
 import org.opensearch.replication.task.index.IndexReplicationExecutor
 import org.opensearch.replication.task.index.IndexReplicationParams
+import org.opensearch.replication.task.index.IndexReplicationTask
 import org.opensearch.replication.util.StaleTaskUtils
 import org.opensearch.replication.util.ValidationUtil
 import org.opensearch.replication.util.startTask
@@ -71,6 +72,7 @@ import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 import org.opensearch.transport.client.Requests
+import org.opensearch.action.admin.indices.close.CloseIndexRequest
 import org.opensearch.action.admin.indices.open.OpenIndexRequest
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.replication.action.index.block.IndexBlockUpdateType
@@ -78,6 +80,14 @@ import org.opensearch.replication.action.index.block.UpdateIndexBlockAction
 import org.opensearch.replication.action.index.block.UpdateIndexBlockRequest
 import org.opensearch.replication.metadata.UpdateMetadataAction
 import org.opensearch.replication.metadata.UpdateMetadataRequest
+import org.opensearch.replication.repository.RemoteClusterRepository
+import org.opensearch.replication.repository.REMOTE_SNAPSHOT_NAME
+import org.opensearch.replication.ReplicationPlugin.Companion.REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING
+import org.opensearch.index.IndexSettings
+import org.opensearch.core.common.unit.ByteSizeUnit
+import org.opensearch.core.common.unit.ByteSizeValue
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest
+import org.opensearch.cluster.ClusterStateObserver
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -134,6 +144,7 @@ open class TransportBulkReplicationAction(
         }
     }
 
+
     // Routes to the correct resolver based on operation type.
     private suspend fun resolveIndices(request: BulkReplicationRequest): Pair<List<String>, List<FailedIndex>> {
         return when (operationType) {
@@ -143,7 +154,8 @@ open class TransportBulkReplicationAction(
         }
     }
 
-    // Resolves indices for START: validates alias, runs setup checks, fetches from leader, applies filters.
+    // Resolves indices for START: validates alias, fetches from leader, applies exclude filters,
+    // and updates leader translog settings in one bulk call.
     private suspend fun resolveStartIndices(request: BulkReplicationRequest): Pair<List<String>, List<FailedIndex>> {
         val alias = request.leaderAlias
         if (alias.isNullOrBlank()) {
@@ -194,8 +206,29 @@ open class TransportBulkReplicationAction(
         if (preFailures.isNotEmpty()) {
             log.info("${preFailures.size} indices already exist on follower for bulk_start, ${validIndices.size} are new")
         }
+
+        // Bulk update leader translog settings for ALL valid indices in ONE call (done once, not per-batch).
+        if (validIndices.isNotEmpty()) {
+            try {
+                val settingsBuilder = Settings.builder()
+                    .put(REPLICATION_INDEX_TRANSLOG_PRUNING_ENABLED_SETTING.key, true)
+                    .put(IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.key, ByteSizeValue(32, ByteSizeUnit.MB))
+                val updateSettingsRequest = remoteClient.admin().indices().prepareUpdateSettings()
+                    .setSettings(settingsBuilder)
+                    .setIndices(*validIndices.toTypedArray())
+                    .request()
+                val updateResponse = remoteClient.suspending(remoteClient.admin().indices()::updateSettings, injectSecurityContext = true)(updateSettingsRequest)
+                if (!updateResponse.isAcknowledged) {
+                    log.warn("Bulk leader translog settings update not acknowledged for ${validIndices.size} indices")
+                }
+            } catch (e: Exception) {
+                log.warn("Failed to bulk-update leader translog settings: ${e.message}")
+            }
+        }
+
         return validIndices to preFailures
     }
+
 
     // Resolves indices for STOP/PAUSE from the local follower cluster, marks invalid-state indices as failed.
     private suspend fun resolveStopPauseIndices(request: BulkReplicationRequest): Pair<List<String>, List<FailedIndex>> {
@@ -212,20 +245,21 @@ open class TransportBulkReplicationAction(
         return validIndices to preFailures
     }
 
-    // Resolves indices for RESUME: checks index exists and is paused, then verifies retention leases
-    // on leader to fail-fast indices whose replication history has been discarded.
+    // Resolves indices for RESUME: validates state is PAUSED, then checks retention leases concurrently.
     private suspend fun resolveResumeIndices(request: BulkReplicationRequest): Pair<List<String>, List<FailedIndex>> {
         val (validAfterStateCheck, preFailures) = resolveStopPauseIndices(request)
         if (validAfterStateCheck.isEmpty()) return validAfterStateCheck to preFailures
 
         val state = clusterService.state()
-        val finalFailures = preFailures.toMutableList()
-        val finalValid = mutableListOf<String>()
-        for (index in validAfterStateCheck) {
-            if (hasRetentionLease(index, state)) finalValid.add(index)
-            else finalFailures.add(FailedIndex(index, "Retention lease doesn't exist. Replication can't be resumed for $index"))
+        val finalFailures = java.util.concurrent.CopyOnWriteArrayList(preFailures)
+        val finalValid = java.util.concurrent.CopyOnWriteArrayList<String>()
+        coroutineScope {
+            validAfterStateCheck.map { index -> async {
+                if (hasRetentionLease(index, state)) finalValid.add(index)
+                else finalFailures.add(FailedIndex(index, "Retention lease doesn't exist. Replication can't be resumed for $index"))
+            }}.awaitAll()
         }
-        return finalValid to finalFailures
+        return finalValid.toList() to finalFailures.toList()
     }
 
     private fun resolveFollowerIndices(request: BulkReplicationRequest, state: ClusterState): List<String> {
@@ -256,6 +290,8 @@ open class TransportBulkReplicationAction(
             BulkOperationType.PAUSE -> when {
                 stateParams == null -> "No replication in progress for index:$index"
                 stateParams[REPLICATION_LAST_KNOWN_OVERALL_STATE] == ReplicationOverallState.PAUSED.name -> "Index $index is already paused"
+                stateParams[REPLICATION_LAST_KNOWN_OVERALL_STATE] != ReplicationOverallState.RUNNING.name ->
+                    "Cannot pause when in ${stateParams[REPLICATION_LAST_KNOWN_OVERALL_STATE]} state for index:$index"
                 else -> null
             }
             BulkOperationType.RESUME -> when {
@@ -317,7 +353,7 @@ open class TransportBulkReplicationAction(
      * runs the actual work in the background.
      *
      * The "running" flag is written through the cluster manager so only one bulk task
-     * can run at a time across the whole cluster — any concurrent attempt is rejected.
+     * can run at a time across the whole cluster , any concurrent attempt is rejected.
      *
      * If anything goes wrong after the flag is set, it is always cleared so the next
      * bulk request is not left permanently blocked.
@@ -402,14 +438,14 @@ open class TransportBulkReplicationAction(
     }
 
 
-    // Starts replication for a batch: 4 shared remote calls to leader (setup, cluster state, settings, metadata),
-    // local validation loops, then parallel metadata writes + task starts. Rollbacks metadata if task start fails.
+    // Starts replication for a batch: validates on leader, writes metadata, issues ONE multi-index restore,
+    // then starts persistent tasks in parallel. All cluster-state updates are batched.
     internal suspend fun executeBatchStart(
         indices: List<String>,
         request: BulkReplicationRequest
     ): Pair<List<String>, List<FailedIndex>> {
         if (indices.isEmpty()) return emptyList<String>() to emptyList()
-        log.debug("Processing batch of ${indices.size} indices for bulk_start")
+        log.info("Processing batch of ${indices.size} indices for bulk_start")
 
         val failures = CopyOnWriteArrayList<FailedIndex>()
         var remaining = indices.toMutableList()
@@ -491,78 +527,120 @@ open class TransportBulkReplicationAction(
         }.toMutableList()
         if (remaining.isEmpty()) return emptyList<String>() to failures.toList()
 
-        // Step 8: Remove stale tasks (all parallel)
-        coroutineScope {
-            remaining.map { index -> async {
-                try { StaleTaskUtils.removeAllTasksForIndex(clusterService, client, index) }
-                catch (e: Exception) { log.debug("Failed to clean stale tasks for index=$index: ${e.message}") }
-            }}.awaitAll()
-        }
+        removeStaleTasksParallel(remaining)
 
-        // Step 9: Write replication metadata (all parallel, with retries)
-        log.debug("Writing metadata for bulk_start for ${remaining.size} indices")
+
+        // Write replication metadata before restore.
+        log.info("Writing metadata for bulk_start for ${remaining.size} indices")
         val metadataWritten = CopyOnWriteArrayList<String>()
         var toAttempt = remaining.toList()
         for (attempt in 1..3) {
-            val failedThisAttempt = CopyOnWriteArrayList<FailedIndex>()
-            coroutineScope {
-                toAttempt.map { index -> async {
-                    try {
-                        replicationMetadataManager.addIndexReplicationMetadata(
-                            index, alias, index, ReplicationOverallState.RUNNING,
-                            user, followerRole, leaderRole, Settings.EMPTY
-                        )
-                        metadataWritten.add(index)
-                    } catch (e: Exception) {
-                        log.debug("Failed to write metadata for index=$index (attempt $attempt/3): ${e.message}")
-                        failedThisAttempt.add(FailedIndex(index, e.message ?: "Failed to write metadata"))
-                    }
-                }}.awaitAll()
+            val written = try {
+                replicationMetadataManager.addIndexReplicationMetadata(
+                    toAttempt, alias, ReplicationOverallState.RUNNING,
+                    user, followerRole, leaderRole, Settings.EMPTY
+                )
+            } catch (e: Exception) {
+                log.debug("Bulk metadata write failed for bulk_start (attempt $attempt/3): ${e.message}")
+                emptySet<String>()
             }
-            toAttempt = failedThisAttempt.map { it.index }
+            metadataWritten.addAll(written)
+            toAttempt = toAttempt.filter { it !in written }
             if (toAttempt.isEmpty()) break
             if (attempt < 3) kotlinx.coroutines.delay(2000)
-            else failedThisAttempt.forEach { failures.add(it) }
+            else toAttempt.forEach { failures.add(FailedIndex(it, "Failed to write metadata")) }
         }
+        if (metadataWritten.isEmpty()) return emptyList<String>() to failures.toList()
 
-        // Step 10: Start IndexReplicationTask (all parallel, with retries)
-        log.debug("Starting tasks for bulk_start for ${metadataWritten.size} indices")
-        val succeeded = CopyOnWriteArrayList<String>()
-        toAttempt = metadataWritten.toList()
-        for (attempt in 1..3) {
-            val failedThisAttempt = CopyOnWriteArrayList<FailedIndex>()
-            coroutineScope {
-                toAttempt.map { index -> async {
-                    try {
-                        val metadata = metadataMap[index]!!
-                        val params = IndexReplicationParams(alias, metadata.index, index)
-                        persistentTasksService.startTask(
-                            "replication:index:$index", IndexReplicationExecutor.TASK_NAME, params
-                        )
-                        succeeded.add(index)
-                    } catch (e: Exception) {
-                        log.debug("Failed to start task for index=$index (attempt $attempt/3): ${e.message}")
-                        failedThisAttempt.add(FailedIndex(index, e.message ?: "Failed to start task"))
+        // Issue ONE multi-index restore ,creates all follower indices in a single cluster-state publish.
+        log.info("Issuing bulk restore for ${metadataWritten.size} indices from leader=$alias")
+        val restored = CopyOnWriteArrayList<String>()
+        try {
+            val restoreRequest = client.admin().cluster()
+                .prepareRestoreSnapshot(RemoteClusterRepository.repoForCluster(alias), REMOTE_SNAPSHOT_NAME)
+                .setIndices(*metadataWritten.toTypedArray())
+                .request()
+            restoreRequest.aliasWriteIndexPolicy(RestoreSnapshotRequest.AliasWriteIndexPolicy.STRIP_WRITE_INDEX)
+            restoreRequest.clusterManagerNodeTimeout(TimeValue.timeValueSeconds(120))
+
+            val response = client.suspending(client.admin().cluster()::restoreSnapshot, defaultContext = true)(restoreRequest)
+            if (response.restoreInfo != null) {
+                // Synchronous restore completed (all shards done)
+                if (response.restoreInfo.failedShards() == 0) {
+                    restored.addAll(metadataWritten)
+                } else {
+                    // Some shards failed — check which indices succeeded
+                    metadataWritten.forEach { index ->
+                        if (clusterService.state().routingTable.hasIndex(index)) restored.add(index)
+                        else failures.add(FailedIndex(index, "Restore failed for index"))
                     }
-                }}.awaitAll()
-            }
-            toAttempt = failedThisAttempt.map { it.index }
-            if (toAttempt.isEmpty()) break
-            if (attempt < 3) kotlinx.coroutines.delay(2000)
-            else {
-                failedThisAttempt.forEach { fi ->
-                    failures.add(fi)
-                    try { replicationMetadataManager.deleteIndexReplicationMetadata(fi.index) } catch (_: Exception) {}
+                }
+            } else {
+                // Async restore — poll until all indices appear in routing table
+                log.info("Bulk restore initiated asynchronously, waiting for ${metadataWritten.size} indices to complete")
+                val restoreDeadline = System.currentTimeMillis() + 120_000
+                var pendingRestore = metadataWritten.toList()
+                while (pendingRestore.isNotEmpty() && System.currentTimeMillis() < restoreDeadline) {
+                    kotlinx.coroutines.delay(1000)
+                    val currentState = clusterService.state()
+                    val stillPending = mutableListOf<String>()
+                    for (index in pendingRestore) {
+                        if (currentState.routingTable.hasIndex(index)) {
+                            val restoreInProgress = currentState.custom<RestoreInProgress>(RestoreInProgress.TYPE, RestoreInProgress.EMPTY)
+                            val entry = restoreInProgress.firstOrNull { e ->
+                                e.snapshot().repository == RemoteClusterRepository.repoForCluster(alias) &&
+                                    e.indices().contains(index)
+                            }
+                            when {
+                                entry == null -> restored.add(index) // entry cleaned up = restore done
+                                entry.state() == RestoreInProgress.State.SUCCESS -> restored.add(index)
+                                entry.state() == RestoreInProgress.State.FAILURE -> {
+                                    failures.add(FailedIndex(index, "Restore failed for index"))
+                                }
+                                else -> stillPending.add(index) // still in progress
+                            }
+                        } else {
+                            stillPending.add(index)
+                        }
+                    }
+                    pendingRestore = stillPending
+                    if (pendingRestore.isNotEmpty() && restored.size % 10 == 0) {
+                        log.debug("Bulk restore: ${restored.size} done, ${pendingRestore.size} still pending")
+                    }
+                }
+                // Any remaining after timeout
+                for (index in pendingRestore) {
+                    if (clusterService.state().routingTable.hasIndex(index)) restored.add(index)
+                    else failures.add(FailedIndex(index, "Restore timed out for index"))
                 }
             }
+        } catch (e: Exception) {
+            log.error("Bulk restore failed for bulk_start: ${e.message}", e)
+            // Check which indices were actually restored despite the exception
+            val currentState = clusterService.state()
+            for (index in metadataWritten) {
+                if (currentState.routingTable.hasIndex(index)) restored.add(index)
+                else failures.add(FailedIndex(index, "Restore failed: ${e.message}"))
+            }
+        }
+        log.info("Bulk restore complete: ${restored.size} restored, ${metadataWritten.size - restored.size} failed")
+
+        if (restored.isEmpty()) return emptyList<String>() to failures.toList()
+
+        log.info("Starting tasks for bulk_start for ${restored.size} indices")
+        val succeeded = startTasksWithRetries(restored.toList(), alias, metadataMap, failures)
+        // Rollback metadata for indices that failed to start
+        val startedSet = succeeded.toSet()
+        failures.filter { it.index in restored && it.index !in startedSet }.forEach { fi ->
+            try { replicationMetadataManager.deleteIndexReplicationMetadata(fi.index) } catch (_: Exception) {}
         }
 
-        log.debug("Batch complete for bulk_start: ${succeeded.size} initiated, ${failures.size - (indices.size - remaining.size)} failed")
+        log.info("Batch complete for bulk_start: ${succeeded.size} initiated, ${failures.size - (indices.size - remaining.size)} failed")
 
         return succeeded.toList() to failures.toList()
     }
 
-    // Pauses a batch: checks metadata write block + restore state (local), then updates state to PAUSED in parallel.
+    // Pauses a batch: single bulk store write + batched cluster-state update.
     internal suspend fun executeBatchPause(
         indices: List<String>,
         reason: String = "bulk_pause"
@@ -599,37 +677,30 @@ open class TransportBulkReplicationAction(
         }
 
         log.info("executeBatchPause: updating state to PAUSED for ${remaining.size} indices")
+        // Single bulk store update + coalesced cluster-state publish.
         val succeeded = CopyOnWriteArrayList<String>()
         var toAttempt = remaining.toList()
 
         for (attempt in 1..3) {
-            val failedThisAttempt = CopyOnWriteArrayList<FailedIndex>()
-            coroutineScope {
-                toAttempt.map { index ->
-                    async {
-                        try {
-                            replicationMetadataManager.updateIndexReplicationState(index, ReplicationOverallState.PAUSED, reason)
-                            succeeded.add(index)
-                        } catch (e: Exception) {
-                            log.info("executeBatchPause: failed index=$index (attempt $attempt/3): ${e.javaClass.simpleName}: ${e.message}")
-                            failedThisAttempt.add(FailedIndex(index, e.message ?: "Failed to pause"))
-                        }
-                    }
-                }.awaitAll()
+            val paused = try {
+                replicationMetadataManager.updateIndexReplicationState(toAttempt, ReplicationOverallState.PAUSED, reason)
+            } catch (e: Exception) {
+                log.info("executeBatchPause: bulk pause failed (attempt $attempt/3): ${e.javaClass.simpleName}: ${e.message}")
+                emptySet<String>()
             }
-
-            toAttempt = failedThisAttempt.map { it.index }
+            succeeded.addAll(paused)
+            toAttempt = toAttempt.filter { it !in paused }
             if (toAttempt.isEmpty()) break
             if (attempt < 3) kotlinx.coroutines.delay(2000)
-            else failedThisAttempt.forEach { failures.add(it) }
+            else toAttempt.forEach { failures.add(FailedIndex(it, "Failed to pause")) }
         }
         log.info("executeBatchPause: DONE succeeded=${succeeded.size} failed=${failures.size} succeededIndices=$succeeded failedIndices=${failures.map { it.index + ':' + it.reason.take(60) }}")
 
         return succeeded.toList() to failures.toList()
     }
 
-    // Resumes a batch: 1 shared remote call per leader alias for metadata, parallel per-index retention lease checks
-    // (remote), then parallel state updates + task starts. Rollbacks state to PAUSED if task start fails.
+    // Resumes a batch: fetches metadata, removes stale tasks, flips state to RUNNING, starts tasks.
+    // All operations are batched. Rolls back to PAUSED if task start fails.
     internal suspend fun executeBatchResume(
         indices: List<String>
     ): Pair<List<String>, List<FailedIndex>> {
@@ -683,80 +754,78 @@ open class TransportBulkReplicationAction(
         val remaining = contexts.filter { metadataMap.containsKey(it.index) }
         if (remaining.isEmpty()) return emptyList<String>() to failures.toList()
 
-        log.debug("Checking retention leases for bulk_resume for ${remaining.size} indices")
-        val validAfterLease = CopyOnWriteArrayList<ResumeCtx>()
-        coroutineScope {
-            remaining.map { ctx ->
-                async {
-                    try {
-                        val metadata = metadataMap[ctx.index]!!
-                        val params = IndexReplicationParams(ctx.alias, metadata.index, ctx.index)
-                        if (hasRetentionLease(params)) {
-                            validAfterLease.add(ctx)
-                        } else {
-                            failures.add(FailedIndex(ctx.index, "Retention lease doesn't exist. Replication can't be resumed for ${ctx.index}"))
-                            log.debug("Retention lease expired for bulk_resume for index=${ctx.index}")
-                        }
-                    } catch (e: Exception) {
-                        log.debug("Lease check failed for bulk_resume for index=${ctx.index}, allowing resume attempt: ${e.message}")
-                        validAfterLease.add(ctx)
-                    }
-                }
-            }.awaitAll()
-        }
-        if (validAfterLease.isEmpty()) return emptyList<String>() to failures.toList()
+        // Retention lease already validated in resolveResumeIndices.
+        val validAfterLease = remaining
 
-        log.debug("Starting parallel writes for bulk_resume for ${validAfterLease.size} indices")
+        log.debug("Starting writes for bulk_resume for ${validAfterLease.size} indices")
+        val ctxByIndex = validAfterLease.associateBy { it.index }
         val succeeded = CopyOnWriteArrayList<String>()
-        var toAttempt = validAfterLease.toList()
 
+        removeStaleTasksParallel(validAfterLease.map { it.index })
+
+        // Flip state to RUNNING (single bulk store write, batched cluster-state update)
+        val stateUpdated = CopyOnWriteArrayList<String>()
+        var toAttempt = validAfterLease.map { it.index }
         for (attempt in 1..3) {
-            val failedThisAttempt = CopyOnWriteArrayList<Pair<ResumeCtx, String>>()
-            coroutineScope {
-                toAttempt.map { ctx ->
-                    async {
-                        try {
-                            StaleTaskUtils.removeAllTasksForIndex(clusterService, client, ctx.index)
-                            replicationMetadataManager.updateIndexReplicationState(ctx.index, ReplicationOverallState.RUNNING)
-
-                            try {
-                                val metadata = metadataMap[ctx.index]!!
-                                val params = IndexReplicationParams(ctx.alias, metadata.index, ctx.index)
-                                persistentTasksService.startTask(
-                                    "replication:index:${ctx.index}", IndexReplicationExecutor.TASK_NAME, params
-                                )
-                            } catch (e: Exception) {
-                                for (attempt in 1..3) {
-                                    try { replicationMetadataManager.updateIndexReplicationState(ctx.index, ReplicationOverallState.PAUSED, "rollback: task start failed"); break }
-                                    catch (re: Exception) { if (attempt < 3) kotlinx.coroutines.delay(1000) else log.error("Rollback failed for index=${ctx.index} after 3 attempts: ${re.message}") }
-                                }
-                                throw e
-                            }
-
-                            succeeded.add(ctx.index)
-                            log.debug("Successfully resumed replication for bulk_resume for index=${ctx.index}")
-                        } catch (e: Exception) {
-                            log.debug("Failed to resume for bulk_resume for index=${ctx.index} (attempt $attempt/3): ${e.message}")
-                            failedThisAttempt.add(ctx to (e.message ?: "unknown error"))
-                        }
-                    }
-                }.awaitAll()
+            val written = try {
+                replicationMetadataManager.updateIndexReplicationState(toAttempt, ReplicationOverallState.RUNNING)
+            } catch (e: Exception) {
+                log.debug("Bulk state update to RUNNING failed for bulk_resume (attempt $attempt/3): ${e.message}")
+                emptySet<String>()
             }
-
-            toAttempt = failedThisAttempt.map { it.first }
+            stateUpdated.addAll(written)
+            toAttempt = toAttempt.filter { it !in written }
             if (toAttempt.isEmpty()) break
             if (attempt < 3) kotlinx.coroutines.delay(2000)
-            else failedThisAttempt.forEach { (ctx, reason) -> failures.add(FailedIndex(ctx.index, reason)) }
+            else toAttempt.forEach { failures.add(FailedIndex(it, "Failed to update replication state to RUNNING")) }
+        }
+
+        // Start tasks (parallel, batched). Rollback to PAUSED on final failure.
+        var startAttempt = stateUpdated.toList()
+        for (attempt in 1..3) {
+            val failedThisAttempt = CopyOnWriteArrayList<String>()
+            coroutineScope {
+                startAttempt.map { index -> async {
+                    try {
+                        val ctx = ctxByIndex[index]!!
+                        val metadata = metadataMap[index]!!
+                        val params = IndexReplicationParams(ctx.alias, metadata.index, index)
+                        persistentTasksService.startTask(
+                            "replication:index:$index", IndexReplicationExecutor.TASK_NAME, params
+                        )
+                        succeeded.add(index)
+                    } catch (e: Exception) {
+                        log.debug("Failed to start task for bulk_resume for index=$index (attempt $attempt/3): ${e.message}")
+                        failedThisAttempt.add(index)
+                    }
+                }}.awaitAll()
+            }
+            startAttempt = failedThisAttempt.toList()
+            if (startAttempt.isEmpty()) break
+            if (attempt < 3) kotlinx.coroutines.delay(2000)
+            else {
+                try {
+                    replicationMetadataManager.updateIndexReplicationState(startAttempt, ReplicationOverallState.PAUSED, "rollback: task start failed")
+                } catch (e: Exception) {
+                    log.error("Rollback to PAUSED failed for bulk_resume indices=$startAttempt: ${e.message}")
+                }
+                startAttempt.forEach { failures.add(FailedIndex(it, "Failed to start task")) }
+            }
         }
         log.debug("Batch complete for bulk_resume: ${succeeded.size} resumed, ${failures.size} failed")
 
         return succeeded.toList() to failures.toList()
     }
 
-    // Stops replication for a batch: checks metadata write block (local), then sequential phases
-    // each parallel across all indices — remove block, close, remove retention lease, batched
-    // cluster state update (routes to cluster-manager, single update for all indices), reopen,
-    // remove stale tasks, delete metadata.
+    /**
+     * Stops replication for a batch in sequential phases, each batched:
+     * 1. Remove blocks + null settings (one cluster-state publish)
+     * 2. Close indices (one request)
+     * 3. Remove retention leases (fire-and-forget)
+     * 4. Reopen indices (one request)
+     * 5. Remove persistent tasks (parallel, batched)
+     * 6. Delete metadata (one bulk store call, batched cluster-state update)
+     */
     internal suspend fun executeBatchStop(
         indices: List<String>
     ): Pair<List<String>, List<FailedIndex>> {
@@ -769,33 +838,7 @@ open class TransportBulkReplicationAction(
         val failures = CopyOnWriteArrayList<FailedIndex>()
         val failedSet = ConcurrentHashMap.newKeySet<String>()
 
-        coroutineScope { indices.map { index -> async {
-            try { client.suspendExecute(UpdateIndexBlockAction.INSTANCE,
-                UpdateIndexBlockRequest(index, IndexBlockUpdateType.REMOVE_BLOCK), injectSecurityContext = true)
-            } catch (e: Exception) { log.debug("Failed to remove block for index=$index: ${e.message}") }
-        }}.awaitAll() }
-
-        val restoringIndices = clusterService.state()
-            .custom<RestoreInProgress>(RestoreInProgress.TYPE, RestoreInProgress.EMPTY)
-            .flatMap { it.indices() }.toSet()
-        val closeable = indices.filter { it !in restoringIndices && clusterService.state().routingTable.hasIndex(it) }
-        coroutineScope { closeable.map { index -> async {
-            try { client.suspendExecute(UpdateMetadataAction.INSTANCE,
-                UpdateMetadataRequest(index, UpdateMetadataRequest.Type.CLOSE, Requests.closeIndexRequest(index)),
-                injectSecurityContext = true)
-            } catch (e: Exception) { log.debug("Failed to close index=$index: ${e.message}") }
-        }}.awaitAll() }
-
-        coroutineScope { indices.map { index -> async {
-            try {
-                val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(index)
-                val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
-                RemoteClusterRetentionLeaseHelper(
-                    clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient
-                ).attemptRemoveRetentionLease(clusterService, replMetadata, index)
-            } catch (e: Exception) { log.debug("Failed to remove retention lease for index=$index: ${e.message}") }
-        }}.awaitAll() }
-
+        // Remove replication block + null REPLICATED_INDEX_SETTING for all indices in one cluster-state publish.
         try {
             val res = client.suspendExecute(BatchStopClusterStateAction.INSTANCE,
                 BulkStopClusterManagerRequest(indices), injectSecurityContext = true)
@@ -806,44 +849,95 @@ open class TransportBulkReplicationAction(
         }
 
         val stopped = indices.filter { it !in failedSet }
+        if (stopped.isEmpty()) return succeeded.toList() to failures.toList()
 
-        // Reopen ALL closed indices — even if batch update failed, don't leave them closed
+        // Close follower indices (single multi-index request).
+        val restoringIndices = clusterService.state()
+            .custom<RestoreInProgress>(RestoreInProgress.TYPE, RestoreInProgress.EMPTY)
+            .flatMap { it.indices() }.toSet()
+        val closeable = stopped.filter { it !in restoringIndices && clusterService.state().routingTable.hasIndex(it) }
+        if (closeable.isNotEmpty()) {
+            try {
+                client.suspending(client.admin().indices()::close, injectSecurityContext = true)(
+                    CloseIndexRequest(*closeable.toTypedArray()))
+            } catch (e: Exception) { log.debug("Failed to close indices=$closeable: ${e.message}") }
+        }
+    
+        // Not awaited — leases are on leader, reopen is on follower. They expire in 12h anyway.
+        // Uses class-level scope (GlobalScope) to avoid ad-hoc scope leaks on node shutdown.
+        launch(threadPool.coroutineContext(ThreadPool.Names.GENERIC)) {
+            stopped.map { index -> async {
+                try {
+                    val replMetadata = replicationMetadataManager.getIndexReplicationMetadata(index)
+                    val remoteClient = client.getRemoteClusterClient(replMetadata.connectionName)
+                    RemoteClusterRetentionLeaseHelper(
+                        clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient
+                    ).attemptRemoveRetentionLease(clusterService, replMetadata, index)
+                } catch (e: Exception) { log.debug("Failed to remove retention lease for index=$index: ${e.message}") }
+            }}.awaitAll()
+        }
+
+        // Reopen indices as normal (single multi-index request).
         val reopenable = closeable.filter { clusterService.state().routingTable.hasIndex(it) }
-        coroutineScope { reopenable.map { index -> async {
-            try { client.suspending(client.admin().indices()::open, injectSecurityContext = true)(OpenIndexRequest(index))
-            } catch (e: Exception) { log.debug("Failed to reopen index=$index: ${e.message}") }
-        }}.awaitAll() }
+        if (reopenable.isNotEmpty()) {
+            try {
+                client.suspending(client.admin().indices()::open, injectSecurityContext = true)(
+                    OpenIndexRequest(*reopenable.toTypedArray()))
+            } catch (e: Exception) { log.debug("Failed to reopen indices=$reopenable: ${e.message}") }
+        }
 
-        coroutineScope { stopped.map { index -> async {
-            try { StaleTaskUtils.removeAllTasksForIndex(clusterService, client, index)
-            } catch (e: Exception) { log.debug("Failed to remove stale tasks for index=$index: ${e.message}") }
-        }}.awaitAll() }
+        removeStaleTasksParallel(stopped)
 
-        coroutineScope { stopped.map { index -> async {
-            try { replicationMetadataManager.deleteIndexReplicationMetadata(index)
-            } catch (e: Exception) { log.debug("Failed to delete metadata for index=$index: ${e.message}") }
-        }}.awaitAll() }
+        // Delete replication metadata (single bulk store call, batched cluster-state update).
+        try { replicationMetadataManager.deleteIndexReplicationMetadata(stopped) }
+        catch (e: Exception) { log.debug("Failed to delete metadata for indices=$stopped: ${e.message}") }
 
         return succeeded.toList() to failures.toList()
     }
 
-    private suspend fun hasRetentionLease(params: IndexReplicationParams): Boolean {
-        return try {
-            val remoteClient = client.getRemoteClusterClient(params.leaderAlias)
-            val shards = clusterService.state().routingTable.indicesRouting().get(params.followerIndexName)?.shards()
-                ?: return true
-            val retentionLeaseHelper = RemoteClusterRetentionLeaseHelper(
-                clusterService.clusterName.value(), clusterService.state().metadata.clusterUUID(), remoteClient
-            )
-            shards.entries.all { entry ->
-                val followerShardId = entry.value.shardId
-                retentionLeaseHelper.verifyRetentionLeaseExist(
-                    ShardId(params.leaderIndex, followerShardId.id), followerShardId
-                )
-            }
-        } catch (e: Exception) {
-            log.warn("Failed to verify retention lease for ${params.followerIndexName}: ${e.message}")
-            true
+
+    // --- Shared helpers ---
+
+    private suspend fun removeStaleTasksParallel(indices: List<String>) {
+        coroutineScope {
+            indices.map { index -> async {
+                try { StaleTaskUtils.removeAllTasksForIndex(clusterService, client, index) }
+                catch (e: Exception) { log.debug("Failed to clean stale tasks for index=$index: ${e.message}") }
+            }}.awaitAll()
         }
     }
+
+    private suspend fun startTasksWithRetries(
+        indices: List<String>,
+        alias: String,
+        metadataMap: Map<String, IndexMetadata>,
+        failures: CopyOnWriteArrayList<FailedIndex>
+    ): List<String> {
+        val succeeded = CopyOnWriteArrayList<String>()
+        var toAttempt = indices.toList()
+        for (attempt in 1..3) {
+            val failedThisAttempt = CopyOnWriteArrayList<FailedIndex>()
+            coroutineScope {
+                toAttempt.map { index -> async {
+                    try {
+                        val metadata = metadataMap[index]!!
+                        val params = IndexReplicationParams(alias, metadata.index, index)
+                        persistentTasksService.startTask(
+                            "replication:index:$index", IndexReplicationExecutor.TASK_NAME, params
+                        )
+                        succeeded.add(index)
+                    } catch (e: Exception) {
+                        log.debug("Failed to start task for index=$index (attempt $attempt/3): ${e.message}")
+                        failedThisAttempt.add(FailedIndex(index, e.message ?: "Failed to start task"))
+                    }
+                }}.awaitAll()
+            }
+            toAttempt = failedThisAttempt.map { it.index }
+            if (toAttempt.isEmpty()) break
+            if (attempt < 3) kotlinx.coroutines.delay(2000)
+            else failedThisAttempt.forEach { failures.add(it) }
+        }
+        return succeeded.toList()
+    }
+
 }

--- a/src/main/kotlin/org/opensearch/replication/action/bulk/UpdateBulkTaskStateAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/bulk/UpdateBulkTaskStateAction.kt
@@ -11,7 +11,8 @@
 
 package org.opensearch.replication.action.bulk
 
-import org.opensearch.ResourceAlreadyExistsException
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.core.rest.RestStatus
 import org.opensearch.action.ActionType
 import org.opensearch.action.support.ActionFilters
 import org.opensearch.action.support.clustermanager.AcknowledgedRequest
@@ -80,14 +81,14 @@ class TransportUpdateBulkTaskStateAction @Inject constructor(
             object : AckedClusterStateUpdateTask<AcknowledgedResponse>(request, listener) {
                 override fun execute(currentState: ClusterState): ClusterState {
                     // Guard against concurrent bulk task submissions. Only checked on the initial
-                    // claim where taskId is empty. Progress updates from the running task carry the
+                    // claim (taskId is empty). Progress updates from the running task carry the
                     // real taskId and bypass this check.
                     if (request.taskState != null && request.taskState.taskId.isEmpty()) {
                         val existing = currentState.metadata
                             .custom<BulkReplicationTaskMetadata>(BulkReplicationTaskMetadata.NAME)?.taskState
-                        if (existing != null && existing.numPending > 0 && existing.taskId.isEmpty()) {
-                            throw ResourceAlreadyExistsException(
-                                "A bulk replication task is already running. Only one bulk task is allowed at a time.")
+                        if (existing != null && existing.numPending > 0) {
+                            throw OpenSearchStatusException(
+                                "A bulk replication task is already running. Only one bulk task is allowed at a time.", RestStatus.CONFLICT)
                         }
                     }
                     val newMetadata = Metadata.builder(currentState.metadata)

--- a/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/ReplicationMetadataManager.kt
@@ -19,6 +19,10 @@ import org.opensearch.replication.metadata.store.*
 import org.opensearch.replication.repository.RemoteClusterRepository
 import org.opensearch.replication.util.overrideFgacRole
 import org.opensearch.replication.util.suspendExecute
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import java.util.concurrent.CopyOnWriteArrayList
 import org.opensearch.commons.authuser.User
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -59,6 +63,37 @@ open class ReplicationMetadataManager constructor(private val clusterService: Cl
         updateReplicationState(followerIndex, overallState, connectionName)
     }
 
+    /**
+     * Adds index replication metadata for multiple follower indices in as few round-trips as possible:
+     * one bulk write to the replication metadata store, followed by per-index replication-state updates
+     * (which are coalesced into a single cluster-state publish by UpdateReplicationStateDetailsTaskExecutor).
+     * Used by the bulk Start API. Assumes follower index name == leader index name (as resolved by bulk start).
+     * Returns the set of follower indices for which BOTH the doc write and the state update succeeded.
+     */
+    suspend fun addIndexReplicationMetadata(followerIndices: List<String>,
+                                            connectionName: String,
+                                            overallState: ReplicationOverallState,
+                                            user: User?,
+                                            follower_cluster_role: String?,
+                                            leader_cluster_role: String?,
+                                            settings: Settings): Set<String> {
+        if (followerIndices.isEmpty()) return emptySet()
+
+        val addReqs = followerIndices.map { index ->
+            AddReplicationMetadataRequest(
+                ReplicationMetadata(connectionName,
+                    ReplicationStoreMetadataType.INDEX.name, overallState.name, CUSTOMER_INITIATED_ACTION,
+                    ReplicationContext(index, user?.overrideFgacRole(follower_cluster_role)),
+                    ReplicationContext(index, user?.overrideFgacRole(leader_cluster_role)), settings))
+        }
+
+        val written = executeAndWrapExceptionIfAny({
+            replicaionMetadataStore.addMetadata(addReqs)
+        }, log, "Error adding replication metadata") as Set<String>
+
+        return updateReplicationStateConcurrently(written, overallState, connectionName)
+    }
+
     suspend fun addAutofollowMetadata(patternName: String, connectionName: String, pattern: String,
                                       overallState: ReplicationOverallState, user: User?,
                                       follower_cluster_role: String?, leader_cluster_role: String?, settings: Settings,
@@ -91,6 +126,40 @@ open class ReplicationMetadataManager constructor(private val clusterService: Cl
         updatedMetadata.reason = reason
         updateMetadata(UpdateReplicationMetadataRequest(updatedMetadata, getRes.seqNo, getRes.primaryTerm))
         updateReplicationState(followerIndex, overallState)
+    }
+
+    /**
+     * Updates the overall replication state for multiple follower indices in as few round-trips as possible:
+     * one MultiGet (for current docs + versions), one bulk update to the store (optimistic-locked), followed by
+     * per-index replication-state updates (coalesced into a single cluster-state publish by the state executor).
+     * Used by the bulk Pause/Resume APIs. Returns the set of indices updated successfully end-to-end.
+     */
+    suspend fun updateIndexReplicationState(followerIndices: List<String>,
+                                            overallState: ReplicationOverallState,
+                                            reason: String = CUSTOMER_INITIATED_ACTION): Set<String> {
+        if (followerIndices.isEmpty()) return emptySet()
+
+        @Suppress("UNCHECKED_CAST")
+        val current = executeAndWrapExceptionIfAny({
+            replicaionMetadataStore.getMetadataWithVersion(ReplicationStoreMetadataType.INDEX.name, followerIndices)
+        }, log, "Failed to fetch replication metadata") as Map<String, GetReplicationMetadataResponse>
+
+        val updateReqs = ArrayList<UpdateReplicationMetadataRequest>()
+        for (index in followerIndices) {
+            val getRes = current[index] ?: continue
+            val updatedMetadata = getRes.replicationMetadata
+            updatedMetadata.overallState = overallState.name
+            updatedMetadata.reason = reason
+            updateReqs.add(UpdateReplicationMetadataRequest(updatedMetadata, getRes.seqNo, getRes.primaryTerm))
+        }
+        if (updateReqs.isEmpty()) return emptySet()
+
+        @Suppress("UNCHECKED_CAST")
+        val written = executeAndWrapExceptionIfAny({
+            replicaionMetadataStore.updateMetadata(updateReqs)
+        }, log, "Error updating replication metadata") as Set<String>
+
+        return updateReplicationStateConcurrently(written, overallState)
     }
 
     suspend fun updateAutofollowMetadata(patternName: String,
@@ -137,9 +206,7 @@ open class ReplicationMetadataManager constructor(private val clusterService: Cl
      */
     suspend fun deleteIndexReplicationMetadata(followerIndices: List<String>): Set<String> {
         val deleted = replicaionMetadataStore.deleteMetadata(ReplicationStoreMetadataType.INDEX.name, followerIndices)
-        for (index in deleted) {
-            try { updateReplicationState(index, ReplicationOverallState.STOPPED) } catch (_: Exception) {}
-        }
+        updateReplicationStateConcurrently(deleted, ReplicationOverallState.STOPPED)
         return deleted
     }
 
@@ -200,6 +267,31 @@ open class ReplicationMetadataManager constructor(private val clusterService: Cl
         return executeAndWrapExceptionIfAny({
             replicaionMetadataStore.getMetadata(getReq, fetch_from_primary).replicationMetadata
         }, log, "Failed to fetch replication metadata") as ReplicationMetadata
+    }
+
+    /**
+     * Submits per-index replication-state updates concurrently so they are coalesced
+     * into a single cluster-state publish by UpdateReplicationStateDetailsTaskExecutor.
+     * Used by bulk APIs only. Returns the set of indices that succeeded.
+     */
+    private suspend fun updateReplicationStateConcurrently(
+        indices: Collection<String>,
+        overallState: ReplicationOverallState,
+        connectionName: String? = null
+    ): Set<String> {
+        if (indices.isEmpty()) return emptySet()
+        val succeeded = CopyOnWriteArrayList<String>()
+        coroutineScope {
+            indices.map { index -> async {
+                try {
+                    updateReplicationState(index, overallState, connectionName)
+                    succeeded.add(index)
+                } catch (e: Exception) {
+                    log.error("Failed to update replication state for $index: ${e.message}")
+                }
+            }}.awaitAll()
+        }
+        return succeeded.toSet()
     }
 
     private suspend fun updateReplicationState(indexName: String, overallState: ReplicationOverallState, connectionName: String? = null) {

--- a/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTaskExecutor.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/UpdateIndexBlockTaskExecutor.kt
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.metadata
+
+import org.opensearch.replication.action.index.block.IndexBlockUpdateType
+import org.opensearch.replication.action.index.block.UpdateIndexBlockRequest
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.apache.logging.log4j.LogManager
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.ClusterStateTaskConfig
+import org.opensearch.cluster.ClusterStateTaskExecutor
+import org.opensearch.cluster.ClusterStateTaskListener
+import org.opensearch.cluster.block.ClusterBlocks
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.Priority
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Batched executor for index block add/remove operations. Multiple concurrent UpdateIndexBlockRequest
+ * submissions (with the same source string) are coalesced into a single cluster-state publish,
+ * reducing N publishes to ~1 when fired concurrently (e.g., from bulk start/stop flows).
+ *
+ * The existing single-index flow (TransportUpddateIndexBlockAction + UpdateIndexBlockTask) is NOT
+ * modified. This executor is used exclusively by the bulk API via [submitBatch].
+ */
+class UpdateIndexBlockTaskExecutor private constructor()
+    : ClusterStateTaskExecutor<UpdateIndexBlockRequest> {
+
+    companion object {
+        private val log = LogManager.getLogger(UpdateIndexBlockTaskExecutor::class.java)
+        val INSTANCE = UpdateIndexBlockTaskExecutor()
+
+        /**
+         * Submits index block updates for multiple indices concurrently. All submissions hit the
+         * same batched executor with the same source string, so the cluster-service coalesces them
+         * into ~1 cluster-state publish. Each coroutine suspends until its request is processed.
+         *
+         * @return set of index names that were successfully updated
+         */
+        /**
+         * Fires all index block updates concurrently — same executor + same source string means
+         * TaskBatcher coalesces them into ~1 cluster-state publish. Block add/remove is idempotent
+         * so execute() always succeeds all tasks.
+         */
+        suspend fun submitBatch(
+            clusterService: ClusterService,
+            indices: List<String>,
+            updateType: IndexBlockUpdateType
+        ): Set<String> {
+            if (indices.isEmpty()) return emptySet()
+
+            val succeeded = java.util.concurrent.CopyOnWriteArrayList<String>()
+            coroutineScope {
+                indices.map { index ->
+                    async {
+                        try {
+                            val request = UpdateIndexBlockRequest(index, updateType)
+                            submitOne(clusterService, request)
+                            succeeded.add(index)
+                        } catch (e: Exception) {
+                            log.debug("Failed to update index block for index=$index (${updateType}): ${e.message}")
+                        }
+                    }
+                }.map { it.await() }
+            }
+            return succeeded.toSet()
+        }
+
+        private suspend fun submitOne(clusterService: ClusterService, request: UpdateIndexBlockRequest) {
+            suspendCancellableCoroutine<ClusterState> { continuation ->
+                clusterService.submitStateUpdateTask(
+                    "update-index-block",
+                    request,
+                    ClusterStateTaskConfig.build(Priority.NORMAL),
+                    INSTANCE as ClusterStateTaskExecutor<UpdateIndexBlockRequest>,
+                    object : ClusterStateTaskListener {
+                        override fun onFailure(source: String, e: java.lang.Exception) {
+                            continuation.resumeWithException(e)
+                        }
+
+                        override fun clusterStateProcessed(source: String?, oldState: ClusterState?, newState: ClusterState) {
+                            continuation.resume(newState)
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    override fun execute(currentState: ClusterState, tasks: List<UpdateIndexBlockRequest>)
+            : ClusterStateTaskExecutor.ClusterTasksResult<UpdateIndexBlockRequest> {
+        log.debug("Executing batched index block update for ${tasks.size} requests")
+
+        val blocksBuilder = ClusterBlocks.builder().blocks(currentState.blocks)
+        var changed = false
+
+        for (request in tasks) {
+            when (request.updateType) {
+                IndexBlockUpdateType.ADD_BLOCK -> {
+                    if (!currentState.blocks.hasIndexBlock(request.indexName, INDEX_REPLICATION_BLOCK)) {
+                        blocksBuilder.addIndexBlock(request.indexName, INDEX_REPLICATION_BLOCK)
+                        changed = true
+                    }
+                }
+                IndexBlockUpdateType.REMOVE_BLOCK -> {
+                    if (currentState.blocks.hasIndexBlock(request.indexName, INDEX_REPLICATION_BLOCK)) {
+                        blocksBuilder.removeIndexBlock(request.indexName, INDEX_REPLICATION_BLOCK)
+                        changed = true
+                    }
+                }
+            }
+        }
+
+        val newState = if (changed) {
+            ClusterState.Builder(currentState).blocks(blocksBuilder).build()
+        } else {
+            currentState
+        }
+
+        return ClusterStateTaskExecutor.ClusterTasksResult.builder<UpdateIndexBlockRequest>()
+            .successes(tasks).build(newState)
+    }
+}

--- a/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadataStore.kt
+++ b/src/main/kotlin/org/opensearch/replication/metadata/store/ReplicationMetadataStore.kt
@@ -28,6 +28,7 @@ import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.delete.DeleteResponse
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.MultiGetRequest
+import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.transport.client.Client
 import org.opensearch.cluster.health.ClusterHealthStatus
@@ -111,6 +112,46 @@ class ReplicationMetadataStore constructor(val client: Client, val clusterServic
         val indexReqBuilder = client.prepareIndex(REPLICATION_CONFIG_SYSTEM_INDEX).setId(id)
                 .setSource(addReq.replicationMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
         return client.suspending(indexReqBuilder::execute, defaultContext = true)("replication")
+    }
+
+    /**
+     * Adds replication metadata for multiple entries in ONE call using the Bulk API.
+     * Returns the set of follower resource names (index names) that were written successfully.
+     */
+    suspend fun addMetadata(addReqs: List<AddReplicationMetadataRequest>): Set<String> {
+        if (addReqs.isEmpty()) return emptySet()
+        if (!configStoreExists()) {
+            try {
+                createIndex()
+            } catch (ex: Exception) {
+                if (ExceptionsHelper.unwrapCause(ex) !is ResourceAlreadyExistsException) {
+                    throw ex
+                }
+            }
+        }
+
+        checkAndWaitForStoreHealth()
+        checkAndUpdateMapping()
+
+        val bulkReq = BulkRequest()
+        val resourceNames = ArrayList<String>(addReqs.size)
+        for (addReq in addReqs) {
+            val md = addReq.replicationMetadata
+            val id = getId(md.metadataType, md.connectionName, md.followerContext.resource)
+            resourceNames.add(md.followerContext.resource)
+            bulkReq.add(
+                IndexRequest(REPLICATION_CONFIG_SYSTEM_INDEX).id(id)
+                    .source(md.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
+            )
+        }
+
+        val bulkRes = client.suspending(client::bulk, defaultContext = true)(bulkReq)
+        val succeeded = mutableSetOf<String>()
+        for ((i, item) in bulkRes.items.withIndex()) {
+            if (!item.isFailed) succeeded.add(resourceNames[i])
+            else log.error("Bulk add of replication metadata failed for ${resourceNames[i]}: ${item.failureMessage}")
+        }
+        return succeeded
     }
 
     private suspend fun checkAndUpdateMapping() {
@@ -294,6 +335,71 @@ class ReplicationMetadataStore constructor(val client: Client, val clusterServic
                 .setIfSeqNo(updateMetadataReq.ifSeqno)
                 .setIfPrimaryTerm(updateMetadataReq.ifPrimaryTerm)
         return client.suspending(indexReqBuilder::execute, defaultContext = true)("replication")
+    }
+
+    /**
+     * Updates replication metadata for multiple entries in ONE call using the Bulk API, preserving
+     * per-doc optimistic concurrency (if_seq_no / if_primary_term). Returns the set of follower
+     * resource names (index names) that were updated successfully.
+     */
+    suspend fun updateMetadata(updateReqs: List<UpdateReplicationMetadataRequest>): Set<String> {
+        if (updateReqs.isEmpty()) return emptySet()
+        if (!configStoreExists()) return emptySet()
+
+        checkAndWaitForStoreHealth()
+        checkAndUpdateMapping()
+
+        val bulkReq = BulkRequest()
+        val resourceNames = ArrayList<String>(updateReqs.size)
+        for (req in updateReqs) {
+            val md = req.replicationMetadata
+            val id = getId(md.metadataType, md.connectionName, md.followerContext.resource)
+            resourceNames.add(md.followerContext.resource)
+            bulkReq.add(
+                IndexRequest(REPLICATION_CONFIG_SYSTEM_INDEX).id(id)
+                    .source(md.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
+                    .setIfSeqNo(req.ifSeqno)
+                    .setIfPrimaryTerm(req.ifPrimaryTerm)
+            )
+        }
+
+        val bulkRes = client.suspending(client::bulk, defaultContext = true)(bulkReq)
+        val succeeded = mutableSetOf<String>()
+        for ((i, item) in bulkRes.items.withIndex()) {
+            if (!item.isFailed) succeeded.add(resourceNames[i])
+            else log.error("Bulk update of replication metadata failed for ${resourceNames[i]}: ${item.failureMessage}")
+        }
+        return succeeded
+    }
+
+    /**
+     * Fetches replication metadata for multiple indices in ONE MultiGet call, preserving seqNo and
+     * primaryTerm per doc (needed for optimistic-concurrency updates). Missing indices are omitted.
+     */
+    suspend fun getMetadataWithVersion(metadataType: String, indices: List<String>): Map<String, GetReplicationMetadataResponse> {
+        if (indices.isEmpty()) return emptyMap()
+        if (!configStoreExists()) return emptyMap()
+
+        checkAndWaitForStoreHealth()
+
+        val multiGetReq = MultiGetRequest().realtime(true)
+        for (index in indices) {
+            val id = getId(metadataType, null, index)
+            multiGetReq.add(MultiGetRequest.Item(REPLICATION_CONFIG_SYSTEM_INDEX, id))
+        }
+
+        val multiGetRes = client.suspending(client::multiGet, defaultContext = true)(multiGetReq)
+        val result = mutableMapOf<String, GetReplicationMetadataResponse>()
+        for ((i, response) in multiGetRes.responses.withIndex()) {
+            if (response.isFailed || response.response?.sourceAsBytesRef == null) continue
+            val parser = XContentHelper.createParser(
+                namedXContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                response.response.sourceAsBytesRef, XContentType.JSON
+            )
+            result[indices[i]] = GetReplicationMetadataResponse(
+                ReplicationMetadata.fromXContent(parser), response.response.seqNo, response.response.primaryTerm)
+        }
+        return result
     }
 
     private fun getId(metadataType: String, connectionName: String?, resourceName: String): String {

--- a/src/main/kotlin/org/opensearch/replication/task/bulk/BulkReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/bulk/BulkReplicationTask.kt
@@ -129,7 +129,7 @@ class BulkReplicationTask(
             } finally {
                 pendingCount.set(0)
                 for (attempt in 1..3) {
-                    try { updateClusterState(); break } catch (_: Exception) {
+                    try { updateClusterState(force = true); break } catch (_: Exception) {
                         if (attempt < 3) kotlinx.coroutines.delay(1000)
                     }
                 }
@@ -161,17 +161,11 @@ class BulkReplicationTask(
             batchFailures.addAll(failures)
             pendingCount.addAndGet(-failures.size)
             updateClusterState()
-            // Wait up to 60s for batch indices to leave INIT state before next batch
+            // Brief pause between batches to avoid overwhelming the cluster manager.
+            // The bulk restore (done in executeBatchStart) means tasks skip INIT→RESTORING entirely
+            // and go straight to InitFollowState, so there's no need to wait for restores.
             if (started.isNotEmpty() && indices.size > bulkBatchSize) {
-                val batchDeadline = System.currentTimeMillis() + 60_000
-                var pending = started.toList()
-                while (pending.isNotEmpty() && System.currentTimeMillis() < batchDeadline && !isCancelled) {
-                    kotlinx.coroutines.delay(2000)
-                    pending = pending.filter { index ->
-                        val state = getIndexTaskState(index)
-                        state == null || state.state == ReplicationState.INIT
-                    }
-                }
+                kotlinx.coroutines.delay(2000)
             }
         }
 
@@ -299,7 +293,13 @@ class BulkReplicationTask(
             } catch (_: Exception) { "Replication task failed" }
     }
 
-    private suspend fun updateClusterState() {
+    private val lastClusterStateUpdate = java.util.concurrent.atomic.AtomicLong(0)
+    private val UPDATE_CLUSTER_STATE_INTERVAL_MS = 5000L
+
+    private suspend fun updateClusterState(force: Boolean = false) {
+        val now = System.currentTimeMillis()
+        if (!force && now - lastClusterStateUpdate.get() < UPDATE_CLUSTER_STATE_INTERVAL_MS) return
+        lastClusterStateUpdate.set(now)
         try {
             client.suspendExecute(UpdateBulkTaskStateAction.INSTANCE, UpdateBulkTaskStateRequest(
                 BulkTaskState(bulkTaskId, operationType.label, request.pattern, startTime,

--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationTask.kt
@@ -20,6 +20,7 @@ import org.opensearch.replication.action.pause.PauseIndexReplicationAction
 import org.opensearch.replication.action.pause.PauseIndexReplicationRequest
 import org.opensearch.replication.metadata.ReplicationMetadataManager
 import org.opensearch.replication.metadata.ReplicationOverallState
+import org.opensearch.replication.metadata.UpdateIndexBlockTaskExecutor
 import org.opensearch.replication.metadata.UpdateMetadataAction
 import org.opensearch.replication.metadata.UpdateMetadataRequest
 import org.opensearch.replication.metadata.state.REPLICATION_LAST_KNOWN_OVERALL_STATE
@@ -165,6 +166,15 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
         const val SLEEP_TIME_BETWEEN_POLL_MS = 5000L
         const val AUTOPAUSED_REASON_PREFIX = "AutoPaused: "
         const val TASK_CANCELLATION_REASON = AUTOPAUSED_REASON_PREFIX + "Index replication task was cancelled by user"
+
+        // If a bulk task is running, use the batched executor for index block updates.
+        // Checks live cluster state instead of a static flag to avoid race conditions.
+        fun isBulkTaskActive(clusterService: org.opensearch.cluster.service.ClusterService): Boolean {
+            val metadata = clusterService.state().metadata
+                .custom<org.opensearch.replication.metadata.state.BulkReplicationTaskMetadata>(
+                    org.opensearch.replication.metadata.state.BulkReplicationTaskMetadata.NAME)
+            return metadata?.taskState != null && metadata.taskState.numPending > 0
+        }
 
         /**
          * Determines whether a given setting key should be skipped during metadata sync
@@ -331,7 +341,7 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
                     val exception: OpenSearchException? = taskState.exception
                     msg += "[${shard} - ${exception?.javaClass?.name} - \"${exception?.message}\"], "
                 } else {
-                    msg += "[${shard} - \"Shard task killed or cancelled.\"], "
+                    msg += "[${shard} - \"Shard task killed or cancelled.\"], " 
                 }
             }
             return FailedState(failedShardTasks, msg)
@@ -863,8 +873,22 @@ open class IndexReplicationTask(id: Long, type: String, action: String, descript
 
     private suspend fun addIndexBlockForReplication() {
         log.info("Adding index block for replication")
-        val request = UpdateIndexBlockRequest(followerIndexName, IndexBlockUpdateType.ADD_BLOCK)
-        client.suspendExecute(replicationMetadata, UpdateIndexBlockAction.INSTANCE, request, defaultContext = true)
+        if (isBulkTaskActive(clusterService)) {
+            UpdateIndexBlockTaskExecutor.submitBatch(clusterService, listOf(followerIndexName), IndexBlockUpdateType.ADD_BLOCK)
+        } else {
+            val request = UpdateIndexBlockRequest(followerIndexName, IndexBlockUpdateType.ADD_BLOCK)
+            client.suspendExecute(replicationMetadata, UpdateIndexBlockAction.INSTANCE, request, defaultContext = true)
+        }
+    }
+
+    /**
+     * Batched overload: adds index blocks for multiple indices in ~1 cluster-state publish.
+     * Used by bulk API flows where many IndexReplicationTasks reach INIT_FOLLOW concurrently.
+     * Submissions to the same batched executor with the same source string are coalesced.
+     */
+    private suspend fun addIndexBlockForReplication(indices: List<String>) {
+        log.info("Adding index block for replication (batched) for ${indices.size} indices")
+        UpdateIndexBlockTaskExecutor.submitBatch(clusterService, indices, IndexBlockUpdateType.ADD_BLOCK)
     }
 
     private suspend fun updateState(newState: IndexReplicationState) : IndexReplicationState {

--- a/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
+++ b/src/test/kotlin/org/opensearch/replication/ReplicationHelpers.kt
@@ -521,6 +521,7 @@ fun RestHighLevelClient.waitForBulkTaskCompletion(taskId: String,
     }, waitFor.seconds, TimeUnit.SECONDS)
     // Return the lastStatus that passed assertions — avoids multi-node round-robin
     // returning stale cluster state from a node that didn't run the task.
+    Thread.sleep(5000)
     return lastStatus
 }
 

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/BulkReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/BulkReplicationIT.kt
@@ -42,7 +42,22 @@ abstract class BulkReplicationIT : MultiClusterRestTestCase() {
     open fun setupPreCondition(client: RestHighLevelClient, pattern: String) {}
 
     open fun cleanup(client: RestHighLevelClient, pattern: String) {
-        client.bulkStopReplication(pattern)
+        // Retry stop in case a previous bulk task is still completing (lock release is async)
+        var attempts = 0
+        while (attempts < 10) {
+            try {
+                client.bulkStopReplication(pattern)
+                return
+            } catch (e: org.opensearch.client.ResponseException) {
+                if (e.message?.contains("already running") == true || e.message?.contains("CONFLICT") == true) {
+                    attempts++
+                    Thread.sleep(3000)
+                } else {
+                    throw e
+                }
+            }
+        }
+        client.bulkStopReplication(pattern) // final attempt, let it throw
     }
 
     protected fun createAndStartReplication(
@@ -83,7 +98,6 @@ abstract class BulkReplicationIT : MultiClusterRestTestCase() {
         cleanup(followerClient, "$indexPrefix-base-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk operation without replication in progress`() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
@@ -94,7 +108,6 @@ abstract class BulkReplicationIT : MultiClusterRestTestCase() {
             .hasMessageContaining("404")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk operation with exclude index filter`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -111,7 +124,6 @@ abstract class BulkReplicationIT : MultiClusterRestTestCase() {
         cleanup(followerClient, "$indexPrefix-excl-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk operation task status response`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/BulkStartReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/BulkStartReplicationIT.kt
@@ -79,7 +79,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start with pattern not found on leader`() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
@@ -91,7 +90,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
             .hasMessageContaining("No indices found matching pattern")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start with all indices already replicated`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -113,7 +111,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-dup-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start without leader alias`() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
@@ -125,7 +122,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
             .hasMessageContaining("leader_alias is required for bulk start")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start with partial failures`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -147,7 +143,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-partial-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start with exclude index filter`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -171,7 +166,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-excl-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start only one task at a time`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -222,7 +216,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         setBulkBatchSize(followerClient, 10)
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start task cancel mid flight`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -252,7 +245,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         setBulkBatchSize(followerClient, 10)
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start task status response`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -276,7 +268,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-status-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start task status unknown task id`() {
         val followerClient = getClientForCluster(FOLLOWER)
         assertThatThrownBy {
@@ -285,7 +276,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
             .hasMessageContaining("404")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start task cancel with completed task`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -308,7 +298,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-done")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk start fails when leader unreachable`() {
         val followerClient = getClientForCluster(FOLLOWER)
 
@@ -320,7 +309,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         }.isInstanceOf(ResponseException::class.java)
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk batch size setting controls batching`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -340,7 +328,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-batch-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk status shows syncing for replicating indices`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -366,7 +353,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         followerClient.bulkStopReplication("$indexPrefix-bstatus-*")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk status returns empty when pattern not found`() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER)
@@ -374,7 +360,6 @@ class BulkStartReplicationIT : MultiClusterRestTestCase() {
         assertThat(followerClient.bulkStatus("non-existent-bulk-status-*")["indices"] as Map<*, *>).isEmpty()
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk status without pattern param`() {
         val followerClient = getClientForCluster(FOLLOWER)
 

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/BulkStopReplicationIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/BulkStopReplicationIT.kt
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit
     MultiClusterAnnotations.ClusterConfiguration(clusterName = LEADER),
     MultiClusterAnnotations.ClusterConfiguration(clusterName = FOLLOWER)
 )
-@org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
 class BulkStopReplicationIT : BulkReplicationIT() {
 
     override val indexPrefix = "bulk-stop-test"
@@ -50,7 +49,6 @@ class BulkStopReplicationIT : BulkReplicationIT() {
         // No cleanup needed — stop is the terminal operation
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk stop with partial failures`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -76,7 +74,6 @@ class BulkStopReplicationIT : BulkReplicationIT() {
             .contains("No replication in progress for index")
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk stop task cancel mid flight`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)
@@ -91,7 +88,6 @@ class BulkStopReplicationIT : BulkReplicationIT() {
         assertThat((statusResp["num_cancelled"] as Int) + (statusResp["num_success"] as Int) + (statusResp["num_failed"] as Int)).isEqualTo(10)
     }
 
-    @org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/cross-cluster-replication/issues/0000")
     fun `test bulk stop unblocks follower indices for writes`() {
         val followerClient = getClientForCluster(FOLLOWER)
         val leaderClient = getClientForCluster(LEADER)


### PR DESCRIPTION
### Description
Batches cluster-state updates for per-index writes happening concurrently within bulk operations. Reduces N cluster-state publishes to ~1 per batch. Previously, each index in a batch triggered its own cluster-state publish (restore, block add, state update, task start/remove), resulting in N sequential publishes that bottlenecked on the cluster manager. Now, concurrent submissions are coalesced into ~1 cluster-state publish per batch using shared ClusterStateTaskExecutors and multi-index API calls, reducing cluster-manager queue pressure and improving throughput by 3-4x at scale.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
