### PR TITLE
Make autofollow pattern REMOVE idempotent

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/autofollow/TransportAutoFollowClusterManagerNodeAction.kt
@@ -70,7 +70,12 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
                 if (request.action == UpdateAutoFollowPatternRequest.Action.REMOVE) {
                     // Stopping the tasks and removing the context information from the cluster state
                     stopAutoFollowTask(request.connection, request.patternName)
-                    metadataManager.deleteAutofollowMetadata(request.patternName, request.connection)
+                    try {
+                        metadataManager.deleteAutofollowMetadata(request.patternName, request.connection)
+                    } catch (e: ResourceNotFoundException) {
+                        // Metadata already removed. Removal must be idempotent, so treat as success.
+                        log.warn("Autofollow metadata for '${request.connection}:${request.patternName}' already removed", e)
+                    }
                 }
 
                 if (request.action == UpdateAutoFollowPatternRequest.Action.ADD) {
@@ -123,9 +128,9 @@ class TransportAutoFollowClusterManagerNodeAction @Inject constructor(transportS
         try {
             persistentTasksService.removeTask("autofollow:$clusterAlias:$patternName")
         } catch(e: ResourceNotFoundException) {
-            // Log warn as the task is already removed
+            // Task already removed. Removal must be idempotent (e.g. a retried REMOVE), so treat as success
+            // instead of failing the request.
             log.warn("Task already stopped for '$clusterAlias:$patternName'", e)
-            throw OpenSearchException("Autofollow replication rule $clusterAlias:$patternName does not exist")
         } catch (e: Exception) {
            log.error("Failed to stop auto follow task for cluster '$clusterAlias:$patternName'", e)
             throw OpenSearchException(AUTOFOLLOW_EXCEPTION_GENERIC_STRING)

--- a/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
+++ b/src/test/kotlin/org/opensearch/replication/integ/rest/UpdateAutoFollowPatternIT.kt
@@ -378,11 +378,10 @@ class UpdateAutoFollowPatternIT: MultiClusterRestTestCase() {
         val followerClient = getClientForCluster(FOLLOWER)
         createConnectionBetweenClusters(FOLLOWER, LEADER, connectionAlias)
         followerClient.updateAutoFollowPattern(connectionAlias, indexPatternName, indexPattern)
-        //Delete a replication rule which does not exist
-        Assertions.assertThatThrownBy {
+        //Delete a replication rule which does not exist — idempotent: succeeds instead of throwing
+        Assertions.assertThatCode {
             followerClient.deleteAutoFollowPattern(connectionAlias, "dummy_conn")
-        }.isInstanceOf(ResponseException::class.java)
-                .hasMessageContaining("does not exist")
+        }.doesNotThrowAnyException()
         //Delete a replication rule which exists
         Assertions.assertThatCode {
             followerClient.deleteAutoFollowPattern(connectionAlias, indexPatternName)


### PR DESCRIPTION
### Description
Autofollow pattern REMOVE performed two non-idempotent steps that each threw when their target was already gone, so a double-remove (or a retry after a partial removal) failed, and a partial failure (task stopped but metadata delete failed) could **orphan the pattern metadata unrecoverably** (every retry then failed at `stopAutoFollowTask`).

- `stopAutoFollowTask`: on `ResourceNotFoundException` (task already gone), log and continue instead of rethrowing `OpenSearchException`.
- REMOVE branch: ignore `ResourceNotFoundException` from `deleteAutofollowMetadata`.

REMOVE is now idempotent, and a partially-completed removal can be completed by retrying.

### Related Issues
Resolves #1727
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
