### PR TITLE
Apply dynamic batch-size reduction to replayed (missing) batches

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationChangesTracker.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/shard/ShardReplicationChangesTracker.kt
@@ -64,8 +64,23 @@ class ShardReplicationChangesTracker(indexShard: IndexShard, private val replica
 
             // missing batch takes higher priority.
             return if (missingBatches.isNotEmpty()) {
-                logDebug("Fetching missing batch ${missingBatches[0].first}-${missingBatches[0].second}")
-                missingBatches.removeAt(0)
+                // Cap the replayed missing range to the (possibly dynamically-reduced) effective batch size.
+                // A batch that failed the 2GB serialization limit is re-queued at its ORIGINAL width; without
+                // this cap the dynamic reduction (reduceBatchSize) is only applied to newly-carved batches and
+                // never reaches the offending range, so the fetch keeps retrying the same oversized span and
+                // makes no progress. Splitting here lets the reduced size take effect on retried batches too.
+                val missing = missingBatches.removeAt(0)
+                val effectiveBatchSize = batchSizeSettings.getEffectiveBatchSize().toLong()
+                if (missing.second - missing.first + 1 > effectiveBatchSize) {
+                    val cappedTo = missing.first + effectiveBatchSize - 1
+                    // Re-queue the remainder at the front to preserve ordering and complete coverage.
+                    missingBatches.add(0, Pair(cappedTo + 1, missing.second))
+                    logDebug("Fetching missing batch ${missing.first}-$cappedTo (capped from ${missing.first}-${missing.second}, batch size: $effectiveBatchSize)")
+                    Pair(missing.first, cappedTo)
+                } else {
+                    logDebug("Fetching missing batch ${missing.first}-${missing.second}")
+                    Pair(missing.first, missing.second)
+                }
             } else {
                 // return the next batch to fetch and update seqNoAlreadyRequested.
                 val currentBatchSize = batchSizeSettings.getEffectiveBatchSize()

--- a/src/test/kotlin/org/opensearch/replication/task/shard/ShardReplicationChangesTrackerTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/shard/ShardReplicationChangesTrackerTests.kt
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.task.shard
+
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.opensearch.Version
+import org.opensearch.cluster.ClusterName
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.metadata.IndexMetadata
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.settings.ClusterSettings
+import org.opensearch.common.settings.Settings
+import org.opensearch.core.index.shard.ShardId
+import org.opensearch.index.IndexSettings
+import org.opensearch.index.shard.IndexShard
+import org.opensearch.replication.ReplicationPlugin
+import org.opensearch.replication.ReplicationSettings
+import org.opensearch.test.ClusterServiceUtils
+import org.opensearch.test.OpenSearchTestCase
+import org.opensearch.threadpool.TestThreadPool
+import java.util.concurrent.TimeUnit
+
+/**
+ * Unit tests for [ShardReplicationChangesTracker], focused on the interaction between the dynamic
+ * batch-size reduction (used to recover from the 2GB serialization limit) and the replay of
+ * "missing" batches. A missing batch that failed at the 2GB limit must be re-sliced to the current
+ * (reduced) effective batch size on retry; otherwise it is replayed at its original width forever
+ * and never makes progress.
+ */
+class ShardReplicationChangesTrackerTests : OpenSearchTestCase() {
+
+    private lateinit var clusterService: ClusterService
+    private lateinit var replicationSettings: ReplicationSettings
+    private lateinit var threadPool: TestThreadPool
+    private lateinit var mockIndexShard: IndexShard
+
+    @Before
+    fun setup() {
+        threadPool = TestThreadPool("ShardReplicationChangesTrackerTests")
+
+        val clusterSettings = ClusterSettings(
+            Settings.EMPTY,
+            setOf(
+                ReplicationPlugin.REPLICATION_FOLLOWER_CONCURRENT_READERS_PER_SHARD,
+                ReplicationPlugin.REPLICATION_FOLLOWER_CONCURRENT_WRITERS_PER_SHARD,
+                ReplicationPlugin.REPLICATION_FOLLOWER_OPS_BATCH_SIZE,
+                ReplicationPlugin.REPLICATION_PARALLEL_READ_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_REMOTE_INDICES_RETRY_POLL_INTERVAL,
+                ReplicationPlugin.REPLICATION_METADATA_SYNC_INTERVAL,
+                ReplicationPlugin.REPLICATION_RETENTION_LEASE_MAX_FAILURE_DURATION,
+                ReplicationPlugin.REPLICATION_FOLLOWER_BLOCK_START,
+                ReplicationPlugin.REPLICATION_AUTOFOLLOW_CONCURRENT_REPLICATION_JOBS_TRIGGER_SIZE,
+                ReplicationPlugin.REPLICATION_REPLICATE_INDEX_DELETION,
+                ReplicationPlugin.REPLICATION_FOLLOWER_RECOVERY_CHUNK_SIZE,
+                ReplicationPlugin.REPLICATION_FOLLOWER_RECOVERY_PARALLEL_CHUNKS,
+                ReplicationPlugin.REPLICATION_FOLLOWER_BULK_BATCH_SIZE,
+                ReplicationPlugin.REPLICATION_FOLLOWER_BULK_POLL_TIMEOUT
+            )
+        )
+
+        val clusterState = ClusterState.builder(ClusterName.DEFAULT).build()
+        clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
+        val clusterServiceField = clusterService.javaClass.getDeclaredField("clusterSettings")
+        clusterServiceField.isAccessible = true
+        clusterServiceField.set(clusterService, clusterSettings)
+        replicationSettings = ReplicationSettings(clusterService)
+
+        mockIndexShard = mock(IndexShard::class.java)
+        `when`(mockIndexShard.shardId()).thenReturn(ShardId("test-index", "test-uuid", 0))
+        `when`(mockIndexShard.localCheckpoint).thenReturn(0L)
+        `when`(mockIndexShard.indexSettings()).thenReturn(createIndexSettings(Settings.EMPTY))
+    }
+
+    /**
+     * Reproduces the wedge: a wide missing batch (created under parallel readers) that, after the
+     * dynamic reducer shrinks the effective batch size to the floor, must be handed out in slices of
+     * the reduced size rather than replayed at its original width.
+     */
+    @Test
+    fun `missing batch is re-sliced to the reduced effective batch size`() = runBlocking {
+        val tracker = ShardReplicationChangesTracker(mockIndexShard, replicationSettings)
+        val batchSize = replicationSettings.batchSize.toLong() // default 50000
+
+        // Carve batch A (1..batchSize) and mark it complete, advancing the observed leader checkpoint
+        // well ahead so subsequent carves don't block.
+        val a = tracker.requestBatchToFetch()
+        assertEquals(Pair(1L, batchSize), a)
+        tracker.updateBatchFetched(true, a.first, a.second, a.second, 4 * batchSize)
+
+        // Carve B and C so that when B fails it is NOT the last-requested batch and therefore lands
+        // in missingBatches (the parallel-reader path) at its full original width.
+        val b = tracker.requestBatchToFetch()
+        assertEquals(Pair(batchSize + 1, 2 * batchSize), b)
+        val c = tracker.requestBatchToFetch()
+        assertEquals(Pair(2 * batchSize + 1, 3 * batchSize), c)
+
+        // B fails entirely (received nothing) -> queued as a full-width missing batch.
+        tracker.updateBatchFetched(false, b.first, b.second, b.first - 1, -1)
+
+        // Simulate repeated 2GB hits driving the effective batch size to the floor (MIN_OPS_BATCH_SIZE=16).
+        repeat(20) { tracker.reduceBatchSize() }
+        val reduced = tracker.batchSizeSettings().getEffectiveBatchSize().toLong()
+        assertEquals(16L, reduced)
+
+        // The next fetch must return only a `reduced`-wide slice of the missing batch, not the whole span.
+        val slice1 = tracker.requestBatchToFetch()
+        assertEquals(Pair(b.first, b.first + reduced - 1), slice1)
+
+        // And the remainder must be preserved and handed out contiguously on the following fetch.
+        val slice2 = tracker.requestBatchToFetch()
+        assertEquals(Pair(b.first + reduced, b.first + 2 * reduced - 1), slice2)
+    }
+
+    private fun createIndexSettings(settings: Settings): IndexSettings {
+        val indexMetadata = IndexMetadata.builder("test-index")
+            .settings(Settings.builder()
+                .put(settings)
+                .put("index.version.created", Version.CURRENT)
+                .put("index.number_of_shards", 1)
+                .put("index.number_of_replicas", 0)
+                .build())
+            .build()
+        return IndexSettings(indexMetadata, Settings.EMPTY)
+    }
+
+    @After
+    fun cleanup() {
+        try {
+            clusterService.close()
+        } catch (e: Exception) {
+            logger.warn("Exception during cluster service cleanup", e)
+        }
+        try {
+            threadPool.shutdown()
+            if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                threadPool.shutdownNow()
+            }
+        } catch (e: Exception) {
+            threadPool.shutdownNow()
+        }
+    }
+
+    override fun tearDown() {
+        super.tearDown()
+    }
+}


### PR DESCRIPTION
### Description
The 2GB dynamic batch-size reducer only shrank newly-carved batches. A batch that failed the ReleasableBytesStreamOutput 2GB limit is re-queued into missingBatches at its original width, and requestBatchToFetch() returned that entry verbatim. Under parallel readers (concurrent_readers_per_shard > 1) the offending range was therefore retried at full width forever, so replication made no progress (follower_checkpoint wedged) even though 'Reduced batch size to 16' was logged.

Cap the replayed missing range to the current effective (possibly reduced) batch size and re-queue the remainder, so the reduction reaches retried batches too. Adds ShardReplicationChangesTrackerTests covering the re-slice.

Tested by creating local leader and follower cluster and inducing the exception `IllegalArgumentException - ReleasableBytesStreamOutput cannot hold more than 2GB`.

### Related Issues
Related: opensearch-project/cross-cluster-replication#1568

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
