### PR TITLE
Bootstrap: seek to chunk offset on the leader instead of read-and-dis…

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/action/repository/TransportGetFileChunkAction.kt
+++ b/src/main/kotlin/org/opensearch/replication/action/repository/TransportGetFileChunkAction.kt
@@ -56,11 +56,10 @@ class TransportGetFileChunkAction @Inject constructor(threadPool: ThreadPool, cl
 
         store.performOp({
             val fileMetaData = request.storeFileMetadata
-            val currentInput = restoreLeaderService.openInputStream(request.restoreUUID, request,
-                    fileMetaData.name(), fileMetaData.length())
             val offset = request.offset
             if (offset < fileMetaData.length()) {
-                currentInput.skip(offset)
+                val currentInput = restoreLeaderService.openInputStream(request.restoreUUID, request,
+                        fileMetaData.name(), offset, fileMetaData.length())
                 bytesRead = currentInput.read(buffer)
             }
         })

--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRestoreLeaderService.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRestoreLeaderService.kt
@@ -68,12 +68,23 @@ class RemoteClusterRestoreLeaderService @Inject constructor(private val indicesS
     fun <T : SingleShardRequest<T>?> openInputStream(restoreUUID: String,
                                                      request: RemoteClusterRepositoryRequest<T>,
                                                      fileName: String,
+                                                     offset: Long,
                                                      length: Long): InputStreamIndexInput {
         val leaderIndexShard = indicesService.getShardOrNull(request.leaderShardId)
                 ?: throw OpenSearchException("Shard [$request.leaderShardId] missing")
         val store = leaderIndexShard.store()
         val restoreContext = getLeaderClusterRestore(restoreUUID)
         val indexInput = restoreContext.openInput(store, fileName)
+
+        /**
+         * Seek directly to the requested chunk offset on the (cloned) IndexInput instead of
+         * relying on InputStream.skip, which is a read-and-discard loop. Skipping made serving
+         * chunk k cost O(k * chunkSize) of leader-side reads, i.e. O(N^2) per file transfer.
+         * The clone is per-request, so seeking it is safe under concurrent chunk fetches.
+         */
+        if (offset > 0) {
+            indexInput.seek(offset)
+        }
 
         return object : InputStreamIndexInput(indexInput, length) {
             @Throws(IOException::class)


### PR DESCRIPTION
…card

### Description
During remote-restore bootstrap, the leader served each file chunk by opening an `InputStreamIndexInput` on a fresh `IndexInput` clone (position 0) and calling `InputStream.skip(offset)` to reach the chunk. The default `skip` is a read-and-discard loop, so serving chunk *k* re-read `k × chunkSize` bytes — `O(N²)` leader-side reads per file, the dominant cost on the bootstrap path.

`RemoteClusterRestoreLeaderService.openInputStream` now takes the chunk `offset` and calls `indexInput.seek(offset)` before wrapping; `TransportGetFileChunkAction` drops the `skip` call. The seek is `O(1)` per chunk (`O(N)` per file).

Safe because `RestoreContext.openInput` returns a per-request `clone()`, so seeking one clone doesn't affect concurrent chunk fetches. `InputStreamIndexInput` still caps its read to `fileLength − offset`, leaving the final-chunk read unchanged.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
