### PR TITLE
Fix removeStaleTasksForIndex deleting running tasks on transient ListTasks failure

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/util/StaleTaskUtils.kt
+++ b/src/main/kotlin/org/opensearch/replication/util/StaleTaskUtils.kt
@@ -127,6 +127,13 @@ object StaleTaskUtils {
 
             // Node is valid — check task manager to see if tasks are actually running
             val runningDescriptions = getRunningTaskDescriptions(client, nodeId)
+            if (runningDescriptions == null) {
+                // The task manager on this node could not be queried (transient failure, timeout,
+                // disconnect). Fail closed: never remove a task we cannot confirm is stale, otherwise
+                // a momentary query failure would delete actively-running replication tasks.
+                log.warn("Skipping stale-task removal for node $nodeId as its running tasks could not be queried")
+                continue
+            }
             for (task in tasks) {
                 if (!isTaskRunningOnNode(task, runningDescriptions)) {
                     log.info("Task ${task.id} is assigned to node $nodeId but not running in task manager")
@@ -196,7 +203,9 @@ object StaleTaskUtils {
     }
 
     //  Queries the task manager on a specific node to get descriptions of running replication tasks.
-    private suspend fun getRunningTaskDescriptions(client: Client, nodeId: String): Set<String> {
+    //  Returns null when the query fails, so callers can distinguish "no running tasks" from
+    //  "could not determine" and avoid removing tasks that may still be running.
+    private suspend fun getRunningTaskDescriptions(client: Client, nodeId: String): Set<String>? {
         return try {
             val listTasksRequest = ListTasksRequest()
                 .setActions("cluster:indices/admin/replication*", "cluster:indices/shards/replication*")
@@ -207,7 +216,7 @@ object StaleTaskUtils {
             response.tasks.mapNotNull { it.description }.toSet()
         } catch (e: Exception) {
             log.error("Failed to fetch running tasks from node $nodeId: ${e.message}")
-            emptySet()
+            null
         }
     }
 

--- a/src/test/kotlin/org/opensearch/replication/util/StaleTaskUtilsTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/util/StaleTaskUtilsTests.kt
@@ -43,6 +43,8 @@ import org.opensearch.test.ClusterServiceUtils.setState
 import org.opensearch.test.OpenSearchTestCase
 import org.opensearch.test.client.NoOpNodeClient
 import org.opensearch.threadpool.TestThreadPool
+import org.opensearch.core.tasks.TaskId
+import org.opensearch.tasks.TaskInfo
 import java.util.Collections
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
@@ -350,6 +352,44 @@ class StaleTaskUtilsTests : OpenSearchTestCase() {
         assertThat(removed).isEqualTo(1)
     }
 
+    // Regression tests: removeStaleTasksForIndex must NOT delete a task it cannot confirm is stale.
+
+    fun testRemoveStaleTasksForIndex_preservesRunningTaskOnValidNode() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.Assignment("valid_node", "test")
+        )
+        setClusterStateWithTasksAndNodes(tasks.build(), listOf("valid_node"))
+
+        // Task manager reports this task IS running on the valid node — it must be preserved.
+        val client = StaleTaskTestClient("running",
+            runningDescriptions = setOf("replication:remote:$followerIndex -> $followerIndex"))
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(0)
+        assertThat(client.removedTaskIds).isEmpty()
+    }
+
+    fun testRemoveStaleTasksForIndex_skipsRemovalWhenTaskManagerQueryFails() = runBlocking {
+        val tasks = PersistentTasksCustomMetadata.builder()
+        tasks.addTask<PersistentTaskParams>(
+            "replication:index:$followerIndex",
+            IndexReplicationExecutor.TASK_NAME,
+            IndexReplicationParams("remote", Index(followerIndex, "_na_"), followerIndex),
+            PersistentTasksCustomMetadata.Assignment("valid_node", "test")
+        )
+        setClusterStateWithTasksAndNodes(tasks.build(), listOf("valid_node"))
+
+        // The task-manager query fails — we cannot confirm the task is stale, so it must NOT be removed.
+        val client = StaleTaskTestClient("listFails",
+            listTasksThrows = RuntimeException("list tasks timed out"))
+        val removed = StaleTaskUtils.removeStaleTasksForIndex(clusterService, client, followerIndex)
+        assertThat(removed).isEqualTo(0)
+        assertThat(client.removedTaskIds).isEmpty()
+    }
+
     //Helpers
 
     private fun buildPersistentTask(
@@ -400,7 +440,8 @@ class StaleTaskUtilsTests : OpenSearchTestCase() {
     inner class StaleTaskTestClient(
         testName: String,
         private val runningDescriptions: Set<String> = emptySet(),
-        private val removeThrows: Exception? = null
+        private val removeThrows: Exception? = null,
+        private val listTasksThrows: Exception? = null
     ) : NoOpNodeClient(testName) {
 
         val removedTaskIds = mutableListOf<String>()
@@ -421,8 +462,17 @@ class StaleTaskUtilsTests : OpenSearchTestCase() {
                     }
                 }
                 ListTasksAction.INSTANCE -> {
-                    val response = ListTasksResponse(emptyList(), emptyList(), emptyList())
-                    listener.onResponse(response as Response)
+                    if (listTasksThrows != null) {
+                        listener.onFailure(listTasksThrows)
+                    } else {
+                        val taskInfos = runningDescriptions.map { desc ->
+                            TaskInfo(TaskId("node", 1L), "persistent",
+                                IndexReplicationExecutor.TASK_NAME, desc, null, 0L, 0L,
+                                false, false, TaskId.EMPTY_TASK_ID, Collections.emptyMap(), null)
+                        }
+                        val response = ListTasksResponse(taskInfos, emptyList(), emptyList())
+                        listener.onResponse(response as Response)
+                    }
                 }
                 else -> {
                     listener.onFailure(UnsupportedOperationException("Unexpected action: ${action?.name()}"))


### PR DESCRIPTION
### Description

`StaleTaskUtils.removeStaleTasksForIndex` (introduced in #1629) can delete actively-running replication tasks when a transient failure occurs while querying a node's task manager.

For an assigned task on an otherwise-valid node, the code removes the task when it isn't found among that node's running task descriptions. `getRunningTaskDescriptions(nodeId)` catches **all** exceptions and returns `emptySet()` on failure. So a transient `ListTasks` failure (timeout, busy/overloaded node, brief disconnect) yields an empty set, `isTaskRunningOnNode` returns `false` for every task on that node, and all actively-running assigned replication tasks on that node get force-removed from cluster state via `RemovePersistentTaskAction`. The failure is silently swallowed (ERROR log only) and the method reports success.

Note the asymmetry this creates: the unknown-params branch already fails **open** (`else -> return true`, "assume running to be safe"), but the query-failure case failed **closed** (treats everything as dead) — defeating the safety intent already present in the code.

### Fix

- `getRunningTaskDescriptions` now returns `Set<String>?`, returning `null` on failure instead of `emptySet()`.
- `removeStaleTasksForIndex` skips removal for a node when the query failed (fail closed): a task is only removed when we positively confirm it is not running. This does not leak stale tasks — if the node is genuinely gone, the `!validNodeIds.contains(nodeId)` branch cleans it up on a later (idempotent) call.

### Tests

- `StaleTaskUtilsTests.StaleTaskTestClient` previously ignored its `runningDescriptions` parameter — the `ListTasksAction` branch always returned an empty `ListTasksResponse`, so no test exercised the "assigned task IS running → must be preserved" branch. It now honors `runningDescriptions` and can simulate a `ListTasks` failure via a new `listTasksThrows` parameter.
- Added `testRemoveStaleTasksForIndex_preservesRunningTaskOnValidNode` and `testRemoveStaleTasksForIndex_skipsRemovalWhenTaskManagerQueryFails`.

### Related Issues
Resolves #1724

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
