### PR TITLE
Refresh follower_checkpoint from live shard on every read-loop iteration

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/shard/FollowerClusterStats.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/FollowerClusterStats.kt
@@ -117,4 +117,14 @@ class FollowerShardMetric  {
 @Singleton
 class FollowerClusterStats {
     var stats :MutableMap<ShardId, FollowerShardMetric> =  mutableMapOf()
+
+    /**
+     * Syncs the reported follower_checkpoint to the live shard value. Needed because the normal
+     * update (on a successful replay) doesn't happen while the leader is idle and getChanges keeps
+     * timing out, which otherwise leaves follower_stats permanently behind the live checkpoint
+     * reported by _status.
+     */
+    fun refreshFollowerCheckpoint(shardId: ShardId, liveFollowerCheckpoint: Long) {
+        stats[shardId]?.followerCheckpoint = liveFollowerCheckpoint
+    }
 }

--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationTask.kt
@@ -282,6 +282,10 @@ class ShardReplicationTask(id: Long, type: String, action: String, description: 
                         delay(backOffForRetry)
                         backOffForRetry = (backOffForRetry * factor).toLong().coerceAtMost(maxTimeOut)
                     } finally {
+                        // Keep follower_stats' follower_checkpoint in sync with the live shard even when
+                        // this attempt didn't replay anything (e.g. timed out waiting on an idle leader),
+                        // so it doesn't report a permanent phantom lag once the shard has caught up.
+                        followerClusterStats.refreshFollowerCheckpoint(followerShardId, indexShard.localCheckpoint)
                         rateLimiter.release()
                     }
                 }

--- a/src/test/kotlin/org/opensearch/replication/task/shard/FollowerClusterStatsTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/shard/FollowerClusterStatsTests.kt
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.task.shard
+
+import org.opensearch.core.index.Index
+import org.opensearch.core.index.shard.ShardId
+import org.opensearch.test.OpenSearchTestCase
+
+class FollowerClusterStatsTests : OpenSearchTestCase() {
+
+    private val shardId = ShardId(Index("follower-index", "_na_"), 0)
+
+    fun `test refreshFollowerCheckpoint advances a stale checkpoint to the live value`() {
+        val stats = FollowerClusterStats()
+        stats.stats[shardId] = FollowerShardMetric()
+        // Value left behind by the last successful write, before the leader went idle
+        // and subsequent getChanges calls started timing out with nothing to replay.
+        stats.stats[shardId]!!.followerCheckpoint = 218196L
+
+        stats.refreshFollowerCheckpoint(shardId, 218323L)
+
+        assertEquals(218323L, stats.stats[shardId]!!.followerCheckpoint)
+    }
+
+    fun `test refreshFollowerCheckpoint is a no-op when the shard task is not tracked`() {
+        val stats = FollowerClusterStats()
+
+        stats.refreshFollowerCheckpoint(shardId, 100L)
+
+        assertFalse(stats.stats.containsKey(shardId))
+    }
+}


### PR DESCRIPTION
### Description
`follower_stats` reports a permanently stale `follower_checkpoint` on idle-but-fully-synced indices, diverging from `_status` (which is always live).

Root cause: the checkpoint is a cache on `FollowerShardMetric`, refreshed only after a successful replay batch in `TranslogSequencer`. When the leader goes idle, `getChanges()` in `ShardReplicationTask.replicate()` times out without ever triggering a replay, so the cached checkpoint freezes at its last value instead of self-correcting.

Fix: add `FollowerClusterStats.refreshFollowerCheckpoint()` and call it from `ShardReplicationTask`'s read-loop `finally` block on every iteration (including timeouts), so the cache self-heals within one poll cycle instead of staying stale indefinitely.

### Related Issues
Resolves [#1744](https://github.com/opensearch-project/cross-cluster-replication/issues/1744)

### Test plan
- New unit test `FollowerClusterStatsTests` verifies the refresh corrects a stale checkpoint and no-ops safely for untracked shards.
- Re-ran the existing `StartReplicationIT.test follower stats` integration test in isolation — passes, confirming no regression to the existing `follower_stats` contract.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).