### PR TITLE
fix(replication): Version-gate FailedState errorMsg serialization

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationState.kt
+++ b/src/main/kotlin/org/opensearch/replication/task/index/IndexReplicationState.kt
@@ -11,6 +11,7 @@
 
 package org.opensearch.replication.task.index
 
+import org.opensearch.Version
 import org.opensearch.replication.task.ReplicationState
 import org.opensearch.replication.task.shard.ShardReplicationParams
 import org.opensearch.core.ParseField
@@ -131,12 +132,20 @@ object MonitoringState : IndexReplicationState(ReplicationState.MONITORING)
  */
 data class FailedState(val failedShards: Map<ShardId, PersistentTask<ShardReplicationParams>>, val errorMsg: String)
     : IndexReplicationState(ReplicationState.FAILED) {
-    constructor(inp: StreamInput) : this(inp.readMap(::ShardId, ::PersistentTask), inp.readString())
+    constructor(inp: StreamInput) : this(
+        inp.readMap(::ShardId, ::PersistentTask),
+        // errorMsg was added to the FailedState wire format by the CCR bulk feature.
+        // Read it only if the sending node's version wrote it (3.7+).
+        if (inp.version.onOrAfter(Version.V_3_7_0)) inp.readString() else "")
 
     override fun writeTo(out: StreamOutput) {
         super.writeTo(out)
         out.writeMap(failedShards, { o, k -> k.writeTo(o) }, { o, v -> v.writeTo(o) })
-        out.writeString(errorMsg)
+        // errorMsg was added to the FailedState wire format by the CCR bulk feature.
+        // Write it only if the receiving node's version understands it (3.7+).
+        if (out.version.onOrAfter(Version.V_3_7_0)) {
+            out.writeString(errorMsg)
+        }
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params?): XContentBuilder {

--- a/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationStateTests.kt
+++ b/src/test/kotlin/org/opensearch/replication/task/index/IndexReplicationStateTests.kt
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.replication.task.index
+
+import org.assertj.core.api.Assertions.assertThat
+import org.opensearch.Version
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.test.OpenSearchTestCase
+
+class IndexReplicationStateTests : OpenSearchTestCase() {
+
+    private val errorMessage = "index [follower-index] replication failed: leader shard unavailable"
+
+    /**
+     * Tests same-version serialization: errorMsg must survive a 3.7 -> 3.7 round-trip unchanged.
+     */
+    fun testFailedStateErrorMsgSerialized() {
+        val original = FailedState(emptyMap(), errorMessage)
+        BytesStreamOutput().use { out ->
+            out.version = Version.CURRENT
+            original.writeTo(out)
+            val input = out.bytes().streamInput()
+            input.version = Version.CURRENT
+            val roundtripped = IndexReplicationState.reader(input) as FailedState
+            assertThat(roundtripped.errorMsg).isEqualTo(errorMessage)
+        }
+    }
+
+    /**
+     * Tests backward compatibility: the errorMsg field is version-gated on 3.7,
+     * so a 3.7 node must neither write nor read it when the peer is older. The field defaults to
+     * "" on the receiving side and the stream must round-trip without corruption.
+     */
+    fun testFailedStateErrorMsgNotSerialized() {
+        val original = FailedState(emptyMap(), errorMessage)
+        BytesStreamOutput().use { out ->
+            out.version = Version.V_2_19_0
+            original.writeTo(out)
+            val input = out.bytes().streamInput()
+            input.version = Version.V_2_19_0
+            val roundtripped = IndexReplicationState.reader(input) as FailedState
+            assertThat(roundtripped.errorMsg).isEqualTo("")
+        }
+    }
+}


### PR DESCRIPTION

### Description
The errorMsg field in FailedState is version-gated so it is only written and read when the peer node is on 3.7+ (Version.V_3_7_0). This prevents StreamInput/StreamOutput corruption during mixed-cluster rolling upgrades, where a 3.7 node would otherwise write an extra string that a pre-3.7 node cannot parse. On older peers errorMsg defaults to "".

Adds IndexReplicationStateTests covering the 3.7 same-version round-trip and pre-3.7 backward-compatibility (V_2_19_0).


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
